### PR TITLE
feat: add expandable missing items list in category status

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -239,6 +239,7 @@
     "allCategories": "All",
     "noItems": "No items found",
     "missing": "Missing",
+    "showLess": "Show less",
     "expired": "Expired",
     "expiresIn": "Expires in {{days}} days",
     "searchPlaceholder": "Search items...",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -239,6 +239,7 @@
     "allCategories": "Kaikki",
     "noItems": "Ei tuotteita",
     "missing": "Puuttuu",
+    "showLess": "Näytä vähemmän",
     "expired": "Vanhentunut",
     "expiresIn": "Vanhenee {{days}} päivässä",
     "searchPlaceholder": "Hae tuotteita...",

--- a/src/components/inventory/CategoryStatusSummary.module.css
+++ b/src/components/inventory/CategoryStatusSummary.module.css
@@ -68,6 +68,60 @@
   margin-top: var(--spacing-xs);
 }
 
+.missingSection {
+  margin-top: var(--spacing-sm);
+}
+
+.missingLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-xs);
+}
+
+.missingList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.missingItem {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  padding-left: var(--spacing-sm);
+  position: relative;
+}
+
+.missingItem::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  color: var(--color-text-tertiary);
+}
+
+.expandButton {
+  background: none;
+  border: none;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-primary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.2s ease;
+}
+
+.expandButton:hover {
+  background-color: var(--color-background-secondary);
+}
+
+.expandButton:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .missingCalories {
   font-size: var(--font-size-sm);
   color: var(--color-warning);


### PR DESCRIPTION
## Summary
- Missing items list now shows first 3 items with a clickable `+N` button for overflow
- Clicking the button expands to show all missing items
- "Show less" button collapses back to the 3-item summary view

## Test plan
- [ ] Verify missing items display correctly when there are 3 or fewer items (no expand button)
- [ ] Verify `+N` button appears when there are more than 3 missing items
- [ ] Verify clicking `+N` expands to show all items
- [ ] Verify "Show less" button appears when expanded and collapses the list
- [ ] Run tests: `npm test CategoryStatusSummary`