### PR TITLE
fix: remove duplicate providers from App.tsx

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 import { createMockAppData } from './utils/test/factories';
+import { SettingsProvider } from './contexts/SettingsProvider';
+import { HouseholdProvider } from './contexts/HouseholdProvider';
+import { InventoryProvider } from './contexts/InventoryProvider';
+import { ThemeApplier } from './components/ThemeApplier';
+import { ErrorBoundary } from './components/common/ErrorBoundary';
 
 // Mock i18next
 jest.mock('react-i18next', () => ({
@@ -32,6 +37,23 @@ const setupCompletedOnboarding = () => {
   localStorage.setItem('emergencySupplyTracker', JSON.stringify(appData));
 };
 
+// Helper to render App with all required providers
+const renderApp = () => {
+  return render(
+    <ErrorBoundary>
+      <SettingsProvider>
+        <ThemeApplier>
+          <HouseholdProvider>
+            <InventoryProvider>
+              <App />
+            </InventoryProvider>
+          </HouseholdProvider>
+        </ThemeApplier>
+      </SettingsProvider>
+    </ErrorBoundary>,
+  );
+};
+
 describe('App', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -39,7 +61,7 @@ describe('App', () => {
   });
 
   it('renders navigation', () => {
-    render(<App />);
+    renderApp();
 
     expect(screen.getByText('navigation.dashboard')).toBeInTheDocument();
     expect(screen.getByText('navigation.inventory')).toBeInTheDocument();
@@ -47,14 +69,14 @@ describe('App', () => {
   });
 
   it('renders dashboard by default', () => {
-    render(<App />);
+    renderApp();
 
     // Dashboard should show quick actions
     expect(screen.getByText('dashboard.quickActions')).toBeInTheDocument();
   });
 
   it('navigates to inventory when clicking inventory button', () => {
-    render(<App />);
+    renderApp();
 
     const inventoryButton = screen.getByText('navigation.inventory');
     fireEvent.click(inventoryButton);
@@ -68,7 +90,7 @@ describe('App', () => {
   });
 
   it('navigates to settings when clicking settings button', () => {
-    render(<App />);
+    renderApp();
 
     const settingsButton = screen.getByText('navigation.settings');
     fireEvent.click(settingsButton);
@@ -82,7 +104,7 @@ describe('App', () => {
   });
 
   it('navigates between pages', () => {
-    render(<App />);
+    renderApp();
 
     // Start on dashboard
     expect(screen.getByText('dashboard.quickActions')).toBeInTheDocument();
@@ -101,7 +123,7 @@ describe('App', () => {
   });
 
   it('navigates to help page', () => {
-    render(<App />);
+    renderApp();
 
     const helpButton = screen.getByText('navigation.help');
     fireEvent.click(helpButton);
@@ -124,14 +146,14 @@ describe('App', () => {
     });
     localStorage.setItem('emergencySupplyTracker', JSON.stringify(appData));
 
-    render(<App />);
+    renderApp();
 
     // Should show onboarding content (welcome screen or first step)
     expect(screen.getByText('app.title')).toBeInTheDocument();
   });
 
   it('has skip link for accessibility', () => {
-    render(<App />);
+    renderApp();
 
     const skipLink = screen.getByText('accessibility.skipToContent');
     expect(skipLink).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { trackAppLaunch } from './utils/analytics';
-import { SettingsProvider } from './contexts/SettingsProvider';
-import { HouseholdProvider } from './contexts/HouseholdProvider';
-import { InventoryProvider } from './contexts/InventoryProvider';
-import { ThemeApplier } from './components/ThemeApplier';
-import { ErrorBoundary } from './components/common/ErrorBoundary';
 import { Navigation, PageType } from './components/common/Navigation';
 import { Dashboard } from './pages/Dashboard';
 import { Inventory } from './pages/Inventory';
@@ -98,19 +93,7 @@ function App() {
     trackAppLaunch();
   }, []);
 
-  return (
-    <ErrorBoundary>
-      <SettingsProvider>
-        <ThemeApplier>
-          <HouseholdProvider>
-            <InventoryProvider>
-              <AppContent />
-            </InventoryProvider>
-          </HouseholdProvider>
-        </ThemeApplier>
-      </SettingsProvider>
-    </ErrorBoundary>
-  );
+  return <AppContent />;
 }
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import App from './App.tsx';
 import { InventoryProvider } from './contexts/InventoryProvider';
 import { HouseholdProvider } from './contexts/HouseholdProvider';
 import { SettingsProvider } from './contexts/SettingsProvider';
+import { ErrorBoundary } from './components/common/ErrorBoundary';
+import { ThemeApplier } from './components/ThemeApplier';
 import * as serviceWorker from './utils/serviceWorker';
 
 createRoot(document.getElementById('root')!).render(
@@ -15,13 +17,17 @@ createRoot(document.getElementById('root')!).render(
         <div style={{ padding: '2rem', textAlign: 'center' }}>Loading...</div>
       }
     >
-      <SettingsProvider>
-        <HouseholdProvider>
-          <InventoryProvider>
-            <App />
-          </InventoryProvider>
-        </HouseholdProvider>
-      </SettingsProvider>
+      <ErrorBoundary>
+        <SettingsProvider>
+          <ThemeApplier>
+            <HouseholdProvider>
+              <InventoryProvider>
+                <App />
+              </InventoryProvider>
+            </HouseholdProvider>
+          </ThemeApplier>
+        </SettingsProvider>
+      </ErrorBoundary>
     </Suspense>
   </StrictMode>,
 );


### PR DESCRIPTION
## Problem

Duplicate providers (SettingsProvider, HouseholdProvider, InventoryProvider) were defined in both `main.tsx` and `App.tsx`, creating nested contexts. This caused components to read from the inner providers while the outer providers in `main.tsx` were unused, potentially leading to state synchronization issues.

## Solution

- Removed duplicate providers from `App.tsx`
- Moved `ErrorBoundary` and `ThemeApplier` to `main.tsx` to maintain proper provider hierarchy
- All providers are now defined once in `main.tsx` as the single source of truth
- Updated `App.test.tsx` to wrap `App` with providers for testing

## Provider Hierarchy (now in main.tsx)

```
ErrorBoundary
  └─ SettingsProvider
      └─ ThemeApplier (needs SettingsProvider)
          └─ HouseholdProvider
              └─ InventoryProvider
                  └─ App
```

## Testing

- All existing tests pass (797 tests)
- TypeScript compilation successful
- Build successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test setup to use a new helper function that properly wraps the App component with all required providers before testing.

* **Refactor**
  * Reorganized how providers and error handling are initialized at the application root level for improved code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->