### PR TITLE
feat: add automatic version number injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - name: Generate version
+        run: echo "VITE_APP_VERSION=$(date +'%Y.%m.%d')-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-pages-artifact@v4

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -138,7 +138,6 @@
     },
     "about": {
       "version": "Version",
-      "versionNumber": "0.0.0",
       "viewOnGitHub": "View on GitHub"
     },
     "language": {

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -138,7 +138,6 @@
     },
     "about": {
       "version": "Versio",
-      "versionNumber": "0.0.0",
       "viewOnGitHub": "Näytä GitHubissa"
     },
     "language": {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { DebugExport } from '../components/settings/DebugExport';
 import { ClearDataButton } from '../components/settings/ClearDataButton';
 import { HiddenAlerts } from '../components/settings/HiddenAlerts';
 import { DisabledRecommendations } from '../components/settings/DisabledRecommendations';
+import { APP_VERSION } from '../utils/version';
 import styles from './Settings.module.css';
 
 export function Settings() {
@@ -77,7 +78,7 @@ export function Settings() {
           <div className={styles.about}>
             <p className={styles.appName}>{t('app.title')}</p>
             <p className={styles.version}>
-              {t('settings.about.version')}: {t('settings.about.versionNumber')}
+              {t('settings.about.version')}: {APP_VERSION}
             </p>
             <p className={styles.description}>{t('app.tagline')}</p>
             <a

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,10 @@
+// Type declaration for the injected global
+declare const __APP_VERSION__: string | undefined;
+
+/**
+ * Application version injected at build time via Vite's define.
+ * Format: YYYY.MM.DD-shortSha (e.g., 2025.01.15-abc1234)
+ * Falls back to 'dev' when running locally without version injection.
+ */
+export const APP_VERSION: string =
+  typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,9 @@ const dirname =
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.VITE_APP_VERSION || 'dev'),
+  },
   base:
     process.env.NODE_ENV === 'production'
       ? process.env.VITE_BASE_PATH || '/emergency-supply-tracker/'


### PR DESCRIPTION
## Summary
- Generate version from date + git SHA during deployment (format: `YYYY.MM.DD-shortSha`)
- Inject version via Vite's `define` at build time using `VITE_APP_VERSION` env var
- Display dynamic version in Settings page instead of hardcoded translation value
- Show `dev` as fallback when running locally

## Test plan
- [ ] Verify Settings page shows "Version: dev" in local development
- [ ] Deploy to GitHub Pages and verify version format (e.g., `2025.12.30-abc1234`)
- [ ] Confirm version updates on each new deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * About screen now shows the actual build version (date + commit) instead of a static placeholder.

* **Chores**
  * CI pipeline now generates a build version string at build time and exposes it to the app.
  * Removed static version translation entries from locale files to rely on the runtime build version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->