### PR TITLE
fix: resolve Jest console warnings and errors

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,8 +4,8 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
   moduleNameMapper: {
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
-    '\\.(svg|png|jpg|jpeg|gif)$': 'identity-obj-proxy',
+    '\\.(css|less|scss|sass)$': '<rootDir>/src/test/cssModuleMock.cjs',
+    '\\.(svg|png|jpg|jpeg|gif)$': '<rootDir>/src/test/fileMock.cjs',
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',

--- a/src/components/settings/ClearDataButton.test.tsx
+++ b/src/components/settings/ClearDataButton.test.tsx
@@ -12,11 +12,20 @@ jest.mock('react-i18next', () => ({
 // Mock localStorage utilities
 jest.mock('../../utils/storage/localStorage');
 
+// Store original console.error to restore later
+const originalConsoleError = console.error;
+
 describe('ClearDataButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     global.alert = jest.fn();
     global.confirm = jest.fn(() => false);
+    // Suppress the "Not implemented: navigation" error from jsdom
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
   });
 
   it('should render clear data button', () => {
@@ -59,16 +68,12 @@ describe('ClearDataButton', () => {
     render(<ClearDataButton />);
 
     const button = screen.getByText('settings.clearData.button');
-
-    // Note: window.location.reload() will throw in jsdom, so we catch it
-    try {
-      fireEvent.click(button);
-    } catch {
-      // Expected - window.location.reload() not implemented in jsdom
-    }
+    fireEvent.click(button);
 
     expect(global.confirm).toHaveBeenCalledTimes(2);
     expect(localStorage.clearAppData).toHaveBeenCalled();
     expect(global.alert).toHaveBeenCalledWith('settings.clearData.success');
+    // window.location.reload is called but throws in jsdom - we just verify the error was logged
+    expect(console.error).toHaveBeenCalled();
   });
 });

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -5,6 +5,13 @@ import { HouseholdProvider } from '../contexts/HouseholdProvider';
 import { SettingsProvider } from '../contexts/SettingsProvider';
 import type { InventoryItem } from '../types';
 
+// Mock i18next
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
 // Mock child components
 jest.mock('../components/dashboard/DashboardHeader', () => ({
   DashboardHeader: ({ preparednessScore }: { preparednessScore: number }) => (

--- a/src/test/cssModuleMock.cjs
+++ b/src/test/cssModuleMock.cjs
@@ -1,0 +1,30 @@
+// CSS Module mock that returns strings for all property access
+// Works around issues with identity-obj-proxy and ESM/React 19
+
+// Create a proxy that returns strings for class names, but returns itself for 'default'
+// This handles both ESM imports (which access .default first) and CSS classes named 'default'
+const handler = {
+  get: function (target, prop) {
+    // Handle Symbol.toPrimitive - this is called when the proxy needs to be converted
+    // to a primitive value (e.g., in array.join() or string concatenation)
+    if (prop === Symbol.toPrimitive) {
+      return () => 'default';
+    }
+    // Return undefined for other symbols
+    if (typeof prop === 'symbol') {
+      return undefined;
+    }
+    // For ESM compatibility: when accessing .default, return the proxy itself
+    // so that styles.default.className works (ESM import pattern)
+    if (prop === 'default' || prop === '__esModule') {
+      return prop === '__esModule' ? true : proxy;
+    }
+    // Return the property name as a string for CSS class access
+    return String(prop);
+  },
+};
+
+const proxy = new Proxy({}, handler);
+
+// Export for CommonJS
+module.exports = proxy;

--- a/src/test/fileMock.cjs
+++ b/src/test/fileMock.cjs
@@ -1,0 +1,2 @@
+// Mock for static file imports (images, SVGs, etc.)
+module.exports = 'test-file-stub';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "types": ["@testing-library/jest-dom"],
+    "esModuleInterop": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
- Replace identity-obj-proxy with custom CSS module mock that properly handles ESM default exports and CSS classes named "default"
- Add missing react-i18next mock to Dashboard.test.tsx
- Mock console.error in ClearDataButton.test.tsx to suppress jsdom "Not implemented: navigation" error from window.location.reload()
- Add esModuleInterop: true to tsconfig.json to fix ts-jest warnings

The root cause of className errors was identity-obj-proxy returning String.prototype.link (a function) when accessing styles.default.link due to ESM import patterns going through .default first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced module mocking for CSS styles and static assets to improve test reliability.
  * Added better error suppression and test assertions for improved test isolation.

* **Chores**
  * Updated configuration to improve module interoperability and test infrastructure stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->