### PR TITLE
fix: include weight and calories for onboarding items

### DIFF
--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -87,6 +87,8 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
         expirationDate,
         neverExpires: !item.defaultExpirationMonths,
         productTemplateId: item.id,
+        weightGrams: item.weightGramsPerUnit, // Store template weight per unit for calculations
+        caloriesPerUnit: item.caloriesPerUnit, // Store template calories per unit
         createdAt: now,
         updatedAt: now,
       };

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -137,6 +137,15 @@ export function Inventory({
 
   const handleEditItem = (item: InventoryItem) => {
     setEditingItem(item);
+    // If item has a template, set it so weight/calorie calculations work
+    if (item.productTemplateId) {
+      const template = RECOMMENDED_ITEMS.find(
+        (t) => t.id === item.productTemplateId,
+      );
+      setSelectedTemplate(template);
+    } else {
+      setSelectedTemplate(undefined);
+    }
     setShowAddModal(true);
   };
 


### PR DESCRIPTION
Items added through onboarding were missing weight and calorie data. When quantity was later updated, weight remained empty because the template data wasn't available.

- Store weightGrams and caloriesPerUnit from template during onboarding
- Look up template when editing existing items so weight recalculates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inventory items now include per-unit weight and calorie fields, improving nutritional tracking and portion management.

* **Bug Fixes**
  * Editing an item now correctly applies its associated template (or clears it if none), keeping weight and calorie calculations consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->