### PR TITLE
fix: prevent modal horizontal overflow on mobile devices

### DIFF
--- a/src/components/common/Modal.module.css
+++ b/src/components/common/Modal.module.css
@@ -10,6 +10,7 @@
   justify-content: center;
   z-index: 1000;
   padding: var(--spacing-md);
+  overflow: hidden;
 }
 
 .modal {
@@ -20,19 +21,21 @@
   flex-direction: column;
   max-height: 90vh;
   width: 100%;
+  max-width: calc(100vw - var(--spacing-md) * 2);
   animation: modalFadeIn 0.2s ease-out;
+  overflow: hidden;
 }
 
 .modal.small {
-  max-width: 400px;
+  max-width: min(400px, calc(100vw - var(--spacing-md) * 2));
 }
 
 .modal.medium {
-  max-width: 600px;
+  max-width: min(600px, calc(100vw - var(--spacing-md) * 2));
 }
 
 .modal.large {
-  max-width: 800px;
+  max-width: min(800px, calc(100vw - var(--spacing-md) * 2));
 }
 
 @keyframes modalFadeIn {
@@ -121,6 +124,7 @@
 
 .content {
   padding: var(--spacing-lg);
+  overflow-x: hidden;
   overflow-y: auto;
   flex: 1;
 }


### PR DESCRIPTION
## Summary
- Fix add item modal moving sideways and not fitting to screen on mobile devices
- Add viewport-aware max-width constraints using CSS `min()` function
- Prevent horizontal overflow with `overflow: hidden` on overlay, modal, and content

## Test plan
- [ ] Open app on mobile device or mobile emulator (< 400px width)
- [ ] Open "Add Item" modal
- [ ] Verify modal fits within viewport with no horizontal scrolling
- [ ] Test on various screen sizes (iPhone SE, iPhone 14, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved modal responsiveness to adapt better to various screen sizes
  * Enhanced overflow handling for modal content with automatic scrolling support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->