### PR TITLE
feat: show water breakdown in water-beverages status

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -257,7 +257,10 @@
       "missing": "Need {{count}} {{unit}} {{item}}",
       "missingMultiple": "Need {{count}} {{unit}} {{item}} +{{more}} more",
       "kcal": "kcal",
-      "recommendedCalories": "Recommended {{count}} kcal more"
+      "recommendedCalories": "Recommended {{count}} kcal more",
+      "waterForPeople": "Water for people",
+      "waterForPreparation": "Water for preparation",
+      "totalWater": "Total required"
     }
   },
   "inventory": {

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -257,7 +257,10 @@
       "missing": "Tarvitaan {{count}} {{unit}} {{item}}",
       "missingMultiple": "Tarvitaan {{count}} {{unit}} {{item}} +{{more}} muuta",
       "kcal": "kcal",
-      "recommendedCalories": "Suositeltu {{count}} kcal lisää"
+      "recommendedCalories": "Suositeltu {{count}} kcal lisää",
+      "waterForPeople": "Vesi ihmisille",
+      "waterForPreparation": "Vesi valmistukseen",
+      "totalWater": "Yhteensä tarvitaan"
     }
   },
   "inventory": {

--- a/src/components/inventory/CategoryStatusSummary.module.css
+++ b/src/components/inventory/CategoryStatusSummary.module.css
@@ -181,6 +181,32 @@
   font-weight: var(--font-weight-medium);
 }
 
+.waterBreakdown {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background-color: var(--color-background-secondary);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.waterBreakdownItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--font-size-sm);
+}
+
+.waterBreakdownLabel {
+  color: var(--color-text-secondary);
+}
+
+.waterBreakdownValue {
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+}
+
 /* Mobile responsiveness */
 @media (max-width: 640px) {
   .summary {

--- a/src/components/inventory/CategoryStatusSummary.tsx
+++ b/src/components/inventory/CategoryStatusSummary.tsx
@@ -26,6 +26,9 @@ export interface CategoryStatusSummaryProps {
   totalActualCalories?: number;
   totalNeededCalories?: number;
   missingCalories?: number;
+  // Water breakdown for water-beverages category
+  drinkingWaterNeeded?: number;
+  preparationWaterNeeded?: number;
   // Action handlers for recommended items
   onAddToInventory?: (itemId: string) => void;
   onDisableRecommended?: (itemId: string) => void;
@@ -42,6 +45,8 @@ export const CategoryStatusSummary = ({
   totalActualCalories,
   totalNeededCalories,
   missingCalories,
+  drinkingWaterNeeded,
+  preparationWaterNeeded,
   onAddToInventory,
   onDisableRecommended,
 }: CategoryStatusSummaryProps) => {
@@ -49,6 +54,7 @@ export const CategoryStatusSummary = ({
 
   const categoryName = t(categoryId, { ns: 'categories' });
   const isFoodCategory = categoryId === 'food';
+  const isWaterCategory = categoryId === 'water-beverages';
 
   // Format progress text - calories for food, units for others
   const getProgressText = (): string => {
@@ -167,6 +173,38 @@ export const CategoryStatusSummary = ({
             {t('dashboard.category.recommendedCalories', {
               count: Math.round(missingCalories),
             })}
+          </div>
+        )}
+        {isWaterCategory && drinkingWaterNeeded !== undefined && (
+          <div className={styles.waterBreakdown}>
+            <div className={styles.waterBreakdownItem}>
+              <span className={styles.waterBreakdownLabel}>
+                {t('dashboard.category.waterForPeople')}:
+              </span>
+              <span className={styles.waterBreakdownValue}>
+                {Math.round(drinkingWaterNeeded)} {t('liters', { ns: 'units' })}
+              </span>
+            </div>
+            {preparationWaterNeeded !== undefined &&
+              preparationWaterNeeded > 0 && (
+                <div className={styles.waterBreakdownItem}>
+                  <span className={styles.waterBreakdownLabel}>
+                    {t('dashboard.category.waterForPreparation')}:
+                  </span>
+                  <span className={styles.waterBreakdownValue}>
+                    {Math.round(preparationWaterNeeded)}{' '}
+                    {t('liters', { ns: 'units' })}
+                  </span>
+                </div>
+              )}
+            <div className={styles.waterBreakdownItem}>
+              <span className={styles.waterBreakdownLabel}>
+                {t('dashboard.category.totalWater')}:
+              </span>
+              <span className={styles.waterBreakdownValue}>
+                {Math.round(totalNeeded)} {t('liters', { ns: 'units' })}
+              </span>
+            </div>
           </div>
         )}
       </div>

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -322,6 +322,8 @@ export function Inventory({
             totalActualCalories={categoryStatus.totalActualCalories}
             totalNeededCalories={categoryStatus.totalNeededCalories}
             missingCalories={categoryStatus.missingCalories}
+            drinkingWaterNeeded={categoryStatus.drinkingWaterNeeded}
+            preparationWaterNeeded={categoryStatus.preparationWaterNeeded}
             onAddToInventory={handleAddRecommendedToInventory}
             onDisableRecommended={handleDisableRecommendedItem}
           />

--- a/src/utils/dashboard/categoryStatus.test.ts
+++ b/src/utils/dashboard/categoryStatus.test.ts
@@ -380,7 +380,7 @@ describe('calculateCategoryShortages', () => {
       );
       expect(waterShortage).toBeDefined();
       expect(waterShortage!.needed).toBe(18); // Just base water requirement
-      expect(result.preparationWaterNeeded).toBeUndefined();
+      expect(result.preparationWaterNeeded).toBe(0); // Now always defined for water-beverages category
     });
   });
 

--- a/src/utils/dashboard/categoryStatus.ts
+++ b/src/utils/dashboard/categoryStatus.ts
@@ -58,7 +58,8 @@ export interface CategoryStatusSummary {
   totalActualCalories?: number;
   totalNeededCalories?: number;
   missingCalories?: number;
-  // Water for food preparation (for water-beverages category)
+  // Water breakdown for water-beverages category
+  drinkingWaterNeeded?: number;
   preparationWaterNeeded?: number;
 }
 
@@ -103,6 +104,7 @@ export function calculateCategoryShortages(
   totalActualCalories?: number;
   totalNeededCalories?: number;
   missingCalories?: number;
+  drinkingWaterNeeded?: number;
   preparationWaterNeeded?: number;
 } {
   const childrenMultiplier =
@@ -152,6 +154,9 @@ export function calculateCategoryShortages(
       dailyCalories * peopleMultiplier * household.supplyDurationDays;
   }
 
+  // Track drinking water separately for water-beverages category
+  let drinkingWaterNeeded = 0;
+
   // Track units to find the most common one and detect mixed units
   const unitCounts = new Map<Unit, number>();
   const uniqueUnits = new Set<Unit>();
@@ -168,6 +173,11 @@ export function calculateCategoryShortages(
 
     if (recItem.scaleWithDays) {
       recommendedQty *= household.supplyDurationDays;
+    }
+
+    // Track drinking water separately for water-beverages category
+    if (isWaterCategory && recItem.id === 'bottled-water') {
+      drinkingWaterNeeded = recommendedQty;
     }
 
     // Add water needed for food preparation to bottled-water recommendation
@@ -276,13 +286,14 @@ export function calculateCategoryShortages(
     };
   }
 
-  // Return with preparation water data for water-beverages category
-  if (isWaterCategory && preparationWaterNeeded > 0) {
+  // Return with water breakdown data for water-beverages category
+  if (isWaterCategory) {
     return {
       shortages,
       totalActual,
       totalNeeded,
       primaryUnit,
+      drinkingWaterNeeded,
       preparationWaterNeeded,
     };
   }
@@ -369,7 +380,8 @@ export function calculateCategoryStatus(
     totalActualCalories: shortageInfo.totalActualCalories,
     totalNeededCalories: shortageInfo.totalNeededCalories,
     missingCalories: shortageInfo.missingCalories,
-    // Preparation water for water-beverages category
+    // Water breakdown for water-beverages category
+    drinkingWaterNeeded: shortageInfo.drinkingWaterNeeded,
     preparationWaterNeeded: shortageInfo.preparationWaterNeeded,
   };
 }
@@ -412,7 +424,8 @@ export interface CategoryDisplayStatus {
   totalActualCalories?: number;
   totalNeededCalories?: number;
   missingCalories?: number;
-  // Water for food preparation (for water-beverages category)
+  // Water breakdown for water-beverages category
+  drinkingWaterNeeded?: number;
   preparationWaterNeeded?: number;
 }
 
@@ -466,6 +479,7 @@ export function getCategoryDisplayStatus(
     totalActualCalories: shortageInfo.totalActualCalories,
     totalNeededCalories: shortageInfo.totalNeededCalories,
     missingCalories: shortageInfo.missingCalories,
+    drinkingWaterNeeded: shortageInfo.drinkingWaterNeeded,
     preparationWaterNeeded: shortageInfo.preparationWaterNeeded,
   };
 }


### PR DESCRIPTION
## Summary
This PR adds a breakdown display for water requirements in the water-beverages category status, showing:
- Water for people (drinking water requirement)
- Water for preparation (for food preparation)
- Total required (sum of both)

## Changes
- Updated `calculateCategoryShortages` to calculate `drinkingWaterNeeded` separately
- Updated `CategoryStatusSummary` component to display water breakdown for water-beverages category
- Added translation keys for water breakdown labels (English and Finnish)
- Added CSS styles for the water breakdown display
- Updated test expectations to match new behavior

## Testing
- All existing tests pass
- Updated test to expect `preparationWaterNeeded` to be 0 instead of undefined for water-beverages category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Water category now displays a detailed breakdown showing drinking water needed, preparation water, and total water requirements in liters.

* **Localization**
  * Added new translation keys for water-related metrics in English and Finnish language files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->