### PR TITLE
fix: clear lang URL parameter after reading on initial load

### DIFF
--- a/src/components/common/LanguageSwitcher.tsx
+++ b/src/components/common/LanguageSwitcher.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '../../hooks/useSettings';
-import { setLanguageInUrl } from '../../utils/urlLanguage';
 
 export function LanguageSwitcher() {
   const { i18n } = useTranslation();
@@ -11,7 +10,6 @@ export function LanguageSwitcher() {
   ) => {
     const newLanguage = event.target.value as 'en' | 'fi';
     updateSettings({ language: newLanguage });
-    setLanguageInUrl(newLanguage);
     i18n.changeLanguage(newLanguage).catch((error) => {
       console.error('Failed to change language:', error);
     });

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -6,7 +6,7 @@ import {
   createDefaultAppData,
 } from '../utils/storage/localStorage';
 import { SettingsContext } from './SettingsContext';
-import { getLanguageFromUrl, setLanguageInUrl } from '../utils/urlLanguage';
+import { getLanguageFromUrl, clearLanguageFromUrl } from '../utils/urlLanguage';
 
 const DEFAULT_SETTINGS: UserSettings = {
   language: 'en',
@@ -33,11 +33,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     return storedSettings;
   });
 
-  // Sync URL with language on initial load
+  // Clear lang param from URL after reading it on initial load
   useEffect(() => {
-    setLanguageInUrl(settings.language);
+    clearLanguageFromUrl();
     // Only run once on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Save to localStorage on change

--- a/src/utils/urlLanguage.ts
+++ b/src/utils/urlLanguage.ts
@@ -40,14 +40,15 @@ export function getLanguageFromUrl(): SupportedLanguage | null {
 }
 
 /**
- * Updates the URL with the specified language parameter.
+ * Removes the lang parameter from the URL.
  * Uses replaceState to avoid adding to browser history.
- * @param language The language code to set in the URL.
  */
-export function setLanguageInUrl(language: SupportedLanguage): void {
+export function clearLanguageFromUrl(): void {
   const url = new URL(window.location.href);
-  url.searchParams.set('lang', language);
-  window.history.replaceState({}, '', url.toString());
+  if (url.searchParams.has('lang')) {
+    url.searchParams.delete('lang');
+    window.history.replaceState({}, '', url.toString());
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Clear the `lang` URL parameter after reading it on initial load instead of keeping it in the URL
- Remove unused `setLanguageInUrl` function
- Keep URLs clean while still supporting language switching via `?lang=en` or `?lang=fi` parameter

## Test plan
- [ ] Visit `https://ttu.github.io/emergency-supply-tracker/?lang=fi` and verify URL is cleared to `https://ttu.github.io/emergency-supply-tracker/` after load
- [ ] Verify Finnish language is applied and persisted
- [ ] Change language via UI and verify URL remains clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified language preference handling to no longer persist the language parameter in the URL. Language selection is now managed exclusively through application settings and internationalization (i18n) mechanisms. The URL language parameter is cleared after initial language detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->