### PR TITLE
refactor: remove backwards compatibility and legacy migration code

### DIFF
--- a/src/features/dashboard/utils/categoryStatus.ts
+++ b/src/features/dashboard/utils/categoryStatus.ts
@@ -197,7 +197,7 @@ export function calculateCategoryShortages(
       if (item.productTemplateId === recItemId) return true;
       // itemType is now stored as template ID directly
       if (item.itemType === recItemId) return true;
-      // Match name by normalizing to kebab-case (for legacy/manual items)
+      // Match name by normalizing to kebab-case (for manually created items)
       const nameNormalized = item.name.toLowerCase().replace(/\s+/g, '-');
       if (nameNormalized === recItemIdNormalized) return true;
       return false;

--- a/src/features/settings/provider.tsx
+++ b/src/features/settings/provider.tsx
@@ -33,7 +33,7 @@ const DEFAULT_SETTINGS: UserSettings = {
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [settings, setSettings] = useState<UserSettings>(() => {
     const data = getAppData();
-    // Merge stored settings with defaults to handle new fields (migration)
+    // Merge stored settings with defaults to handle new fields
     const storedSettings = { ...DEFAULT_SETTINGS, ...data?.settings };
 
     // If URL has a lang parameter, use it to override stored language

--- a/src/shared/contexts/index.ts
+++ b/src/shared/contexts/index.ts
@@ -1,2 +1,2 @@
-// All contexts have been migrated to feature slices
+// All contexts have been moved to feature slices
 // See @/features/settings, @/features/household, @/features/inventory, @/features/templates

--- a/src/shared/utils/calculations/household.ts
+++ b/src/shared/utils/calculations/household.ts
@@ -1,4 +1,4 @@
-// Re-export from feature slice for backward compatibility
+// Re-export from feature slice
 export {
   calculateHouseholdMultiplier,
   calculateRecommendedQuantity,

--- a/src/shared/utils/storage/localStorage.ts
+++ b/src/shared/utils/storage/localStorage.ts
@@ -10,202 +10,6 @@ import { APP_VERSION } from '@/shared/utils/version';
 const STORAGE_KEY = 'emergencySupplyTracker';
 
 /**
- * Map of legacy translated item type names to canonical template IDs.
- * Used to migrate old data where itemType stored translated names (e.g., "Bottled Water")
- * instead of template IDs (e.g., "bottled-water").
- *
- * Includes both English and Finnish translations.
- */
-const LEGACY_ITEM_TYPE_MAP: Record<string, string> = {
-  // English translations
-  'bottled water': 'bottled-water',
-  'long-life milk': 'long-life-milk',
-  'long-life juice': 'long-life-juice',
-  'canned soup': 'canned-soup',
-  'canned vegetables': 'canned-vegetables',
-  'canned beans': 'canned-beans',
-  'canned fish': 'canned-fish',
-  'canned meat': 'canned-meat',
-  pasta: 'pasta',
-  rice: 'rice',
-  oats: 'oats',
-  oatmeal: 'oatmeal',
-  crackers: 'crackers',
-  'energy bars': 'energy-bars',
-  'cookies or energy bars': 'cookies',
-  spreads: 'spreads',
-  'peanut butter or nut butter': 'peanut-butter',
-  'jam or honey': 'jam',
-  'dried fruits': 'dried-fruits',
-  nuts: 'nuts',
-  'salt and sugar': 'salt-sugar',
-  'coffee and tea': 'coffee-tea',
-  'frozen vegetables': 'frozen-vegetables',
-  'frozen meat': 'frozen-meat',
-  'frozen meals': 'frozen-meals',
-  'frozen bread': 'frozen-bread',
-  'instant coffee or tea': 'instant-coffee',
-  sugar: 'sugar',
-  'camping stove or grill': 'camping-stove',
-  'stove fuel (gas canisters, charcoal)': 'stove-fuel',
-  matches: 'matches',
-  lighter: 'lighter',
-  candles: 'candles',
-  'fire starter or tinder': 'fire-starter',
-  flashlight: 'flashlight',
-  headlamp: 'headlamp',
-  'batteries aa': 'batteries-aa',
-  'batteries aaa': 'batteries-aaa',
-  'batteries d': 'batteries-d',
-  '9v batteries': 'batteries-9v',
-  'power bank': 'power-bank',
-  'charging cables (usb-c, lightning, micro-usb)': 'charging-cables',
-  'solar charger or hand crank charger': 'solar-charger',
-  'gasoline power generator': 'power-generator',
-  'gasoline for generator': 'generator-fuel',
-  'battery-powered radio': 'battery-radio',
-  'hand crank emergency radio': 'hand-crank-radio',
-  'first aid kit': 'first-aid-kit',
-  'prescription medications': 'prescription-meds',
-  'pain relievers (aspirin, ibuprofen)': 'pain-relievers',
-  'fever reducers': 'fever-reducers',
-  'bandages and gauze': 'bandages',
-  disinfectant: 'disinfectant',
-  'antiseptic (alcohol, iodine)': 'antiseptic',
-  thermometer: 'thermometer',
-  antihistamines: 'antihistamines',
-  'anti-diarrheal medication': 'diarrhea-meds',
-  'tweezers and scissors': 'tweezers-scissors',
-  'allergy medication': 'allergy-meds',
-  'rehydration salts': 'rehydration-salts',
-  'toilet paper': 'toilet-paper',
-  'wet wipes': 'wet-wipes',
-  'hand sanitizer': 'hand-sanitizer',
-  soap: 'soap',
-  toothbrush: 'toothbrush',
-  toothpaste: 'toothpaste',
-  'shampoo and conditioner': 'shampoo',
-  deodorant: 'deodorant',
-  'feminine hygiene products': 'feminine-hygiene',
-  'diapers (if applicable)': 'diapers',
-  'garbage bags': 'garbage-bags',
-  'paper towels': 'paper-towels',
-  'trash bags': 'trash-bags',
-  'bucket (with lid, for sanitation)': 'bucket',
-  'water container (collapsible or rigid)': 'water-container',
-  'water purification tablets or filter': 'water-purification',
-  'duct tape': 'duct-tape',
-  'multi-tool or swiss army knife': 'multi-tool',
-  'manual can opener': 'can-opener',
-  'plastic bags': 'plastic-bags',
-  'aluminum foil': 'aluminum-foil',
-  'plastic wrap': 'plastic-wrap',
-  rope: 'rope',
-  'plastic sheeting or tarp': 'plastic-sheeting',
-  'rope or cord': 'rope-cord',
-  whistle: 'whistle',
-  'emergency blanket (mylar)': 'emergency-blanket',
-  'work gloves': 'work-gloves',
-  'dust masks or n95 respirators': 'dust-masks',
-  'cash (small bills and coins)': 'cash',
-  'copies of important documents': 'document-copies',
-  'emergency contact list': 'contact-list',
-
-  // Finnish translations
-  pullovesi: 'bottled-water',
-  säilyvämaito: 'long-life-milk',
-  säilyvämehut: 'long-life-juice',
-  'säilykkeet - keitto': 'canned-soup',
-  'säilykkeet - vihannekset': 'canned-vegetables',
-  'säilykkeet - pavut': 'canned-beans',
-  'säilykkeet - kala': 'canned-fish',
-  'säilykkeet - liha': 'canned-meat',
-  riisi: 'rice',
-  kaura: 'oats',
-  kaurapuuro: 'oatmeal',
-  näkkileipä: 'crackers',
-  energiapatukat: 'energy-bars',
-  'keksit tai energiapatukat': 'cookies',
-  levitteet: 'spreads',
-  'maapähkinävoi tai pähkinävoi': 'peanut-butter',
-  'hillo tai hunaja': 'jam',
-  'kuivatut hedelmät': 'dried-fruits',
-  pähkinät: 'nuts',
-  'suola ja sokeri': 'salt-sugar',
-  'kahvi ja tee': 'coffee-tea',
-  pakastevihannekset: 'frozen-vegetables',
-  'pakastettu liha': 'frozen-meat',
-  pakasteateriat: 'frozen-meals',
-  'pakastettu leipä': 'frozen-bread',
-  'pikakahvi tai tee': 'instant-coffee',
-  sokeri: 'sugar',
-  'retkikeitin tai grilli': 'camping-stove',
-  'keitinpolttoaine (kaasupatruunat, puuhiilet)': 'stove-fuel',
-  tulitikut: 'matches',
-  sytytin: 'lighter',
-  kynttilät: 'candles',
-  'tulukset tai sytyke': 'fire-starter',
-  taskulamppu: 'flashlight',
-  otsalamppu: 'headlamp',
-  'paristot aa': 'batteries-aa',
-  'paristot aaa': 'batteries-aaa',
-  'paristot d': 'batteries-d',
-  '9v paristot': 'batteries-9v',
-  varavirtalähde: 'power-bank',
-  'latausjohdot (usb-c, lightning, micro-usb)': 'charging-cables',
-  'aurinkopaneeli tai kampikäyttöinen laturi': 'solar-charger',
-  bensiiniaggregaatti: 'power-generator',
-  'bensiini aggregaattiin': 'generator-fuel',
-  'paristokäyttöinen radio': 'battery-radio',
-  'kampikäyttöinen hätäradio': 'hand-crank-radio',
-  ensiapulaukku: 'first-aid-kit',
-  reseptilääkkeet: 'prescription-meds',
-  'kipulääkkeet (aspiriini, ibuprofeeni)': 'pain-relievers',
-  kuumelääkkeet: 'fever-reducers',
-  'siteet ja harsot': 'bandages',
-  desinfiointiaine: 'disinfectant',
-  'antiseptiset aineet (alkoholi, jodi)': 'antiseptic',
-  kuumemittari: 'thermometer',
-  antihistamiinit: 'antihistamines',
-  ripulilääke: 'diarrhea-meds',
-  'pinsetti ja sakset': 'tweezers-scissors',
-  allergialääke: 'allergy-meds',
-  nesteytyssuolat: 'rehydration-salts',
-  'wc-paperi': 'toilet-paper',
-  kosteuspyyhkeet: 'wet-wipes',
-  käsidesi: 'hand-sanitizer',
-  saippua: 'soap',
-  hammasharja: 'toothbrush',
-  hammastahna: 'toothpaste',
-  'shampoo ja hoitoaine': 'shampoo',
-  deodorantti: 'deodorant',
-  'naisten hygieniaturotteet': 'feminine-hygiene',
-  'vaipat (tarvittaessa)': 'diapers',
-  jätesäkit: 'garbage-bags',
-  talouspyyhkeet: 'paper-towels',
-  roskapussit: 'trash-bags',
-  'ämpäri (kannella, sanitaatioon)': 'bucket',
-  'vesisäiliö (kokoontaitettava tai jäykkä)': 'water-container',
-  'vedenpuhdistustabletit tai suodatin': 'water-purification',
-  ilmastointiteippi: 'duct-tape',
-  'monitoimityökalu tai linkkuveitsi': 'multi-tool',
-  'käsikäyttöinen purkinavaaja': 'can-opener',
-  muovipussit: 'plastic-bags',
-  alumiinifolio: 'aluminum-foil',
-  kelmukalvo: 'plastic-wrap',
-  köysi: 'rope',
-  'muovikalvo tai pressu': 'plastic-sheeting',
-  'köysi tai naru': 'rope-cord',
-  pilli: 'whistle',
-  'hätäpeite (mylar)': 'emergency-blanket',
-  työkäsineet: 'work-gloves',
-  'pölynaamari tai n95 hengityssuojain': 'dust-masks',
-  'käteinen (pienet setelit ja kolikot)': 'cash',
-  'kopiot tärkeistä asiakirjoista': 'document-copies',
-  'hätänumeroiden lista': 'contact-list',
-};
-
-/**
  * Checks if a value looks like a valid template ID (kebab-case).
  */
 function isTemplateId(value: string): boolean {
@@ -214,43 +18,24 @@ function isTemplateId(value: string): boolean {
 
 /**
  * Normalizes an itemType value to a canonical template ID.
- * Handles migration from legacy translated names to template IDs.
+ * If the itemType is already a valid template ID, returns it.
+ * Otherwise, returns CUSTOM_ITEM_TYPE.
  *
- * @param itemType - The current itemType value (may be translated name or template ID)
- * @param itemName - The item name (used as fallback for matching)
- * @returns The canonical template ID, or CUSTOM_ITEM_TYPE if no match found
+ * @param itemType - The current itemType value
+ * @returns The template ID if valid, or CUSTOM_ITEM_TYPE if not
  */
-function normalizeItemType(
-  itemType: string | undefined,
-  itemName: string,
-): string {
+function normalizeItemType(itemType: string | undefined): string {
   // If itemType is already a valid template ID, use it
   if (itemType && isTemplateId(itemType)) {
     return itemType;
   }
 
-  // Try to find a match in the legacy map using itemType
-  if (itemType) {
-    const normalizedItemType = itemType.toLowerCase().trim();
-    const mappedId = LEGACY_ITEM_TYPE_MAP[normalizedItemType];
-    if (mappedId) {
-      return mappedId;
-    }
-  }
-
-  // Try to find a match using item name as fallback
-  const normalizedName = itemName.toLowerCase().trim();
-  const mappedFromName = LEGACY_ITEM_TYPE_MAP[normalizedName];
-  if (mappedFromName) {
-    return mappedFromName;
-  }
-
-  // No match found - use custom item type
+  // Invalid or missing - use custom item type
   return CUSTOM_ITEM_TYPE;
 }
 
 /**
- * Normalizes inventory items by migrating legacy itemType values.
+ * Normalizes inventory items by ensuring itemType values are valid template IDs.
  */
 function normalizeItems(
   items: InventoryItem[] | undefined,
@@ -259,7 +44,7 @@ function normalizeItems(
 
   return items.map((item) => ({
     ...item,
-    itemType: normalizeItemType(item.itemType, item.name),
+    itemType: normalizeItemType(item.itemType),
   }));
 }
 
@@ -300,7 +85,7 @@ export function getAppData(): AppData | null {
     if (!json) return null;
     const data = JSON.parse(json) as AppData;
 
-    // Normalize items: migrate legacy itemType values to template IDs
+    // Normalize items: ensure itemType values are valid template IDs
     data.items = normalizeItems(data.items) ?? [];
 
     return data;
@@ -399,9 +184,9 @@ export function importFromJSON(json: string): AppData {
 
   // customRecommendedItems is optional - preserve if present, otherwise leave undefined
 
-  // Normalize items: migrate legacy itemType values and set neverExpires flag
+  // Normalize items: ensure itemType values are valid and set neverExpires flag
   if (data.items) {
-    // First normalize itemType values (migrate legacy translated names to template IDs)
+    // First normalize itemType values to ensure they're valid template IDs
     data.items = normalizeItems(data.items as InventoryItem[]);
 
     // Then handle neverExpires normalization

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -112,7 +112,7 @@
   --color-info-light: #60a5fa;
   --color-info-alpha: rgba(59, 130, 246, 0.1);
 
-  /* Legacy status colors for compatibility */
+  /* Status color aliases */
   --color-ok: var(--color-success);
   --color-critical: var(--color-error);
 
@@ -171,7 +171,7 @@
   --color-info-light: #93c5fd;
   --color-info-alpha: rgba(96, 165, 250, 0.08);
 
-  /* Legacy status colors for compatibility */
+  /* Status color aliases */
   --color-ok: var(--color-success);
   --color-critical: var(--color-error);
 


### PR DESCRIPTION
## Summary

Removes all backwards compatibility code since we haven't released to production yet.

## Changes

- **Removed LEGACY_ITEM_TYPE_MAP** (200+ lines) - Map that migrated legacy translated item type names to template IDs
- **Simplified normalizeItemType** - Now only validates template IDs, no migration logic
- **Removed legacy migration tests** - Tests for migrating English/Finnish translated names
- **Updated tests** - Now validate invalid itemType values are set to 'custom' instead of migrating
- **Removed backwards compatibility comments** - Updated comments throughout codebase
- **Updated CSS comments** - Changed "Legacy" to "Status color aliases" for clarity

## Impact

- Codebase now assumes all data is in current format
- Invalid or missing itemType values are set to 'custom' instead of being migrated
- Reduced code complexity and maintenance burden
- No functional changes for valid data

## Testing

- ✅ All tests pass (874 tests)
- ✅ Build succeeds
- ✅ Type checking passes
- ✅ Linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified legacy data handling by removing complex item type migration logic. Items without recognized types now default to custom items.

* **Chores**
  * Updated internal comments and documentation for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->