### PR TITLE
fix: show backup reminder 1 month after changes, not after last backup

### DIFF
--- a/src/utils/dashboard/backupReminder.test.ts
+++ b/src/utils/dashboard/backupReminder.test.ts
@@ -35,20 +35,20 @@ describe('shouldShowBackupReminder', () => {
     expect(shouldShowBackupReminder(appData)).toBe(true);
   });
 
-  it('should return false when backup was less than 30 days ago', () => {
+  it('should return false when changes were made less than 30 days ago', () => {
     const appData = createMockAppData({
       items: [createMockInventoryItem()],
       lastBackupDate: '2025-02-01T12:00:00.000Z', // 14 days ago
-      lastModified: '2025-02-10T12:00:00.000Z', // Modified after backup
+      lastModified: '2025-02-10T12:00:00.000Z', // Modified 5 days ago (after backup)
     });
     expect(shouldShowBackupReminder(appData)).toBe(false);
   });
 
-  it('should return true when backup was more than 30 days ago and data was modified', () => {
+  it('should return true when changes were made more than 30 days ago', () => {
     const appData = createMockAppData({
       items: [createMockInventoryItem()],
       lastBackupDate: '2025-01-01T12:00:00.000Z', // 45 days ago
-      lastModified: '2025-02-10T12:00:00.000Z', // Modified after backup
+      lastModified: '2025-01-10T12:00:00.000Z', // Modified 36 days ago (after backup)
     });
     expect(shouldShowBackupReminder(appData)).toBe(true);
   });
@@ -62,11 +62,20 @@ describe('shouldShowBackupReminder', () => {
     expect(shouldShowBackupReminder(appData)).toBe(false);
   });
 
+  it('should return false when changes were made but less than 30 days ago', () => {
+    const appData = createMockAppData({
+      items: [createMockInventoryItem()],
+      lastBackupDate: '2025-01-01T12:00:00.000Z', // 45 days ago
+      lastModified: '2025-02-10T12:00:00.000Z', // Modified 5 days ago (after backup)
+    });
+    expect(shouldShowBackupReminder(appData)).toBe(false);
+  });
+
   it('should return false when reminder was dismissed for current month', () => {
     const appData = createMockAppData({
       items: [createMockInventoryItem()],
       lastBackupDate: '2025-01-01T12:00:00.000Z', // 45 days ago
-      lastModified: '2025-02-10T12:00:00.000Z', // Modified after backup
+      lastModified: '2025-01-10T12:00:00.000Z', // Modified 36 days ago (after backup)
       backupReminderDismissedUntil: '2025-03-01T00:00:00.000Z', // Dismissed until next month
     });
     expect(shouldShowBackupReminder(appData)).toBe(false);
@@ -76,26 +85,26 @@ describe('shouldShowBackupReminder', () => {
     const appData = createMockAppData({
       items: [createMockInventoryItem()],
       lastBackupDate: '2025-01-01T12:00:00.000Z', // 45 days ago
-      lastModified: '2025-02-10T12:00:00.000Z', // Modified after backup
+      lastModified: '2025-01-10T12:00:00.000Z', // Modified 36 days ago (after backup)
       backupReminderDismissedUntil: '2025-02-01T00:00:00.000Z', // Dismissed until Feb 1, now is Feb 15
     });
     expect(shouldShowBackupReminder(appData)).toBe(true);
   });
 
-  it('should return true at exactly 30 days since backup', () => {
+  it('should return true at exactly 30 days since last modification', () => {
     const appData = createMockAppData({
       items: [createMockInventoryItem()],
-      lastBackupDate: '2025-01-16T12:00:00.000Z', // Exactly 30 days ago
-      lastModified: '2025-02-10T12:00:00.000Z', // Modified after backup
+      lastBackupDate: '2025-01-01T12:00:00.000Z', // 45 days ago
+      lastModified: '2025-01-16T12:00:00.000Z', // Modified exactly 30 days ago (after backup)
     });
     expect(shouldShowBackupReminder(appData)).toBe(true);
   });
 
-  it('should return false at 29 days since backup', () => {
+  it('should return false at 29 days since last modification', () => {
     const appData = createMockAppData({
       items: [createMockInventoryItem()],
-      lastBackupDate: '2025-01-17T12:00:00.000Z', // 29 days ago
-      lastModified: '2025-02-10T12:00:00.000Z', // Modified after backup
+      lastBackupDate: '2025-01-01T12:00:00.000Z', // 45 days ago
+      lastModified: '2025-01-17T12:00:00.000Z', // Modified 29 days ago (after backup)
     });
     expect(shouldShowBackupReminder(appData)).toBe(false);
   });

--- a/src/utils/dashboard/backupReminder.ts
+++ b/src/utils/dashboard/backupReminder.ts
@@ -5,8 +5,9 @@ import { BACKUP_REMINDER_DAYS_THRESHOLD, MS_PER_DAY } from '../constants';
 /**
  * Check if the backup reminder should be shown.
  * Returns true if:
- * 1. Last backup was more than 30 days ago (or never)
- * 2. Data has been modified since the last backup
+ * 1. Never backed up and there are items, OR
+ * 2. Data has been modified since the last backup AND
+ *    30 days have passed since the last modification
  * 3. The dismissal period hasn't expired
  */
 export function shouldShowBackupReminder(appData: AppData | null): boolean {
@@ -35,12 +36,12 @@ export function shouldShowBackupReminder(appData: AppData | null): boolean {
     return false;
   }
 
-  // Check if more than BACKUP_REMINDER_DAYS_THRESHOLD days have passed since last backup
-  const daysSinceBackup = Math.floor(
-    (now.getTime() - lastBackup.getTime()) / MS_PER_DAY,
+  // Check if more than BACKUP_REMINDER_DAYS_THRESHOLD days have passed since last modification
+  const daysSinceModification = Math.floor(
+    (now.getTime() - lastModified.getTime()) / MS_PER_DAY,
   );
 
-  return daysSinceBackup >= BACKUP_REMINDER_DAYS_THRESHOLD;
+  return daysSinceModification >= BACKUP_REMINDER_DAYS_THRESHOLD;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes the backup reminder logic to show the alert 1 month after data modifications were made (based on `lastModified`), rather than 1 month after the last backup.

## Changes

- Updated `shouldShowBackupReminder` to check if 30 days have passed since `lastModified` instead of since `lastBackupDate`
- Updated all related tests to reflect the new behavior
- The alert now appears when users have unsaved changes that are a month old, regardless of when they last backed up

## Testing

All existing tests pass, including the updated backup reminder tests that verify the new timing logic.