### PR TITLE
fix: skip onboarding when importing data

### DIFF
--- a/src/utils/storage/localStorage.test.ts
+++ b/src/utils/storage/localStorage.test.ts
@@ -45,7 +45,11 @@ describe('localStorage utilities', () => {
       });
       const json = JSON.stringify(mockData);
       const imported = importFromJSON(json);
-      expect(imported).toEqual(mockData);
+      // onboardingCompleted is always set to true on import
+      expect(imported).toEqual({
+        ...mockData,
+        settings: { ...mockData.settings, onboardingCompleted: true },
+      });
     });
 
     it('imports data from JSON without customCategories field', () => {
@@ -98,6 +102,55 @@ describe('localStorage utilities', () => {
       const imported = importFromJSON(json);
 
       expect(imported.customTemplates).toEqual([]);
+    });
+
+    it('sets onboardingCompleted to true when settings exist', () => {
+      const mockData = createMockAppData({
+        settings: {
+          language: 'en',
+          theme: 'light',
+          highContrast: false,
+          advancedFeatures: {
+            calorieTracking: false,
+            powerManagement: false,
+            waterTracking: false,
+          },
+          onboardingCompleted: false,
+        },
+      });
+      const json = JSON.stringify(mockData);
+      const imported = importFromJSON(json);
+
+      expect(imported.settings.onboardingCompleted).toBe(true);
+    });
+
+    it('sets onboardingCompleted to true even when not present in imported data', () => {
+      const mockData = createMockAppData();
+      const dataWithoutOnboarding = {
+        version: mockData.version,
+        household: mockData.household,
+        settings: {
+          language: 'en',
+          theme: 'light',
+          highContrast: false,
+          advancedFeatures: {
+            calorieTracking: false,
+            powerManagement: false,
+            waterTracking: false,
+          },
+        },
+        items: mockData.items,
+        lastModified: mockData.lastModified,
+      };
+      const json = JSON.stringify(dataWithoutOnboarding);
+      const imported = importFromJSON(json);
+
+      expect(imported.settings.onboardingCompleted).toBe(true);
+    });
+
+    it('throws error for invalid JSON', () => {
+      const invalidJson = '{ invalid json }';
+      expect(() => importFromJSON(invalidJson)).toThrow();
     });
   });
 });

--- a/src/utils/storage/localStorage.ts
+++ b/src/utils/storage/localStorage.ts
@@ -58,8 +58,24 @@ export function exportToJSON(data: AppData): string {
   return JSON.stringify(data, null, 2);
 }
 
+/**
+ * Parses and normalizes imported JSON data into AppData format.
+ * Ensures required fields exist and sets onboardingCompleted to true
+ * since imported data represents an already-configured setup.
+ *
+ * @param json - JSON string containing app data to import
+ * @returns Parsed and normalized AppData object
+ * @throws Error if JSON parsing fails (invalid JSON format)
+ */
 export function importFromJSON(json: string): AppData {
-  const data = JSON.parse(json) as Partial<AppData>;
+  let data: Partial<AppData>;
+
+  try {
+    data = JSON.parse(json) as Partial<AppData>;
+  } catch (error) {
+    console.error('Failed to parse import JSON:', error);
+    throw error;
+  }
 
   // Ensure customCategories exists (only user's custom categories)
   if (!data.customCategories) {


### PR DESCRIPTION
## Summary
- Ensures importing data always sets `onboardingCompleted: true` in settings
- Prevents users from being redirected to onboarding after importing their data
- Imported data represents an already-configured setup, so onboarding should be skipped

## Test plan
- [x] Build passes
- [x] E2E data-management tests pass (20/20)
- [ ] Manual test: Import a JSON file without `onboardingCompleted` flag and verify app goes to dashboard, not onboarding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed an issue where the onboarding process would restart after importing saved user data, ensuring users can seamlessly resume their previous session following an import.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->