### PR TITLE
chore: remove deprecated husky v9 shebang lines

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
## Summary
- Remove deprecated `#!/usr/bin/env sh` shebang and `. "$(dirname -- "$0")/_/husky.sh"` lines from `.husky/pre-commit`
- These lines will fail in husky v10.0.0 and are no longer needed in v9+

## Test plan
- [x] Verify pre-commit hook still runs lint-staged correctly
- [x] Confirm deprecation warning no longer appears