### PR TITLE
fix: use translated names for onboarding recommended items

### DIFF
--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { WelcomeScreen } from './WelcomeScreen';
 import { HouseholdPresetSelector } from './HouseholdPresetSelector';
 import { HouseholdForm } from './HouseholdForm';
@@ -15,6 +16,7 @@ export interface OnboardingProps {
 type OnboardingStep = 'welcome' | 'preset' | 'household' | 'quickSetup';
 
 export const Onboarding = ({ onComplete }: OnboardingProps) => {
+  const { t } = useTranslation('products');
   const [currentStep, setCurrentStep] = useState<OnboardingStep>('welcome');
   const [selectedPreset, setSelectedPreset] = useState<HouseholdPreset | null>(
     null,
@@ -77,9 +79,11 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
 
       const now = new Date().toISOString();
 
+      const itemName = t(item.i18nKey.replace('products.', ''));
+
       return {
         id: crypto.randomUUID(),
-        name: item.id, // Will be translated via i18nKey in UI
+        name: itemName,
         categoryId: item.category,
         quantity: 0, // Start with 0, user needs to add them
         unit: item.unit,


### PR DESCRIPTION
## Summary
- Fixed onboarding flow to use properly formatted item names (e.g., "AA Batteries", "Canned Meat") instead of lowercase kebab-case IDs (e.g., "aa-batteries", "canned-meat")
- Added i18n translation using `useTranslation` hook to match the behavior of the regular Add Item flow

## Test plan
- [ ] Complete the onboarding flow and add recommended items
- [ ] Verify items appear with properly formatted names (e.g., "AA Batteries" not "aa-batteries")
- [ ] Compare with items added via the regular "Add Item" button - names should be consistent