### PR TITLE
test: suppress console error output in error tests

### DIFF
--- a/src/components/settings/ImportRecommendationsButton.test.tsx
+++ b/src/components/settings/ImportRecommendationsButton.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, jest } from '@jest/globals';
 import { ImportRecommendationsButton } from './ImportRecommendationsButton';
 
 // Mock i18next
@@ -41,14 +42,22 @@ describe('ImportRecommendationsButton', () => {
     ],
   };
 
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Suppress console.error output from expected error handling in tests
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockImportRecommendedItems.mockReturnValue({
       valid: true,
       errors: [],
       warnings: [],
     });
     mockParseRecommendedItemsFile.mockReturnValue(validFile);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('should render import button', () => {

--- a/src/components/settings/RecommendationsStatus.test.tsx
+++ b/src/components/settings/RecommendationsStatus.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { beforeEach, afterEach, jest } from '@jest/globals';
 import { RecommendationsStatus } from './RecommendationsStatus';
 
 // Mock i18next
@@ -22,8 +23,16 @@ jest.mock('@/shared/hooks/useRecommendedItems', () => ({
 }));
 
 describe('RecommendationsStatus', () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Suppress console.error output from expected error handling in tests
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('should show default status when using built-in recommendations', () => {

--- a/src/shared/utils/errorLogger/export.test.ts
+++ b/src/shared/utils/errorLogger/export.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
 import {
   generateDebugExport,
   downloadDebugExport,
@@ -8,8 +15,19 @@ import {
 import { info, error } from './logger';
 
 describe('errorLogger export', () => {
+  let consoleInfoSpy: jest.SpiedFunction<typeof console.info>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
   beforeEach(() => {
     localStorage.clear();
+    // Suppress console output from logger functions during tests
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 
   describe('generateDebugExport', () => {

--- a/src/shared/utils/storage/localStorage.test.ts
+++ b/src/shared/utils/storage/localStorage.test.ts
@@ -188,7 +188,12 @@ describe('localStorage utilities', () => {
 
     it('throws error for invalid JSON', () => {
       const invalidJson = '{ invalid json }';
+      // Suppress console.error for this expected error
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       expect(() => importFromJSON(invalidJson)).toThrow();
+      consoleSpy.mockRestore();
     });
 
     it('sets neverExpires to true when expirationDate is null', () => {


### PR DESCRIPTION
## Summary

This PR suppresses expected console output in test files to prevent cluttering test output while maintaining full test coverage.

## Changes

- Suppress `console.error` in `localStorage.test.ts` for invalid JSON test
- Suppress `console.info` and `console.error` in `errorLogger export.test.ts`
- Suppress `console.error` in `ImportRecommendationsButton.test.tsx`
- Suppress `console.error` in `ImportButton.test.tsx`
- Suppress `console.error` in `RecommendationsStatus.test.tsx`

## Why

These tests intentionally trigger error scenarios to verify error handling. The components correctly log these errors to the console for debugging purposes, but in tests we want to suppress this output since:
1. The errors are expected and intentional
2. They clutter the test output making it harder to spot real issues
3. The tests still verify error handling behavior correctly

## Testing

All tests pass (879 tests, 73 test suites). No functionality changed, only test output cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment by suppressing expected console output during test execution, reducing noise in test logs across multiple test files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->