### PR TITLE
feat: add gasoline power generator and fuel to Light & Power category

### DIFF
--- a/public/locales/en/products.json
+++ b/public/locales/en/products.json
@@ -46,6 +46,8 @@
   "power-bank": "Power Bank (Charged)",
   "charging-cables": "Charging Cables (USB-C, Lightning, Micro-USB)",
   "solar-charger": "Solar Charger or Hand Crank Charger",
+  "power-generator": "Gasoline Power Generator",
+  "generator-fuel": "Gasoline for Generator",
   "battery-radio": "Battery-Powered Radio",
   "hand-crank-radio": "Hand Crank Emergency Radio",
   "first-aid-kit": "First Aid Kit",

--- a/public/locales/fi/products.json
+++ b/public/locales/fi/products.json
@@ -46,6 +46,8 @@
   "power-bank": "Varavirtalähde (Ladattu)",
   "charging-cables": "Latausjohdot (USB-C, Lightning, Micro-USB)",
   "solar-charger": "Aurinkopaneeli tai Kampikäyttöinen Laturi",
+  "power-generator": "Bensiiniaggregaatti",
+  "generator-fuel": "Bensiini Aggregaattiin",
   "battery-radio": "Paristokäyttöinen Radio",
   "hand-crank-radio": "Kampikäyttöinen Hätäradio",
   "first-aid-kit": "Ensiapulaukku",

--- a/src/data/recommendedItems.ts
+++ b/src/data/recommendedItems.ts
@@ -397,6 +397,25 @@ export const RECOMMENDED_ITEMS: RecommendedItemDefinition[] = [
     scaleWithPeople: false,
     scaleWithDays: false,
   },
+  {
+    id: 'power-generator',
+    i18nKey: 'products.power-generator',
+    category: 'light-power',
+    baseQuantity: 1,
+    unit: 'pieces',
+    scaleWithPeople: false,
+    scaleWithDays: false,
+  },
+  {
+    id: 'generator-fuel',
+    i18nKey: 'products.generator-fuel',
+    category: 'light-power',
+    baseQuantity: 10,
+    unit: 'liters',
+    scaleWithPeople: false,
+    scaleWithDays: true,
+    defaultExpirationMonths: 12,
+  },
 
   // ===================================================================
   // 5. Communication


### PR DESCRIPTION
## Summary
- Add gasoline power generator item to Light & Power category (1 piece per household)
- Add generator fuel item with 10 liters base quantity that scales with days
- Include English and Finnish translations for both items

## Test plan
- [ ] Verify new items appear in the Light & Power category
- [ ] Verify fuel quantity scales correctly with number of days
- [ ] Verify translations display correctly in both English and Finnish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new products to recommendations: Gasoline Power Generator and Gasoline for Generator
  * Full localization support in English and Finnish
  * Generator Fuel automatically scales quantities based on trip duration and includes 12-month expiration tracking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->