### PR TITLE
fix: rename hasFreezer to useFreezer for clearer user intent

### DIFF
--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -58,11 +58,11 @@ Status indicators for inventory items:
 type ItemStatus = 'ok' | 'warning' | 'critical';
 ```
 
-| Status | Meaning |
-|--------|---------|
-| `ok` | Sufficient quantity AND not expiring within 30 days |
-| `warning` | Low quantity (<50% of recommended) OR expiring soon (within 30 days) |
-| `critical` | Missing (quantity = 0) OR already expired |
+| Status     | Meaning                                                              |
+| ---------- | -------------------------------------------------------------------- |
+| `ok`       | Sufficient quantity AND not expiring within 30 days                  |
+| `warning`  | Low quantity (<50% of recommended) OR expiring soon (within 30 days) |
+| `critical` | Missing (quantity = 0) OR already expired                            |
 
 ### StandardCategoryId
 
@@ -112,22 +112,22 @@ Defines the household composition and supply requirements:
 
 ```typescript
 interface HouseholdConfig {
-  adults: number;              // Number of adults (default: 2)
-  children: number;            // Number of children (default: 0)
-  supplyDurationDays: number;  // Target supply duration (default: 7)
-  hasFreezer: boolean;         // Has working freezer (default: false)
+  adults: number; // Number of adults (default: 2)
+  children: number; // Number of children (default: 0)
+  supplyDurationDays: number; // Target supply duration (default: 7)
+  useFreezer: boolean; // Use freezer for emergency supplies (default: false)
   freezerHoldTimeHours?: number; // Optional: freezer holdover time
 }
 ```
 
 ### Default Values
 
-| Field | Default |
-|-------|---------|
-| `adults` | 2 |
-| `children` | 0 |
-| `supplyDurationDays` | 7 |
-| `hasFreezer` | false |
+| Field                | Default |
+| -------------------- | ------- |
+| `adults`             | 2       |
+| `children`           | 0       |
+| `supplyDurationDays` | 7       |
+| `useFreezer`         | false   |
 
 ---
 
@@ -137,12 +137,12 @@ Application preferences and feature flags:
 
 ```typescript
 interface UserSettings {
-  language: 'en' | 'fi';       // UI language
-  theme: 'light' | 'dark' | 'auto';  // Color theme
+  language: 'en' | 'fi'; // UI language
+  theme: 'light' | 'dark' | 'auto'; // Color theme
   advancedFeatures: {
-    calorieTracking: boolean;   // Enable calorie calculations
-    powerManagement: boolean;   // Enable power/battery tracking
-    waterTracking: boolean;     // Enable detailed water tracking
+    calorieTracking: boolean; // Enable calorie calculations
+    powerManagement: boolean; // Enable power/battery tracking
+    waterTracking: boolean; // Enable detailed water tracking
   };
   onboardingCompleted?: boolean; // Has completed initial setup
 }
@@ -150,14 +150,14 @@ interface UserSettings {
 
 ### Default Values
 
-| Field | Default |
-|-------|---------|
-| `language` | `'en'` |
-| `theme` | `'auto'` |
-| `advancedFeatures.calorieTracking` | `false` |
-| `advancedFeatures.powerManagement` | `false` |
-| `advancedFeatures.waterTracking` | `false` |
-| `onboardingCompleted` | `false` |
+| Field                              | Default  |
+| ---------------------------------- | -------- |
+| `language`                         | `'en'`   |
+| `theme`                            | `'auto'` |
+| `advancedFeatures.calorieTracking` | `false`  |
+| `advancedFeatures.powerManagement` | `false`  |
+| `advancedFeatures.waterTracking`   | `false`  |
+| `onboardingCompleted`              | `false`  |
 
 ---
 
@@ -167,11 +167,11 @@ Category definition for organizing items:
 
 ```typescript
 interface Category {
-  id: string;                            // Unique identifier
+  id: string; // Unique identifier
   standardCategoryId?: StandardCategoryId; // Reference to standard category
-  name: string;                          // Display name
-  icon?: string;                         // Emoji icon
-  isCustom: boolean;                     // User-created category flag
+  name: string; // Display name
+  icon?: string; // Emoji icon
+  isCustom: boolean; // User-created category flag
 }
 ```
 
@@ -183,22 +183,22 @@ Individual items tracked in the user's inventory:
 
 ```typescript
 interface InventoryItem {
-  id: string;                    // Unique identifier (UUID)
-  name: string;                  // Item name (or i18n key reference)
-  itemType?: string;             // Template type (e.g., "Canned Tuna")
-  categoryId: string;            // Category reference
-  quantity: number;              // Current quantity owned
-  unit: Unit;                    // Measurement unit
-  recommendedQuantity: number;   // Calculated recommended amount
-  expirationDate?: string;       // ISO date string (YYYY-MM-DD)
-  neverExpires?: boolean;        // Item doesn't expire
-  location?: string;             // Storage location
-  notes?: string;                // User notes
-  productTemplateId?: string;    // Reference to product template
-  weightGrams?: number;          // Total weight (user can override)
-  caloriesPerUnit?: number;      // Calories per unit (user can override)
-  createdAt: string;             // ISO timestamp
-  updatedAt: string;             // ISO timestamp
+  id: string; // Unique identifier (UUID)
+  name: string; // Item name (or i18n key reference)
+  itemType?: string; // Template type (e.g., "Canned Tuna")
+  categoryId: string; // Category reference
+  quantity: number; // Current quantity owned
+  unit: Unit; // Measurement unit
+  recommendedQuantity: number; // Calculated recommended amount
+  expirationDate?: string; // ISO date string (YYYY-MM-DD)
+  neverExpires?: boolean; // Item doesn't expire
+  location?: string; // Storage location
+  notes?: string; // User notes
+  productTemplateId?: string; // Reference to product template
+  weightGrams?: number; // Total weight (user can override)
+  caloriesPerUnit?: number; // Calories per unit (user can override)
+  createdAt: string; // ISO timestamp
+  updatedAt: string; // ISO timestamp
 }
 ```
 
@@ -216,16 +216,16 @@ Templates for creating inventory items:
 
 ```typescript
 interface ProductTemplate {
-  id: string;                           // Unique identifier
-  name?: string;                        // Display name (for custom templates)
-  i18nKey?: string;                     // Translation key (for built-in)
-  kind?: ProductKind;                   // Product classification
+  id: string; // Unique identifier
+  name?: string; // Display name (for custom templates)
+  i18nKey?: string; // Translation key (for built-in)
+  kind?: ProductKind; // Product classification
   category: StandardCategoryId | string; // Category reference
-  defaultUnit?: Unit;                   // Default measurement unit
-  isBuiltIn: boolean;                   // System-provided template
-  isCustom: boolean;                    // User-created template
-  createdAt?: string;                   // ISO timestamp
-  updatedAt?: string;                   // ISO timestamp
+  defaultUnit?: Unit; // Default measurement unit
+  isBuiltIn: boolean; // System-provided template
+  isCustom: boolean; // User-created template
+  createdAt?: string; // ISO timestamp
+  updatedAt?: string; // ISO timestamp
 }
 ```
 
@@ -237,24 +237,25 @@ Definitions for recommended emergency supplies:
 
 ```typescript
 interface RecommendedItemDefinition {
-  id: string;                        // Unique identifier
-  i18nKey: string;                   // Translation key for name
-  category: StandardCategoryId;       // Category reference
-  baseQuantity: number;              // Base amount for 1 person, 3 days
-  unit: Unit;                        // Measurement unit
-  scaleWithPeople: boolean;          // Multiply by household size
-  scaleWithDays: boolean;            // Multiply by duration
-  requiresFreezer?: boolean;         // Only applicable if hasFreezer
-  defaultExpirationMonths?: number;  // Default shelf life
-  weightGramsPerUnit?: number;       // Weight per unit for calorie calc
-  caloriesPer100g?: number;          // Calories per 100g
-  caloriesPerUnit?: number;          // Calories per unit (direct value)
+  id: string; // Unique identifier
+  i18nKey: string; // Translation key for name
+  category: StandardCategoryId; // Category reference
+  baseQuantity: number; // Base amount for 1 person, 3 days
+  unit: Unit; // Measurement unit
+  scaleWithPeople: boolean; // Multiply by household size
+  scaleWithDays: boolean; // Multiply by duration
+  requiresFreezer?: boolean; // Only applicable if useFreezer
+  defaultExpirationMonths?: number; // Default shelf life
+  weightGramsPerUnit?: number; // Weight per unit for calorie calc
+  caloriesPer100g?: number; // Calories per 100g
+  caloriesPerUnit?: number; // Calories per unit (direct value)
 }
 ```
 
 ### Scaling Rules
 
 Items can scale based on:
+
 - **People**: `scaleWithPeople: true` - quantity increases with household size
 - **Duration**: `scaleWithDays: true` - quantity increases with supply duration
 
@@ -266,13 +267,13 @@ Root structure for all persisted application data:
 
 ```typescript
 interface AppData {
-  version: string;                      // Schema version
-  household: HouseholdConfig;           // Household settings
-  settings: UserSettings;               // App preferences
-  customCategories: Category[];         // User's custom categories only
-  items: InventoryItem[];               // All inventory items
-  customTemplates: ProductTemplate[];   // User's custom templates
-  lastModified: string;                 // ISO timestamp
+  version: string; // Schema version
+  household: HouseholdConfig; // Household settings
+  settings: UserSettings; // App preferences
+  customCategories: Category[]; // User's custom categories only
+  items: InventoryItem[]; // All inventory items
+  customTemplates: ProductTemplate[]; // User's custom templates
+  lastModified: string; // ISO timestamp
 }
 ```
 
@@ -288,17 +289,17 @@ interface AppData {
 
 The 9 built-in supply categories:
 
-| ID | Name | Icon |
-|----|------|------|
-| `water-beverages` | Water & Beverages | :droplet: |
-| `food` | Food | :fork_and_knife: |
-| `cooking-heat` | Cooking & Heat | :fire: |
-| `light-power` | Light & Power | :bulb: |
-| `communication-info` | Communication & Info | :radio: |
-| `medical-health` | Medical & Health | :hospital: |
-| `hygiene-sanitation` | Hygiene & Sanitation | :soap: |
-| `tools-supplies` | Tools & Supplies | :wrench: |
-| `cash-documents` | Cash & Documents | :moneybag: |
+| ID                   | Name                 | Icon             |
+| -------------------- | -------------------- | ---------------- |
+| `water-beverages`    | Water & Beverages    | :droplet:        |
+| `food`               | Food                 | :fork_and_knife: |
+| `cooking-heat`       | Cooking & Heat       | :fire:           |
+| `light-power`        | Light & Power        | :bulb:           |
+| `communication-info` | Communication & Info | :radio:          |
+| `medical-health`     | Medical & Health     | :hospital:       |
+| `hygiene-sanitation` | Hygiene & Sanitation | :soap:           |
+| `tools-supplies`     | Tools & Supplies     | :wrench:         |
+| `cash-documents`     | Cash & Documents     | :moneybag:       |
 
 Standard categories are always available and not stored in `customCategories`. Only user-created categories are persisted.
 
@@ -313,6 +314,7 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 ```
 
 **Example:** 2 adults + 2 children for 7 days:
+
 ```
 (2.0 + 1.5) × (7 ÷ 3) = 3.5 × 2.33 = 8.16×
 ```
@@ -325,7 +327,7 @@ For each recommended item:
 let quantity = baseQuantity;
 
 if (scaleWithPeople) {
-  quantity *= (adults + children);  // Note: simplified scaling
+  quantity *= adults + children; // Note: simplified scaling
 }
 
 if (scaleWithDays) {
@@ -338,10 +340,12 @@ recommendedQuantity = Math.ceil(quantity);
 ### Calorie Tracking
 
 When enabled, daily calorie targets:
+
 - **Adults:** 2,200 kcal/day
 - **Children:** 1,600 kcal/day
 
 Calorie calculation per item:
+
 ```typescript
 // If caloriesPerUnit is provided directly
 totalCalories = quantity * caloriesPerUnit;

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -23,6 +23,7 @@ Households preparing for emergency situations (power outages, service disruption
 ## User Personas
 
 ### Primary: Emma (Prepared Parent)
+
 - 35 years old, 2 children
 - Wants to be prepared for emergencies
 - Prefers mobile access while shopping
@@ -30,6 +31,7 @@ Households preparing for emergency situations (power outages, service disruption
 - Values privacy (no cloud storage)
 
 ### Secondary: Matti (Safety-Conscious Professional)
+
 - 28 years old, lives alone
 - Follows 72tuntia.fi guidelines
 - Tech-savvy, uses desktop browser
@@ -45,29 +47,34 @@ Households preparing for emergency situations (power outages, service disruption
 Users configure their household to get personalized supply recommendations.
 
 #### Household Size
+
 - **Number of adults** (default: 2)
   - Each adult scales supplies by 1.0x multiplier
 - **Number of children** (default: 0)
   - Each child scales supplies by 0.75x multiplier
 
 #### Supply Duration
+
 - **Days of supplies to maintain** (default: 7 days)
 - User-selectable duration
 - Affects quantity calculations for scalable items
 
 #### Living Situation
-- **Has freezer** (default: false)
+
+- **Use freezer** (default: false)
   - Shows/hides frozen food recommendations
   - Frozen items only shown when enabled
 
 #### Calculation Model
 
 **Base Formula:**
+
 ```
 Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 ```
 
 **Example:**
+
 - 2 adults + 2 children for 7 days
 - = (2.0 + 1.5) × (7 ÷ 3)
 - = 3.5 × 2.33
@@ -81,19 +88,20 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 
 #### 9 Standard Categories (based on 72tuntia.fi)
 
-| ID | Name | Icon | Description |
-|----|------|------|-------------|
-| `water-beverages` | Water & Beverages | :droplet: | 3L per person per day |
-| `food` | Food | :fork_and_knife: | Non-perishable, canned, dry goods, frozen |
-| `cooking-heat` | Cooking & Heat | :fire: | Camping stove, fuel, matches, candles |
-| `light-power` | Light & Power | :bulb: | Flashlights, batteries, power banks |
-| `communication-info` | Communication & Info | :radio: | Battery/hand-crank radio |
-| `medical-health` | Medical & Health | :hospital: | First aid, medications |
-| `hygiene-sanitation` | Hygiene & Sanitation | :soap: | Toilet paper, soap, wipes |
-| `tools-supplies` | Tools & Supplies | :wrench: | Bucket, containers, duct tape |
-| `cash-documents` | Cash & Documents | :moneybag: | Cash, document copies |
+| ID                   | Name                 | Icon             | Description                               |
+| -------------------- | -------------------- | ---------------- | ----------------------------------------- |
+| `water-beverages`    | Water & Beverages    | :droplet:        | 3L per person per day                     |
+| `food`               | Food                 | :fork_and_knife: | Non-perishable, canned, dry goods, frozen |
+| `cooking-heat`       | Cooking & Heat       | :fire:           | Camping stove, fuel, matches, candles     |
+| `light-power`        | Light & Power        | :bulb:           | Flashlights, batteries, power banks       |
+| `communication-info` | Communication & Info | :radio:          | Battery/hand-crank radio                  |
+| `medical-health`     | Medical & Health     | :hospital:       | First aid, medications                    |
+| `hygiene-sanitation` | Hygiene & Sanitation | :soap:           | Toilet paper, soap, wipes                 |
+| `tools-supplies`     | Tools & Supplies     | :wrench:         | Bucket, containers, duct tape             |
+| `cash-documents`     | Cash & Documents     | :moneybag:       | Cash, document copies                     |
 
 #### Custom Categories
+
 - Users can create additional categories
 - Useful for pets, hobbies, special needs
 
@@ -103,43 +111,46 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 
 #### Core Item Attributes
 
-| Attribute | Required | Description |
-|-----------|----------|-------------|
-| `name` | Yes | Item name or i18n key reference |
-| `categoryId` | Yes | Category reference |
-| `quantity` | Yes | Current quantity owned |
-| `unit` | Yes | Measurement unit |
-| `recommendedQuantity` | Yes | Calculated recommended amount |
-| `expirationDate` | No | ISO date (YYYY-MM-DD) |
-| `neverExpires` | No | Boolean flag for non-expiring items |
-| `location` | No | Storage location |
-| `notes` | No | User notes |
-| `productTemplateId` | No | Reference to product template |
-| `weightGrams` | No | Total weight (for calorie calc) |
-| `caloriesPerUnit` | No | Calories per unit |
+| Attribute             | Required | Description                         |
+| --------------------- | -------- | ----------------------------------- |
+| `name`                | Yes      | Item name or i18n key reference     |
+| `categoryId`          | Yes      | Category reference                  |
+| `quantity`            | Yes      | Current quantity owned              |
+| `unit`                | Yes      | Measurement unit                    |
+| `recommendedQuantity` | Yes      | Calculated recommended amount       |
+| `expirationDate`      | No       | ISO date (YYYY-MM-DD)               |
+| `neverExpires`        | No       | Boolean flag for non-expiring items |
+| `location`            | No       | Storage location                    |
+| `notes`               | No       | User notes                          |
+| `productTemplateId`   | No       | Reference to product template       |
+| `weightGrams`         | No       | Total weight (for calorie calc)     |
+| `caloriesPerUnit`     | No       | Calories per unit                   |
 
 #### Optional Advanced Features
 
 **Calorie Tracking** (disabled by default):
+
 - Calories per 100g for food items
 - Adults: 2,200 kcal/day target
 - Children: 1,600 kcal/day target
 - Dashboard shows calorie coverage
 
 **Power Management** (disabled by default):
+
 - Track batteries and power banks
 - Dashboard shows power reserve
 
 **Water Tracking** (disabled by default):
+
 - Detailed water consumption tracking
 
 #### Item Status Indicators
 
-| Status | Icon | Meaning |
-|--------|------|---------|
-| OK | :white_check_mark: | Sufficient quantity AND not expiring within 30 days |
-| Warning | :warning: | Low quantity (<50% recommended) OR expiring soon (within 30 days) |
-| Critical | :x: | Missing (quantity = 0) OR already expired |
+| Status   | Icon               | Meaning                                                           |
+| -------- | ------------------ | ----------------------------------------------------------------- |
+| OK       | :white_check_mark: | Sufficient quantity AND not expiring within 30 days               |
+| Warning  | :warning:          | Low quantity (<50% recommended) OR expiring soon (within 30 days) |
+| Critical | :x:                | Missing (quantity = 0) OR already expired                         |
 
 **Important**: Expired items remain in inventory until user removes them.
 
@@ -150,6 +161,7 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 70 recommended items across 9 categories. See [RECOMMENDED_ITEMS.md](RECOMMENDED_ITEMS.md) for complete list.
 
 **Key examples:**
+
 - Bottled water: 9L per person (3 days)
 - Canned soup: 3 cans per person (scales with days)
 - Flashlight: 2 per household (does not scale)
@@ -165,11 +177,13 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 #### First-Time Onboarding (4 Steps)
 
 **Step 1: Welcome**
+
 - Brief app explanation
 - Language selection (English/Finnish)
 - Continue button
 
 **Step 2: Preset Selection**
+
 - Common household presets:
   - Single person
   - Couple
@@ -178,13 +192,15 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 - Quick selection to pre-fill household form
 
 **Step 3: Household Configuration**
+
 - Number of adults
 - Number of children
 - Supply duration (days)
-- Has freezer toggle
+- Use freezer toggle
 - Back/Continue navigation
 
 **Step 4: Quick Setup**
+
 - Option to add all recommended items
 - Option to skip and start empty
 - Shows summary of what will be added
@@ -192,21 +208,25 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 #### Adding Items
 
 **Method 1: Browse from Recommendations**
+
 1. Navigate to category
 2. See recommended items with status
 3. Quick Add or Full Add
 
 **Method 2: Quick Add from Dashboard**
+
 1. Dashboard shows critical missing items
 2. Single tap adds item with defaults
 
 **Method 3: Add from Product Template**
+
 1. Select template
 2. Auto-fill fields
 3. Override defaults if needed
 4. Save to inventory
 
 **Custom Items**
+
 1. Click "Add Custom Item"
 2. Fill in all fields manually
 3. Optionally save as template
@@ -225,27 +245,32 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 #### Dashboard View
 
 **Components:**
+
 - `DashboardHeader`: Household summary, overall preparedness %
 - `AlertBanner`: Expired/expiring/missing items
 - `CategoryGrid`: 9 category cards with status indicators
 
 **Category Card shows:**
+
 - Category name and icon
 - Status indicator (worst item status)
 - Progress bar (% items sufficient)
 - Item counts
 
 **Quick Actions:**
+
 - Add item button
 - Export/Import (in Settings)
 
 #### Inventory View
 
 **Navigation:**
+
 - `CategoryNav`: Horizontal tabs for categories
 - `FilterBar`: Status filters (All, OK, Warning, Critical)
 
 **Item List:**
+
 - `ItemList`: Scrollable list of items
 - `ItemCard`: Individual item display
   - Name, quantity/recommended
@@ -254,6 +279,7 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
   - Edit/Delete actions
 
 **Sorting:**
+
 - By name (alphabetical)
 - By expiration (soonest first)
 - By status (critical first)
@@ -261,6 +287,7 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 #### Add/Edit Item Form
 
 **`ItemForm` Component:**
+
 - Category dropdown
 - Name input (or template selector)
 - Quantity input
@@ -272,26 +299,32 @@ Total Multiplier = (adults × 1.0 + children × 0.75) × (days ÷ 3)
 - Advanced fields (if enabled)
 
 **Actions:**
+
 - Save / Cancel / Delete
 
 #### Settings View
 
 **Household Configuration:**
+
 - `HouseholdForm`: Adults, children, duration, freezer
 
 **Advanced Features:**
+
 - `AdvancedFeatures`: Toggle switches for:
   - Calorie tracking
   - Power management
   - Water tracking
 
 **Language:**
+
 - `LanguageSelector`: English / Finnish
 
 **Theme:**
+
 - `ThemeSelector`: Light / Dark / Auto
 
 **Data Management:**
+
 - `ExportButton`: Export data as JSON
 - `ImportButton`: Import data from JSON
 - `ShoppingListExport`: Export shopping list (TODO)
@@ -325,6 +358,7 @@ Displayed via `AlertBanner` component on Dashboard:
 #### Export Data (JSON)
 
 **Format:**
+
 ```json
 {
   "version": "1.0.0",
@@ -340,6 +374,7 @@ Displayed via `AlertBanner` component on Dashboard:
 #### Import Data (JSON)
 
 **Process:**
+
 1. Upload JSON file
 2. Validate structure
 3. Preview data
@@ -351,6 +386,7 @@ Displayed via `AlertBanner` component on Dashboard:
 **Status:** TODO (not yet implemented)
 
 Planned features:
+
 - Export missing/low items
 - Format options: Text, Markdown, CSV
 - Grouping by category
@@ -378,11 +414,13 @@ Planned features:
 ### Color Scheme
 
 **Status Colors:**
+
 - Green (#4CAF50): OK / Sufficient
 - Yellow (#FFC107): Warning / Low / Expiring
 - Red (#F44336): Critical / Missing / Expired
 
 **Theme Support:**
+
 - Light mode
 - Dark mode
 - Auto (system preference)

--- a/docs/RECOMMENDED_ITEMS.md
+++ b/docs/RECOMMENDED_ITEMS.md
@@ -12,11 +12,11 @@ This document lists all 70 recommended emergency supply items based on Finnish e
 
 Items can scale based on household configuration:
 
-| Rule | Description |
-|------|-------------|
-| `scaleWithPeople: true` | Quantity multiplied by household size |
-| `scaleWithDays: true` | Quantity multiplied by supply duration |
-| `requiresFreezer: true` | Only shown if household has freezer |
+| Rule                    | Description                            |
+| ----------------------- | -------------------------------------- |
+| `scaleWithPeople: true` | Quantity multiplied by household size  |
+| `scaleWithDays: true`   | Quantity multiplied by supply duration |
+| `requiresFreezer: true` | Only shown if household uses freezer   |
 
 **Base quantities** are calculated for 1 person for 3 days.
 
@@ -24,11 +24,11 @@ Items can scale based on household configuration:
 
 ## 1. Water & Beverages
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `bottled-water` | Bottled Water | 9 | liters | People, Days | 12 months |
-| `long-life-milk` | Long-life Milk | 2 | liters | People | 12 months |
-| `long-life-juice` | Long-life Juice | 2 | liters | People | 12 months |
+| ID                | Name            | Base Qty | Unit   | Scales With  | Expiration |
+| ----------------- | --------------- | -------- | ------ | ------------ | ---------- |
+| `bottled-water`   | Bottled Water   | 9        | liters | People, Days | 12 months  |
+| `long-life-milk`  | Long-life Milk  | 2        | liters | People       | 12 months  |
+| `long-life-juice` | Long-life Juice | 2        | liters | People       | 12 months  |
 
 **Water Recommendation:** 3 liters per person per day (drinking + basic hygiene)
 
@@ -38,145 +38,145 @@ Items can scale based on household configuration:
 
 ### Non-Perishable Items
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration | Calories/Unit |
-|----|------|----------|------|-------------|------------|---------------|
-| `canned-soup` | Canned Soup | 3 | cans | People, Days | 24 months | 200 |
-| `canned-vegetables` | Canned Vegetables | 3 | cans | People, Days | 24 months | 100 |
-| `canned-fish` | Canned Fish | 2 | cans | People, Days | 36 months | 200 |
-| `canned-meat` | Canned Meat | 2 | cans | People, Days | 36 months | 300 |
-| `pasta` | Pasta | 0.5 | kilograms | People, Days | 24 months | 3500 |
-| `rice` | Rice | 0.5 | kilograms | People, Days | 24 months | 3600 |
-| `oats` | Oats | 0.5 | kilograms | People, Days | 12 months | 3800 |
-| `crackers` | Crackers | 2 | packages | People, Days | 12 months | 500 |
-| `energy-bars` | Energy Bars | 6 | pieces | People, Days | 12 months | 250 |
-| `spreads` | Spreads (Peanut Butter) | 1 | jars | People | 18 months | 1600 |
-| `dried-fruits` | Dried Fruits | 0.3 | kilograms | People, Days | 12 months | 3000 |
-| `nuts` | Nuts | 0.3 | kilograms | People, Days | 12 months | 6000 |
-| `salt-sugar` | Salt & Sugar | 0.2 | kilograms | - | - | - |
-| `coffee-tea` | Coffee & Tea | 0.2 | kilograms | People | 18 months | - |
+| ID                  | Name                    | Base Qty | Unit      | Scales With  | Expiration | Calories/Unit |
+| ------------------- | ----------------------- | -------- | --------- | ------------ | ---------- | ------------- |
+| `canned-soup`       | Canned Soup             | 3        | cans      | People, Days | 24 months  | 200           |
+| `canned-vegetables` | Canned Vegetables       | 3        | cans      | People, Days | 24 months  | 100           |
+| `canned-fish`       | Canned Fish             | 2        | cans      | People, Days | 36 months  | 200           |
+| `canned-meat`       | Canned Meat             | 2        | cans      | People, Days | 36 months  | 300           |
+| `pasta`             | Pasta                   | 0.5      | kilograms | People, Days | 24 months  | 3500          |
+| `rice`              | Rice                    | 0.5      | kilograms | People, Days | 24 months  | 3600          |
+| `oats`              | Oats                    | 0.5      | kilograms | People, Days | 12 months  | 3800          |
+| `crackers`          | Crackers                | 2        | packages  | People, Days | 12 months  | 500           |
+| `energy-bars`       | Energy Bars             | 6        | pieces    | People, Days | 12 months  | 250           |
+| `spreads`           | Spreads (Peanut Butter) | 1        | jars      | People       | 18 months  | 1600          |
+| `dried-fruits`      | Dried Fruits            | 0.3      | kilograms | People, Days | 12 months  | 3000          |
+| `nuts`              | Nuts                    | 0.3      | kilograms | People, Days | 12 months  | 6000          |
+| `salt-sugar`        | Salt & Sugar            | 0.2      | kilograms | -            | -          | -             |
+| `coffee-tea`        | Coffee & Tea            | 0.2      | kilograms | People       | 18 months  | -             |
 
 ### Frozen Items (requires freezer)
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration | Calories/Unit |
-|----|------|----------|------|-------------|------------|---------------|
-| `frozen-vegetables` | Frozen Vegetables | 1 | kilograms | People, Days | 12 months | 400 |
-| `frozen-meat` | Frozen Meat | 0.5 | kilograms | People, Days | 6 months | 2500 |
-| `frozen-meals` | Frozen Meals | 3 | pieces | People, Days | 12 months | 450 |
+| ID                  | Name              | Base Qty | Unit      | Scales With  | Expiration | Calories/Unit |
+| ------------------- | ----------------- | -------- | --------- | ------------ | ---------- | ------------- |
+| `frozen-vegetables` | Frozen Vegetables | 1        | kilograms | People, Days | 12 months  | 400           |
+| `frozen-meat`       | Frozen Meat       | 0.5      | kilograms | People, Days | 6 months   | 2500          |
+| `frozen-meals`      | Frozen Meals      | 3        | pieces    | People, Days | 12 months  | 450           |
 
 ---
 
 ## 3. Cooking & Heat
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `camping-stove` | Camping Stove | 1 | pieces | - | - |
-| `stove-fuel` | Stove Fuel | 3 | canisters | Days | 60 months |
-| `waterproof-matches` | Waterproof Matches | 2 | boxes | - | 60 months |
-| `lighter` | Lighter | 2 | pieces | - | - |
-| `candles` | Candles | 10 | pieces | - | - |
-| `fire-starter` | Fire Starter | 1 | pieces | - | - |
+| ID                   | Name               | Base Qty | Unit      | Scales With | Expiration |
+| -------------------- | ------------------ | -------- | --------- | ----------- | ---------- |
+| `camping-stove`      | Camping Stove      | 1        | pieces    | -           | -          |
+| `stove-fuel`         | Stove Fuel         | 3        | canisters | Days        | 60 months  |
+| `waterproof-matches` | Waterproof Matches | 2        | boxes     | -           | 60 months  |
+| `lighter`            | Lighter            | 2        | pieces    | -           | -          |
+| `candles`            | Candles            | 10       | pieces    | -           | -          |
+| `fire-starter`       | Fire Starter       | 1        | pieces    | -           | -          |
 
 ---
 
 ## 4. Light & Power
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `flashlight` | Flashlight | 2 | pieces | - | - |
-| `headlamp` | Headlamp | 1 | pieces | People | - |
-| `aa-batteries` | AA Batteries | 20 | pieces | - | 60 months |
-| `aaa-batteries` | AAA Batteries | 12 | pieces | - | 60 months |
-| `d-batteries` | D Batteries | 8 | pieces | - | 60 months |
-| `power-bank` | Power Bank | 1 | pieces | - | - |
-| `charging-cables` | Charging Cables | 2 | pieces | - | - |
-| `solar-charger` | Solar Charger | 1 | pieces | - | - |
+| ID                | Name            | Base Qty | Unit   | Scales With | Expiration |
+| ----------------- | --------------- | -------- | ------ | ----------- | ---------- |
+| `flashlight`      | Flashlight      | 2        | pieces | -           | -          |
+| `headlamp`        | Headlamp        | 1        | pieces | People      | -          |
+| `aa-batteries`    | AA Batteries    | 20       | pieces | -           | 60 months  |
+| `aaa-batteries`   | AAA Batteries   | 12       | pieces | -           | 60 months  |
+| `d-batteries`     | D Batteries     | 8        | pieces | -           | 60 months  |
+| `power-bank`      | Power Bank      | 1        | pieces | -           | -          |
+| `charging-cables` | Charging Cables | 2        | pieces | -           | -          |
+| `solar-charger`   | Solar Charger   | 1        | pieces | -           | -          |
 
 ---
 
 ## 5. Communication & Info
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `battery-radio` | Battery Radio | 1 | pieces | - | - |
-| `hand-crank-radio` | Hand-Crank Radio | 1 | pieces | - | - |
+| ID                 | Name             | Base Qty | Unit   | Scales With | Expiration |
+| ------------------ | ---------------- | -------- | ------ | ----------- | ---------- |
+| `battery-radio`    | Battery Radio    | 1        | pieces | -           | -          |
+| `hand-crank-radio` | Hand-Crank Radio | 1        | pieces | -           | -          |
 
 ---
 
 ## 6. Medical & Health
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `first-aid-kit` | First Aid Kit | 1 | pieces | - | 36 months |
-| `prescription-meds` | Prescription Medications | 3 | days | People, Days | - |
-| `pain-relievers` | Pain Relievers | 1 | packages | - | 36 months |
-| `fever-reducers` | Fever Reducers | 1 | packages | - | 36 months |
-| `bandages` | Bandages | 20 | pieces | - | 60 months |
-| `disinfectant` | Disinfectant | 1 | bottles | - | 36 months |
-| `thermometer` | Thermometer | 1 | pieces | - | - |
-| `antihistamines` | Antihistamines | 1 | packages | - | 36 months |
-| `diarrhea-meds` | Diarrhea Medication | 1 | packages | - | 36 months |
+| ID                  | Name                     | Base Qty | Unit     | Scales With  | Expiration |
+| ------------------- | ------------------------ | -------- | -------- | ------------ | ---------- |
+| `first-aid-kit`     | First Aid Kit            | 1        | pieces   | -            | 36 months  |
+| `prescription-meds` | Prescription Medications | 3        | days     | People, Days | -          |
+| `pain-relievers`    | Pain Relievers           | 1        | packages | -            | 36 months  |
+| `fever-reducers`    | Fever Reducers           | 1        | packages | -            | 36 months  |
+| `bandages`          | Bandages                 | 20       | pieces   | -            | 60 months  |
+| `disinfectant`      | Disinfectant             | 1        | bottles  | -            | 36 months  |
+| `thermometer`       | Thermometer              | 1        | pieces   | -            | -          |
+| `antihistamines`    | Antihistamines           | 1        | packages | -            | 36 months  |
+| `diarrhea-meds`     | Diarrhea Medication      | 1        | packages | -            | 36 months  |
 
 ---
 
 ## 7. Hygiene & Sanitation
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `toilet-paper` | Toilet Paper | 3 | rolls | People, Days | - |
-| `wet-wipes` | Wet Wipes | 1 | packages | People | 24 months |
-| `hand-sanitizer` | Hand Sanitizer | 1 | bottles | - | 24 months |
-| `soap` | Soap | 2 | pieces | - | - |
-| `toothbrush` | Toothbrush | 1 | pieces | People | - |
-| `toothpaste` | Toothpaste | 1 | tubes | - | 24 months |
-| `feminine-hygiene` | Feminine Hygiene Products | 1 | packages | People, Days | - |
-| `diapers` | Diapers | 30 | pieces | People, Days | - |
-| `garbage-bags` | Garbage Bags | 20 | pieces | - | - |
-| `paper-towels` | Paper Towels | 2 | rolls | - | - |
+| ID                 | Name                      | Base Qty | Unit     | Scales With  | Expiration |
+| ------------------ | ------------------------- | -------- | -------- | ------------ | ---------- |
+| `toilet-paper`     | Toilet Paper              | 3        | rolls    | People, Days | -          |
+| `wet-wipes`        | Wet Wipes                 | 1        | packages | People       | 24 months  |
+| `hand-sanitizer`   | Hand Sanitizer            | 1        | bottles  | -            | 24 months  |
+| `soap`             | Soap                      | 2        | pieces   | -            | -          |
+| `toothbrush`       | Toothbrush                | 1        | pieces   | People       | -          |
+| `toothpaste`       | Toothpaste                | 1        | tubes    | -            | 24 months  |
+| `feminine-hygiene` | Feminine Hygiene Products | 1        | packages | People, Days | -          |
+| `diapers`          | Diapers                   | 30       | pieces   | People, Days | -          |
+| `garbage-bags`     | Garbage Bags              | 20       | pieces   | -            | -          |
+| `paper-towels`     | Paper Towels              | 2        | rolls    | -            | -          |
 
 ---
 
 ## 8. Tools & Supplies
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `bucket` | Bucket | 1 | pieces | - | - |
-| `water-container` | Water Container | 1 | pieces | - | - |
-| `duct-tape` | Duct Tape | 1 | rolls | - | - |
-| `multi-tool` | Multi-Tool | 1 | pieces | - | - |
-| `can-opener` | Can Opener | 1 | pieces | - | - |
-| `plastic-bags` | Plastic Bags | 20 | pieces | - | - |
-| `aluminum-foil` | Aluminum Foil | 1 | rolls | - | - |
-| `plastic-wrap` | Plastic Wrap | 1 | rolls | - | - |
-| `rope` | Rope | 10 | meters | - | - |
-| `work-gloves` | Work Gloves | 2 | pairs | - | - |
-| `whistle` | Whistle | 1 | pieces | People | - |
+| ID                | Name            | Base Qty | Unit   | Scales With | Expiration |
+| ----------------- | --------------- | -------- | ------ | ----------- | ---------- |
+| `bucket`          | Bucket          | 1        | pieces | -           | -          |
+| `water-container` | Water Container | 1        | pieces | -           | -          |
+| `duct-tape`       | Duct Tape       | 1        | rolls  | -           | -          |
+| `multi-tool`      | Multi-Tool      | 1        | pieces | -           | -          |
+| `can-opener`      | Can Opener      | 1        | pieces | -           | -          |
+| `plastic-bags`    | Plastic Bags    | 20       | pieces | -           | -          |
+| `aluminum-foil`   | Aluminum Foil   | 1        | rolls  | -           | -          |
+| `plastic-wrap`    | Plastic Wrap    | 1        | rolls  | -           | -          |
+| `rope`            | Rope            | 10       | meters | -           | -          |
+| `work-gloves`     | Work Gloves     | 2        | pairs  | -           | -          |
+| `whistle`         | Whistle         | 1        | pieces | People      | -          |
 
 ---
 
 ## 9. Cash & Documents
 
-| ID | Name | Base Qty | Unit | Scales With | Expiration |
-|----|------|----------|------|-------------|------------|
-| `cash` | Cash | 300 | euros | - | - |
-| `document-copies` | Document Copies | 1 | sets | - | - |
-| `contact-list` | Contact List | 1 | pieces | - | - |
+| ID                | Name            | Base Qty | Unit   | Scales With | Expiration |
+| ----------------- | --------------- | -------- | ------ | ----------- | ---------- |
+| `cash`            | Cash            | 300      | euros  | -           | -          |
+| `document-copies` | Document Copies | 1        | sets   | -           | -          |
+| `contact-list`    | Contact List    | 1        | pieces | -           | -          |
 
 ---
 
 ## Summary
 
-| Category | Item Count |
-|----------|------------|
-| Water & Beverages | 3 |
-| Food | 17 |
-| Cooking & Heat | 6 |
-| Light & Power | 8 |
-| Communication & Info | 2 |
-| Medical & Health | 9 |
-| Hygiene & Sanitation | 10 |
-| Tools & Supplies | 11 |
-| Cash & Documents | 3 |
-| **Total** | **69** |
+| Category             | Item Count |
+| -------------------- | ---------- |
+| Water & Beverages    | 3          |
+| Food                 | 17         |
+| Cooking & Heat       | 6          |
+| Light & Power        | 8          |
+| Communication & Info | 2          |
+| Medical & Health     | 9          |
+| Hygiene & Sanitation | 10         |
+| Tools & Supplies     | 11         |
+| Cash & Documents     | 3          |
+| **Total**            | **69**     |
 
 ---
 
@@ -189,6 +189,7 @@ Food items include calorie data for optional calorie tracking:
 - `caloriesPerUnit`: Total calories per unit
 
 **Daily calorie targets:**
+
 - Adults: 2,200 kcal/day
 - Children: 1,600 kcal/day
 

--- a/e2e/data-management.spec.ts
+++ b/e2e/data-management.spec.ts
@@ -66,7 +66,7 @@ test.describe('Data Management', () => {
         adults: 2,
         children: 1,
         supplyDays: 3,
-        hasFreezer: true,
+        useFreezer: true,
         freezerHoldTime: 48,
       },
       settings: {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -18,7 +18,7 @@ export const defaultAppData = {
     adults: 2,
     children: 0,
     supplyDurationDays: 3,
-    hasFreezer: true,
+    useFreezer: true,
     freezerHoldTime: 48,
   },
   items: [],

--- a/examples/sample-inventory-family5-days3.json
+++ b/examples/sample-inventory-family5-days3.json
@@ -4,7 +4,7 @@
     "adults": 2,
     "children": 3,
     "supplyDurationDays": 3,
-    "hasFreezer": true
+    "useFreezer": true
   },
   "settings": {
     "language": "en",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -92,7 +92,7 @@
     "children": "Children",
     "supplyDays": "Supply Duration (days)",
     "supplyDaysHelper": "Recommended: 3-7 days",
-    "hasFreezer": "Has Freezer",
+    "useFreezer": "Use Freezer",
     "customDescription": "Set your own configuration",
     "presets": {
       "single": "Single Person",
@@ -136,7 +136,7 @@
       "adults": "Adults",
       "children": "Children",
       "supplyDays": "Supply Duration (days)",
-      "hasFreezer": "Has Freezer",
+      "useFreezer": "Use Freezer",
       "freezerHoldTime": "Freezer Hold Time (hours)",
       "presets": {
         "label": "Quick Presets",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -92,7 +92,7 @@
     "children": "Lapset",
     "supplyDays": "Varastojen Kesto (päivää)",
     "supplyDaysHelper": "Suositus: 3-7 päivää",
-    "hasFreezer": "Pakastin",
+    "useFreezer": "Käytä pakastinta",
     "customDescription": "Aseta omat asetukset",
     "presets": {
       "single": "Yksin Asuva",
@@ -136,7 +136,7 @@
       "adults": "Aikuiset",
       "children": "Lapset",
       "supplyDays": "Varastojen Kesto (päivää)",
-      "hasFreezer": "Pakastin",
+      "useFreezer": "Käytä pakastinta",
       "freezerHoldTime": "Pakastimen Säilytysaika (tuntia)",
       "presets": {
         "label": "Pikavalinnat",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -17,7 +17,7 @@ const setupCompletedOnboarding = () => {
       adults: 2,
       children: 0,
       supplyDurationDays: 7,
-      hasFreezer: false,
+      useFreezer: false,
     },
     settings: {
       language: 'en',

--- a/src/components/onboarding/HouseholdForm.stories.tsx
+++ b/src/components/onboarding/HouseholdForm.stories.tsx
@@ -38,7 +38,7 @@ export const WithInitialData: Story = {
       adults: 3,
       children: 2,
       supplyDays: 14,
-      hasFreezer: true,
+      useFreezer: true,
     },
     onSubmit: (data) => {
       console.log('Form submitted:', data);
@@ -66,7 +66,7 @@ export const SinglePerson: Story = {
       adults: 1,
       children: 0,
       supplyDays: 7,
-      hasFreezer: false,
+      useFreezer: false,
     },
     onSubmit: (data) => {
       console.log('Form submitted:', data);
@@ -81,7 +81,7 @@ export const LargeFamily: Story = {
       adults: 4,
       children: 5,
       supplyDays: 14,
-      hasFreezer: true,
+      useFreezer: true,
     },
     onSubmit: (data) => {
       console.log('Form submitted:', data);
@@ -96,7 +96,7 @@ export const ExtendedSupplyDuration: Story = {
       adults: 2,
       children: 2,
       supplyDays: 30,
-      hasFreezer: true,
+      useFreezer: true,
     },
     onSubmit: (data) => {
       console.log('Form submitted:', data);

--- a/src/components/onboarding/HouseholdForm.test.tsx
+++ b/src/components/onboarding/HouseholdForm.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-i18next', () => ({
         'household.adults': 'Adults',
         'household.children': 'Children',
         'household.supplyDays': 'Supply Duration (days)',
-        'household.hasFreezer': 'Has Freezer',
+        'household.useFreezer': 'Use Freezer',
         'household.errors.adultsMin': 'At least {{min}} adult is required',
         'household.errors.adultsMax': 'Maximum {{max}} adults allowed',
         'household.errors.childrenNegative': 'Cannot be negative',
@@ -41,7 +41,7 @@ describe('HouseholdForm', () => {
     expect(screen.getByLabelText(/Adults/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Children/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Supply Duration/i)).toBeInTheDocument();
-    expect(screen.getByLabelText('Has Freezer')).toBeInTheDocument();
+    expect(screen.getByLabelText('Use Freezer')).toBeInTheDocument();
   });
 
   it('displays initial data when provided', () => {
@@ -53,7 +53,7 @@ describe('HouseholdForm', () => {
           adults: 3,
           children: 2,
           supplyDays: 14,
-          hasFreezer: true,
+          useFreezer: true,
         }}
       />,
     );
@@ -61,7 +61,7 @@ describe('HouseholdForm', () => {
     expect(screen.getByLabelText(/Adults/i)).toHaveValue(3);
     expect(screen.getByLabelText(/Children/i)).toHaveValue(2);
     expect(screen.getByLabelText(/Supply Duration/i)).toHaveValue(14);
-    expect(screen.getByLabelText('Has Freezer')).toBeChecked();
+    expect(screen.getByLabelText('Use Freezer')).toBeChecked();
   });
 
   it('calls onSubmit with form data when submitted', async () => {
@@ -72,7 +72,7 @@ describe('HouseholdForm', () => {
     const adultsInput = screen.getByLabelText(/Adults/i);
     const childrenInput = screen.getByLabelText(/Children/i);
     const supplyDaysInput = screen.getByLabelText(/Supply Duration/i);
-    const freezerCheckbox = screen.getByLabelText('Has Freezer');
+    const freezerCheckbox = screen.getByLabelText('Use Freezer');
     const form = container.querySelector('form');
 
     fireEvent.change(adultsInput, { target: { value: '2' } });
@@ -86,7 +86,7 @@ describe('HouseholdForm', () => {
       adults: 2,
       children: 1,
       supplyDays: 10,
-      hasFreezer: true,
+      useFreezer: true,
     });
   });
 

--- a/src/components/onboarding/HouseholdForm.tsx
+++ b/src/components/onboarding/HouseholdForm.tsx
@@ -17,7 +17,7 @@ export interface HouseholdData {
   adults: number;
   children: number;
   supplyDays: number;
-  hasFreezer: boolean;
+  useFreezer: boolean;
 }
 
 export interface HouseholdFormProps {
@@ -36,7 +36,7 @@ export function HouseholdForm({
     adults: initialData?.adults ?? HOUSEHOLD_DEFAULTS.adults,
     children: initialData?.children ?? HOUSEHOLD_DEFAULTS.children,
     supplyDays: initialData?.supplyDays ?? HOUSEHOLD_DEFAULTS.supplyDays,
-    hasFreezer: initialData?.hasFreezer ?? HOUSEHOLD_DEFAULTS.hasFreezer,
+    useFreezer: initialData?.useFreezer ?? HOUSEHOLD_DEFAULTS.useFreezer,
   });
 
   const [errors, setErrors] = useState<
@@ -169,11 +169,11 @@ export function HouseholdForm({
               <label className={styles.checkboxLabel}>
                 <input
                   type="checkbox"
-                  checked={formData.hasFreezer}
-                  onChange={(e) => handleChange('hasFreezer', e.target.checked)}
+                  checked={formData.useFreezer}
+                  onChange={(e) => handleChange('useFreezer', e.target.checked)}
                   className={styles.checkbox}
                 />
-                <span>{t('household.hasFreezer')}</span>
+                <span>{t('household.useFreezer')}</span>
               </label>
             </div>
           </div>

--- a/src/components/onboarding/Onboarding.test.tsx
+++ b/src/components/onboarding/Onboarding.test.tsx
@@ -35,7 +35,7 @@ jest.mock('react-i18next', () => ({
         'household.adults': 'Adults',
         'household.children': 'Children',
         'household.supplyDays': 'Supply Days',
-        'household.hasFreezer': 'I have a freezer',
+        'household.useFreezer': 'I want to use my freezer',
         'actions.save': 'Save',
         'actions.cancel': 'Cancel',
         'quickSetup.addItems': 'Add Items',
@@ -187,7 +187,7 @@ describe('Onboarding', () => {
         adults: expect.any(Number),
         children: expect.any(Number),
         supplyDurationDays: expect.any(Number),
-        hasFreezer: expect.any(Boolean),
+        useFreezer: expect.any(Boolean),
       }),
       [],
     );
@@ -234,7 +234,7 @@ describe('Onboarding', () => {
         adults: expect.any(Number),
         children: expect.any(Number),
         supplyDurationDays: expect.any(Number),
-        hasFreezer: expect.any(Boolean),
+        useFreezer: expect.any(Boolean),
       }),
       expect.arrayContaining([
         expect.objectContaining({

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -37,7 +37,7 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
       adults: data.adults,
       children: data.children,
       supplyDurationDays: data.supplyDays,
-      hasFreezer: data.hasFreezer,
+      useFreezer: data.useFreezer,
     };
     setHouseholdConfig(config);
     setCurrentStep('quickSetup');
@@ -48,8 +48,8 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
 
     // Calculate and create inventory items from recommended items
     const items: InventoryItem[] = RECOMMENDED_ITEMS.filter((item) => {
-      // Skip frozen items if no freezer
-      if (item.requiresFreezer && !householdConfig.hasFreezer) {
+      // Skip frozen items if not using freezer
+      if (item.requiresFreezer && !householdConfig.useFreezer) {
         return false;
       }
       return true;
@@ -124,7 +124,7 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
                   adults: selectedPreset.adults,
                   children: selectedPreset.children,
                   supplyDays: HOUSEHOLD_DEFAULTS.supplyDays,
-                  hasFreezer: HOUSEHOLD_DEFAULTS.hasFreezer,
+                  useFreezer: HOUSEHOLD_DEFAULTS.useFreezer,
                 }
               : undefined
           }

--- a/src/components/onboarding/QuickSetupScreen.stories.tsx
+++ b/src/components/onboarding/QuickSetupScreen.stories.tsx
@@ -26,7 +26,7 @@ const defaultHousehold = createMockHousehold({
   adults: 2,
   children: 1,
   supplyDurationDays: 3,
-  hasFreezer: true,
+  useFreezer: true,
 });
 
 export const Default: Story = {
@@ -47,7 +47,7 @@ export const SinglePerson: Story = {
       adults: 1,
       children: 0,
       supplyDurationDays: 3,
-      hasFreezer: true,
+      useFreezer: true,
     }),
     onAddItems: () => {
       console.log('Add items clicked');
@@ -64,7 +64,7 @@ export const LargeFamily: Story = {
       adults: 2,
       children: 3,
       supplyDurationDays: 7,
-      hasFreezer: true,
+      useFreezer: true,
     }),
     onAddItems: () => {
       console.log('Add items clicked');
@@ -81,7 +81,7 @@ export const NoFreezer: Story = {
       adults: 2,
       children: 1,
       supplyDurationDays: 3,
-      hasFreezer: false,
+      useFreezer: false,
     },
     onAddItems: () => {
       console.log('Add items clicked');
@@ -98,7 +98,7 @@ export const ExtendedSupply: Story = {
       adults: 2,
       children: 0,
       supplyDurationDays: 14,
-      hasFreezer: true,
+      useFreezer: true,
     },
     onAddItems: () => {
       console.log('Add items clicked');

--- a/src/components/onboarding/QuickSetupScreen.test.tsx
+++ b/src/components/onboarding/QuickSetupScreen.test.tsx
@@ -39,7 +39,7 @@ describe('QuickSetupScreen', () => {
     adults: 2,
     children: 1,
     supplyDurationDays: 3,
-    hasFreezer: true,
+    useFreezer: true,
   };
 
   it('renders title and subtitle', () => {
@@ -158,7 +158,7 @@ describe('QuickSetupScreen', () => {
     const onSkip = jest.fn();
     const householdWithoutFreezer: HouseholdConfig = {
       ...defaultHousehold,
-      hasFreezer: false,
+      useFreezer: false,
     };
 
     render(

--- a/src/components/onboarding/QuickSetupScreen.tsx
+++ b/src/components/onboarding/QuickSetupScreen.tsx
@@ -21,8 +21,8 @@ export const QuickSetupScreen = ({
 
   // Calculate which items will be added
   const itemsToAdd = RECOMMENDED_ITEMS.filter((item) => {
-    // Skip frozen items if no freezer
-    if (item.requiresFreezer && !household.hasFreezer) {
+    // Skip frozen items if not using freezer
+    if (item.requiresFreezer && !household.useFreezer) {
       return false;
     }
     return true;
@@ -124,7 +124,7 @@ export const QuickSetupScreen = ({
 
         <div className={styles.info}>
           <p>{t('quickSetup.info')}</p>
-          {!household.hasFreezer && (
+          {!household.useFreezer && (
             <p className={styles.freezerNote}>{t('quickSetup.noFreezer')}</p>
           )}
         </div>

--- a/src/components/settings/ExportButton.test.tsx
+++ b/src/components/settings/ExportButton.test.tsx
@@ -45,7 +45,7 @@ describe('ExportButton', () => {
         adults: 2,
         children: 0,
         supplyDurationDays: 3,
-        hasFreezer: false,
+        useFreezer: false,
       },
     });
 

--- a/src/components/settings/HouseholdForm.test.tsx
+++ b/src/components/settings/HouseholdForm.test.tsx
@@ -27,7 +27,7 @@ describe('HouseholdForm', () => {
       screen.getByLabelText('settings.household.supplyDays'),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText('settings.household.hasFreezer'),
+      screen.getByLabelText('settings.household.useFreezer'),
     ).toBeInTheDocument();
   });
 
@@ -79,7 +79,7 @@ describe('HouseholdForm', () => {
     renderWithProviders(<HouseholdForm />);
 
     const freezerCheckbox = screen.getByLabelText(
-      'settings.household.hasFreezer',
+      'settings.household.useFreezer',
     ) as HTMLInputElement;
 
     // Checkbox starts unchecked by default
@@ -100,7 +100,7 @@ describe('HouseholdForm', () => {
     renderWithProviders(<HouseholdForm />);
 
     const freezerCheckbox = screen.getByLabelText(
-      'settings.household.hasFreezer',
+      'settings.household.useFreezer',
     ) as HTMLInputElement;
 
     // Initial state

--- a/src/components/settings/HouseholdForm.tsx
+++ b/src/components/settings/HouseholdForm.tsx
@@ -75,16 +75,16 @@ export function HouseholdForm() {
         <div className={styles.checkboxField}>
           <input
             type="checkbox"
-            id="hasFreezer"
-            checked={household.hasFreezer}
-            onChange={(e) => handleChange('hasFreezer', e.target.checked)}
+            id="useFreezer"
+            checked={household.useFreezer}
+            onChange={(e) => handleChange('useFreezer', e.target.checked)}
           />
-          <label htmlFor="hasFreezer">
-            {t('settings.household.hasFreezer')}
+          <label htmlFor="useFreezer">
+            {t('settings.household.useFreezer')}
           </label>
         </div>
 
-        {household.hasFreezer && (
+        {household.useFreezer && (
           <Input
             id="freezerHoldTimeHours"
             type="number"

--- a/src/constants/household.ts
+++ b/src/constants/household.ts
@@ -3,7 +3,7 @@ export const HOUSEHOLD_DEFAULTS = {
   adults: 1,
   children: 0,
   supplyDays: 3,
-  hasFreezer: false,
+  useFreezer: false,
 } as const;
 
 // Validation limits for household configuration

--- a/src/contexts/HouseholdProvider.tsx
+++ b/src/contexts/HouseholdProvider.tsx
@@ -7,7 +7,7 @@ const DEFAULT_HOUSEHOLD: HouseholdConfig = {
   adults: 2,
   children: 3,
   supplyDurationDays: 3,
-  hasFreezer: false,
+  useFreezer: false,
 };
 
 const HOUSEHOLD_PRESETS: Record<
@@ -18,19 +18,19 @@ const HOUSEHOLD_PRESETS: Record<
     adults: 1,
     children: 0,
     supplyDurationDays: 3,
-    hasFreezer: false,
+    useFreezer: false,
   },
   couple: {
     adults: 2,
     children: 0,
     supplyDurationDays: 3,
-    hasFreezer: true,
+    useFreezer: true,
   },
   family: {
     adults: 2,
     children: 2,
     supplyDurationDays: 3,
-    hasFreezer: true,
+    useFreezer: true,
   },
 };
 

--- a/src/contexts/InventoryProvider.tsx
+++ b/src/contexts/InventoryProvider.tsx
@@ -19,7 +19,7 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
         adults: 2,
         children: 0,
         supplyDurationDays: 7,
-        hasFreezer: false,
+        useFreezer: false,
       },
       settings: {
         language: 'en',

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -27,7 +27,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         adults: 2,
         children: 0,
         supplyDurationDays: 7,
-        hasFreezer: false,
+        useFreezer: false,
       },
       settings: DEFAULT_SETTINGS,
       customCategories: [], // Only custom categories, STANDARD_CATEGORIES are always available

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -79,8 +79,8 @@ export function useAlerts() {
     );
 
     RECOMMENDED_ITEMS.forEach((recommendedItem) => {
-      // Skip freezer items if household doesn't have a freezer
-      if (recommendedItem.requiresFreezer && !household.hasFreezer) {
+      // Skip freezer items if household doesn't use a freezer
+      if (recommendedItem.requiresFreezer && !household.useFreezer) {
         return;
       }
 

--- a/src/pages/Inventory.test.tsx
+++ b/src/pages/Inventory.test.tsx
@@ -160,7 +160,7 @@ describe('Template to InventoryItem conversion', () => {
       adults: 2,
       children: 0,
       supplyDurationDays: 3,
-      hasFreezer: false,
+      useFreezer: false,
     };
 
     const recommendedQty = calculateRecommendedQuantity(template, household);
@@ -204,7 +204,7 @@ describe('Template to InventoryItem conversion', () => {
       adults: 2,
       children: 0,
       supplyDurationDays: 3,
-      hasFreezer: false,
+      useFreezer: false,
     };
 
     const recommendedQty = calculateRecommendedQuantity(template, household);
@@ -239,7 +239,7 @@ describe('Template to InventoryItem conversion', () => {
       adults: 2,
       children: 0,
       supplyDurationDays: 3,
-      hasFreezer: false,
+      useFreezer: false,
     };
 
     // Item WITH productTemplateId (the fix)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,7 +43,7 @@ export interface HouseholdConfig {
   adults: number;
   children: number;
   supplyDurationDays: number;
-  hasFreezer: boolean;
+  useFreezer: boolean;
   freezerHoldTimeHours?: number;
 }
 

--- a/src/utils/calculations/household.test.ts
+++ b/src/utils/calculations/household.test.ts
@@ -11,7 +11,7 @@ describe('calculateHouseholdMultiplier', () => {
       adults: 2,
       children: 1,
       supplyDurationDays: 7,
-      hasFreezer: false,
+      useFreezer: false,
     };
     // (2 * 1.0 + 1 * 0.75) * (7 / 3) = 2.75 * 2.33 ≈ 6.42
     const result = calculateHouseholdMultiplier(config);
@@ -34,7 +34,7 @@ describe('calculateRecommendedQuantity', () => {
       adults: 2,
       children: 0,
       supplyDurationDays: 7,
-      hasFreezer: false,
+      useFreezer: false,
     };
     // 9 * 2 * (7/3) = 9 * 2 * 2.33 = 42
     const result = calculateRecommendedQuantity(item, household);
@@ -55,7 +55,7 @@ describe('calculateRecommendedQuantity', () => {
       adults: 5,
       children: 3,
       supplyDurationDays: 14,
-      hasFreezer: false,
+      useFreezer: false,
     };
     const result = calculateRecommendedQuantity(item, household);
     expect(result).toBe(1);

--- a/src/utils/dashboard/categoryStatus.test.ts
+++ b/src/utils/dashboard/categoryStatus.test.ts
@@ -208,7 +208,7 @@ describe('calculateCategoryShortages', () => {
     adults: 2,
     children: 0,
     supplyDurationDays: 3,
-    hasFreezer: false,
+    useFreezer: false,
   });
 
   // Water calculation tests - 3 liters per person per day
@@ -218,7 +218,7 @@ describe('calculateCategoryShortages', () => {
         adults: 1,
         children: 0,
         supplyDurationDays: 3,
-        hasFreezer: false,
+        useFreezer: false,
       });
 
       const result = calculateCategoryShortages(
@@ -256,7 +256,7 @@ describe('calculateCategoryShortages', () => {
         adults: 2,
         children: 0,
         supplyDurationDays: 7,
-        hasFreezer: false,
+        useFreezer: false,
       });
 
       const result = calculateCategoryShortages(
@@ -279,7 +279,7 @@ describe('calculateCategoryShortages', () => {
         adults: 2,
         children: 2,
         supplyDurationDays: 3,
-        hasFreezer: false,
+        useFreezer: false,
       });
 
       const result = calculateCategoryShortages(
@@ -302,7 +302,7 @@ describe('calculateCategoryShortages', () => {
         adults: 0,
         children: 1,
         supplyDurationDays: 3,
-        hasFreezer: false,
+        useFreezer: false,
       });
 
       const result = calculateCategoryShortages(
@@ -514,7 +514,7 @@ describe('getCategoryDisplayStatus', () => {
     adults: 2,
     children: 0,
     supplyDurationDays: 3,
-    hasFreezer: false,
+    useFreezer: false,
   });
 
   it('should return all display data for a category', () => {

--- a/src/utils/dashboard/preparedness.test.ts
+++ b/src/utils/dashboard/preparedness.test.ts
@@ -11,7 +11,7 @@ describe('calculatePreparednessScore', () => {
   const baseHousehold = createMockHousehold({
     adults: 2,
     children: 0,
-    hasFreezer: false,
+    useFreezer: false,
     supplyDurationDays: 14,
   });
 
@@ -72,10 +72,10 @@ describe('calculatePreparednessScore', () => {
   });
 
   it('should filter out frozen items when no freezer', () => {
-    const withFreezer: HouseholdConfig = { ...baseHousehold, hasFreezer: true };
+    const withFreezer: HouseholdConfig = { ...baseHousehold, useFreezer: true };
     const withoutFreezer: HouseholdConfig = {
       ...baseHousehold,
-      hasFreezer: false,
+      useFreezer: false,
     };
 
     const items: InventoryItem[] = [];
@@ -117,7 +117,7 @@ describe('calculateCategoryPreparedness', () => {
     adults: 2,
     children: 0,
     hasPets: false,
-    hasFreezer: false,
+    useFreezer: false,
     supplyDurationDays: 14,
   };
 

--- a/src/utils/dashboard/preparedness.ts
+++ b/src/utils/dashboard/preparedness.ts
@@ -11,8 +11,8 @@ export function calculatePreparednessScore(
 ): number {
   // Get recommended items for this household
   const recommendedForHousehold = RECOMMENDED_ITEMS.filter((item) => {
-    // Skip frozen items if no freezer
-    if (item.requiresFreezer && !household.hasFreezer) {
+    // Skip frozen items if not using freezer
+    if (item.requiresFreezer && !household.useFreezer) {
       return false;
     }
     return true;

--- a/src/utils/test/factories.ts
+++ b/src/utils/test/factories.ts
@@ -18,7 +18,7 @@ export function createMockHousehold(
     adults: 2,
     children: 1,
     supplyDurationDays: 7,
-    hasFreezer: true,
+    useFreezer: true,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Renamed `hasFreezer` to `useFreezer` throughout the codebase to better reflect user intent
- The old name was misleading: most households have a freezer, but users may not want to use it for emergency supplies
- The new name clarifies that this setting controls whether to **utilize** the freezer for emergency storage

## Changes

- Updated `HouseholdConfig.hasFreezer` → `useFreezer` in types
- Updated all context providers, components, hooks, and utilities
- Updated locale files (EN: "Use Freezer", FI: "Käytä pakastinta")
- Updated tests, fixtures, and example data
- Updated `docs/DATA_SCHEMA.md` (current documentation)

**Note:** `docs/specifications/` files are intentionally unchanged as they represent original pre-implementation design documents.

## Test plan

- [x] All 400 unit tests pass
- [x] Build succeeds with no TypeScript errors
- [ ] Manual verification of UI checkbox label change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated schema, specs, and recommended-items docs: renamed "Has Freezer" → "Use Freezer", refreshed tables, formatting, and examples; minor formula formatting tweak (no behavior change).

* **Tests**
  * Updated fixtures, mocks, and assertions to use the new "Use Freezer" field.

* **Chores**
  * Renamed freezer configuration property across UI labels, presets, translations, stories, examples, and default data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->