### PR TITLE
feat: implement URL query parameter support for language selection

### DIFF
--- a/src/components/common/LanguageSwitcher.tsx
+++ b/src/components/common/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '../../hooks/useSettings';
+import { setLanguageInUrl } from '../../utils/urlLanguage';
 
 export function LanguageSwitcher() {
   const { i18n } = useTranslation();
@@ -10,6 +11,7 @@ export function LanguageSwitcher() {
   ) => {
     const newLanguage = event.target.value as 'en' | 'fi';
     updateSettings({ language: newLanguage });
+    setLanguageInUrl(newLanguage);
     i18n.changeLanguage(newLanguage).catch((error) => {
       console.error('Failed to change language:', error);
     });

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -6,6 +6,7 @@ import {
   createDefaultAppData,
 } from '../utils/storage/localStorage';
 import { SettingsContext } from './SettingsContext';
+import { getLanguageFromUrl, setLanguageInUrl } from '../utils/urlLanguage';
 
 const DEFAULT_SETTINGS: UserSettings = {
   language: 'en',
@@ -21,8 +22,23 @@ const DEFAULT_SETTINGS: UserSettings = {
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [settings, setSettings] = useState<UserSettings>(() => {
     const data = getAppData();
-    return data?.settings || DEFAULT_SETTINGS;
+    const storedSettings = data?.settings || DEFAULT_SETTINGS;
+
+    // If URL has a lang parameter, use it to override stored language
+    const urlLanguage = getLanguageFromUrl();
+    if (urlLanguage) {
+      return { ...storedSettings, language: urlLanguage };
+    }
+
+    return storedSettings;
   });
+
+  // Sync URL with language on initial load
+  useEffect(() => {
+    setLanguageInUrl(settings.language);
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Save to localStorage on change
   useEffect(() => {

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,15 +1,22 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import HttpBackend from 'i18next-http-backend';
+import { getInitialLanguage } from '../utils/urlLanguage';
+import { getAppData } from '../utils/storage/localStorage';
 
 // Get base path from Vite's import.meta.env.BASE_URL
 const basePath = import.meta.env.BASE_URL || '/';
+
+// Determine initial language: URL param > localStorage > default ('en')
+const storedData = getAppData();
+const storedLanguage = storedData?.settings?.language;
+const initialLanguage = getInitialLanguage(storedLanguage);
 
 i18n
   .use(HttpBackend)
   .use(initReactI18next)
   .init({
-    lng: 'en', // default language
+    lng: initialLanguage, // language from URL param, localStorage, or default
     fallbackLng: 'en',
     ns: ['common', 'categories', 'products', 'units'],
     defaultNS: 'common',

--- a/src/utils/urlLanguage.test.ts
+++ b/src/utils/urlLanguage.test.ts
@@ -1,0 +1,52 @@
+import { extractLanguageFromSearch, isSupportedLanguage } from './urlLanguage';
+
+describe('urlLanguage', () => {
+  describe('isSupportedLanguage', () => {
+    it('returns true for "en"', () => {
+      expect(isSupportedLanguage('en')).toBe(true);
+    });
+
+    it('returns true for "fi"', () => {
+      expect(isSupportedLanguage('fi')).toBe(true);
+    });
+
+    it('returns false for unsupported languages', () => {
+      expect(isSupportedLanguage('de')).toBe(false);
+      expect(isSupportedLanguage('sv')).toBe(false);
+      expect(isSupportedLanguage('')).toBe(false);
+    });
+  });
+
+  describe('extractLanguageFromSearch', () => {
+    it('returns null when no lang parameter is present', () => {
+      expect(extractLanguageFromSearch('')).toBeNull();
+      expect(extractLanguageFromSearch('?foo=bar')).toBeNull();
+    });
+
+    it('returns "en" when lang=en is in the search string', () => {
+      expect(extractLanguageFromSearch('?lang=en')).toBe('en');
+    });
+
+    it('returns "fi" when lang=fi is in the search string', () => {
+      expect(extractLanguageFromSearch('?lang=fi')).toBe('fi');
+    });
+
+    it('returns null for unsupported language codes', () => {
+      expect(extractLanguageFromSearch('?lang=de')).toBeNull();
+      expect(extractLanguageFromSearch('?lang=sv')).toBeNull();
+    });
+
+    it('returns null for empty lang parameter', () => {
+      expect(extractLanguageFromSearch('?lang=')).toBeNull();
+    });
+
+    it('handles multiple query parameters', () => {
+      expect(extractLanguageFromSearch('?foo=bar&lang=fi&baz=qux')).toBe('fi');
+    });
+
+    it('handles lang parameter at different positions', () => {
+      expect(extractLanguageFromSearch('?lang=en&other=value')).toBe('en');
+      expect(extractLanguageFromSearch('?other=value&lang=fi')).toBe('fi');
+    });
+  });
+});

--- a/src/utils/urlLanguage.ts
+++ b/src/utils/urlLanguage.ts
@@ -1,0 +1,76 @@
+/**
+ * Utility functions for reading and updating the lang query parameter in the URL.
+ * Used for hreflang support where ?lang=en and ?lang=fi are used.
+ */
+
+const SUPPORTED_LANGUAGES = ['en', 'fi'] as const;
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+/**
+ * Checks if a language code is supported.
+ */
+export function isSupportedLanguage(lang: string): lang is SupportedLanguage {
+  return SUPPORTED_LANGUAGES.includes(lang as SupportedLanguage);
+}
+
+/**
+ * Extracts the language from a URL search string.
+ * @param search The URL search string (e.g., "?lang=en&foo=bar")
+ * @returns The language code if valid, or null if not present or invalid.
+ */
+export function extractLanguageFromSearch(
+  search: string,
+): SupportedLanguage | null {
+  const params = new URLSearchParams(search);
+  const lang = params.get('lang');
+
+  if (lang && isSupportedLanguage(lang)) {
+    return lang;
+  }
+
+  return null;
+}
+
+/**
+ * Gets the language from the URL query parameter.
+ * @returns The language code if valid, or null if not present or invalid.
+ */
+export function getLanguageFromUrl(): SupportedLanguage | null {
+  return extractLanguageFromSearch(window.location.search);
+}
+
+/**
+ * Updates the URL with the specified language parameter.
+ * Uses replaceState to avoid adding to browser history.
+ * @param language The language code to set in the URL.
+ */
+export function setLanguageInUrl(language: SupportedLanguage): void {
+  const url = new URL(window.location.href);
+  url.searchParams.set('lang', language);
+  window.history.replaceState({}, '', url.toString());
+}
+
+/**
+ * Determines the initial language to use based on priority:
+ * 1. URL query parameter (?lang=xx)
+ * 2. Stored settings (from localStorage)
+ * 3. Default language ('en')
+ *
+ * @param storedLanguage The language from localStorage settings, if any.
+ * @returns The language to use for initialization.
+ */
+export function getInitialLanguage(
+  storedLanguage?: SupportedLanguage | null,
+): SupportedLanguage {
+  const urlLanguage = getLanguageFromUrl();
+
+  if (urlLanguage) {
+    return urlLanguage;
+  }
+
+  if (storedLanguage && isSupportedLanguage(storedLanguage)) {
+    return storedLanguage;
+  }
+
+  return 'en';
+}


### PR DESCRIPTION
## Summary
- Add support for reading and applying the `lang` query parameter (`?lang=en`, `?lang=fi`) on app initialization
- Language priority: URL param > localStorage > default ('en')
- When user changes language via UI, the URL is also updated
- Prepares for hreflang tag support

## Test plan
- [ ] Visit app with `?lang=fi` - should load in Finnish
- [ ] Visit app with `?lang=en` - should load in English
- [ ] Visit app without param - should use localStorage or default to English
- [ ] Change language via UI - URL should update accordingly
- [ ] Invalid lang param (e.g., `?lang=de`) should be ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Language preference is now reflected in the URL, enabling shareable language-specific links.
  * The app respects language parameters from the URL on initial load.
  * Enhanced synchronization between language settings and browser URL state.

* **Tests**
  * Added unit tests for language URL handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->