### PR TITLE
feat: add Jest tests and build to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 npx lint-staged
+npm test
+npm run build


### PR DESCRIPTION
## Summary
- Add `npm test` to run Jest tests before each commit
- Add `npm run build` to verify TypeScript compilation and Vite build
- Catches breaking changes early before they reach the repository

## Test plan
- [ ] Verify pre-commit hook runs lint-staged, tests, and build
- [ ] Confirm failing tests block commits
- [ ] Confirm build errors block commits