### PR TITLE
refactor: store itemType as template ID instead of translated name

### DIFF
--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -185,7 +185,7 @@ Individual items tracked in the user's inventory:
 interface InventoryItem {
   id: string; // Unique identifier (UUID)
   name: string; // Item name (or i18n key reference)
-  itemType?: string; // Template type (e.g., "Canned Tuna")
+  itemType?: string; // Template ID (e.g., "canned-fish") for i18n lookup
   categoryId: string; // Category reference
   quantity: number; // Current quantity owned
   unit: Unit; // Measurement unit

--- a/examples/sample-inventory-family5-days3.json
+++ b/examples/sample-inventory-family5-days3.json
@@ -19,7 +19,7 @@
     {
       "id": "item-1",
       "name": "Water container (red)",
-      "itemType": "Bottled Water",
+      "itemType": "bottled-water",
       "categoryId": "water-beverages",
       "quantity": 40,
       "unit": "liters",
@@ -30,7 +30,7 @@
     {
       "id": "item-2",
       "name": "Valio UHT Milk 1L",
-      "itemType": "Long-life Milk",
+      "itemType": "long-life-milk",
       "categoryId": "water-beverages",
       "quantity": 5,
       "unit": "liters",
@@ -41,7 +41,7 @@
     {
       "id": "item-3",
       "name": "Heinz Tomato Soup",
-      "itemType": "Canned Soup",
+      "itemType": "canned-soup",
       "categoryId": "food",
       "quantity": 20,
       "unit": "cans",
@@ -54,7 +54,7 @@
     {
       "id": "item-4",
       "name": "Del Monte Mixed Vegetables",
-      "itemType": "Canned Vegetables",
+      "itemType": "canned-vegetables",
       "categoryId": "food",
       "quantity": 8,
       "unit": "cans",
@@ -67,7 +67,7 @@
     {
       "id": "item-5",
       "name": "Uncle Ben's Long Grain Rice",
-      "itemType": "Rice",
+      "itemType": "rice",
       "categoryId": "food",
       "quantity": 10,
       "unit": "kilograms",
@@ -80,7 +80,7 @@
     {
       "id": "item-6",
       "name": "Barilla Spaghetti No. 5",
-      "itemType": "Pasta",
+      "itemType": "pasta",
       "categoryId": "food",
       "quantity": 3,
       "unit": "kilograms",
@@ -93,7 +93,7 @@
     {
       "id": "item-7",
       "name": "Johnson & Johnson Travel Kit",
-      "itemType": "First Aid Kit",
+      "itemType": "first-aid-kit",
       "categoryId": "medical-health",
       "quantity": 1,
       "unit": "pieces",
@@ -105,7 +105,7 @@
     {
       "id": "item-8",
       "name": "Ibuprofen 400mg",
-      "itemType": "Pain Relievers",
+      "itemType": "pain-relievers",
       "categoryId": "medical-health",
       "quantity": 2,
       "unit": "boxes",
@@ -116,7 +116,7 @@
     {
       "id": "item-9",
       "name": "Maglite LED Pro",
-      "itemType": "Flashlight",
+      "itemType": "flashlight",
       "categoryId": "light-power",
       "quantity": 3,
       "unit": "pieces",
@@ -128,7 +128,7 @@
     {
       "id": "item-10",
       "name": "IKEA FENOMEN Pillar Candles",
-      "itemType": "Candles",
+      "itemType": "candles",
       "categoryId": "light-power",
       "quantity": 12,
       "unit": "pieces",
@@ -140,7 +140,7 @@
     {
       "id": "item-16",
       "name": "Anker PowerCore",
-      "itemType": "Power Bank",
+      "itemType": "power-bank",
       "categoryId": "light-power",
       "quantity": 2,
       "unit": "pieces",
@@ -154,7 +154,7 @@
     {
       "id": "item-11",
       "name": "Sangean MMR-88 Emergency Radio",
-      "itemType": "Battery Radio",
+      "itemType": "battery-radio",
       "categoryId": "communication-info",
       "quantity": 1,
       "unit": "pieces",
@@ -166,7 +166,7 @@
     {
       "id": "item-12",
       "name": "Duracell Optimum AA",
-      "itemType": "Batteries AA",
+      "itemType": "batteries-aa",
       "categoryId": "communication-info",
       "quantity": 8,
       "unit": "pieces",
@@ -177,7 +177,7 @@
     {
       "id": "item-13",
       "name": "Lambi Classic 12-pack",
-      "itemType": "Toilet Paper",
+      "itemType": "toilet-paper",
       "categoryId": "hygiene-sanitation",
       "quantity": 24,
       "unit": "rolls",
@@ -189,7 +189,7 @@
     {
       "id": "item-14",
       "name": "Purell Advanced 500ml",
-      "itemType": "Hand Sanitizer",
+      "itemType": "hand-sanitizer",
       "categoryId": "hygiene-sanitation",
       "quantity": 3,
       "unit": "bottles",
@@ -200,7 +200,7 @@
     {
       "id": "item-15",
       "name": "SOL Emergency Bivvy",
-      "itemType": "Blankets",
+      "itemType": "emergency-blanket",
       "categoryId": "tools-supplies",
       "quantity": 4,
       "unit": "pieces",

--- a/src/components/inventory/ItemForm.tsx
+++ b/src/components/inventory/ItemForm.tsx
@@ -213,7 +213,9 @@ export const ItemForm = ({
       {formData.itemType && (
         <div className={styles.formGroup}>
           <label className={styles.label}>{t('itemForm.itemType')}</label>
-          <div className={styles.itemTypeDisplay}>{formData.itemType}</div>
+          <div className={styles.itemTypeDisplay}>
+            {t(formData.itemType, { ns: 'products' })}
+          </div>
         </div>
       )}
 

--- a/src/pages/Inventory.test.tsx
+++ b/src/pages/Inventory.test.tsx
@@ -168,7 +168,7 @@ describe('Template to InventoryItem conversion', () => {
     // Simulate what handleSelectTemplate does in Inventory.tsx
     const newItem = {
       name: 'Bottled Water', // translated name
-      itemType: 'Bottled Water',
+      itemType: template.id, // Store template ID, not translated name
       categoryId: template.category,
       quantity: 0,
       unit: template.unit,
@@ -212,7 +212,7 @@ describe('Template to InventoryItem conversion', () => {
     // Simulate what handleSelectTemplate does in Inventory.tsx
     const newItem = {
       name: 'Canned Soup',
-      itemType: 'Canned Soup',
+      itemType: template.id, // Store template ID, not translated name
       categoryId: template.category,
       quantity: 0,
       unit: template.unit,

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -178,7 +178,7 @@ export function Inventory({
 
       const newItem: Omit<InventoryItem, 'id' | 'createdAt' | 'updatedAt'> = {
         name: templateName,
-        itemType: templateName, // Set the template type
+        itemType: template.id, // Store template ID for i18n lookup
         categoryId: template.category,
         quantity: 0,
         unit: template.unit,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,7 +73,7 @@ export interface Category {
 export interface InventoryItem {
   id: string;
   name: string;
-  itemType?: string; // Template type (e.g., "Canned Tuna"), read-only from template
+  itemType?: string; // Template ID (e.g., "canned-fish"), used for i18n lookup, read-only from template
   categoryId: string;
   quantity: number;
   unit: Unit;

--- a/src/utils/dashboard/categoryStatus.ts
+++ b/src/utils/dashboard/categoryStatus.ts
@@ -140,19 +140,15 @@ export function calculateCategoryShortages(
 
     recommendedQty = Math.ceil(recommendedQty);
 
-    // Match items by: productTemplateId, itemType (kebab-case comparison), or name
-    const recItemIdNormalized = recItem.id.toLowerCase();
+    // Match items by: productTemplateId, itemType (direct ID match), or name (normalized)
+    const recItemId = recItem.id;
+    const recItemIdNormalized = recItemId.toLowerCase();
     const matchingItems = categoryItems.filter((item) => {
       // Direct template ID match
-      if (item.productTemplateId === recItem.id) return true;
-      // Match itemType by normalizing to kebab-case (e.g., "Bottled Water" -> "bottled-water")
-      if (item.itemType) {
-        const itemTypeNormalized = item.itemType
-          .toLowerCase()
-          .replace(/\s+/g, '-');
-        if (itemTypeNormalized === recItemIdNormalized) return true;
-      }
-      // Match name by normalizing to kebab-case
+      if (item.productTemplateId === recItemId) return true;
+      // itemType is now stored as template ID directly
+      if (item.itemType === recItemId) return true;
+      // Match name by normalizing to kebab-case (for legacy/manual items)
       const nameNormalized = item.name.toLowerCase().replace(/\s+/g, '-');
       if (nameNormalized === recItemIdNormalized) return true;
       return false;

--- a/src/utils/test/factories.ts
+++ b/src/utils/test/factories.ts
@@ -57,7 +57,7 @@ export function createMockInventoryItem(
   return {
     id: 'test-item-1',
     name: 'Test Item',
-    itemType: 'Test Item',
+    itemType: 'test-item', // Template ID (kebab-case)
     categoryId: 'food',
     quantity: 10,
     unit: 'pieces',


### PR DESCRIPTION
## Summary

- Change `itemType` to store template ID (e.g., `"canned-soup"`) instead of translated display name (e.g., `"Canned Soup"`)
- This makes the data language-independent and enables proper i18n lookup
- Simplify matching logic in `categoryStatus.ts` since itemType is now the ID directly

## Test plan

- [x] All 508 tests pass
- [x] Build succeeds
- [ ] Verify item type displays correctly in ItemForm when editing items
- [ ] Verify existing items with old format still match correctly (via name normalization fallback)