### PR TITLE
refactor: replace hardcoded category count with STANDARD_CATEGORIES.length

### DIFF
--- a/src/shared/utils/storage/localStorage.ts
+++ b/src/shared/utils/storage/localStorage.ts
@@ -8,6 +8,7 @@ import {
 import { CUSTOM_ITEM_TYPE } from '@/shared/utils/constants';
 import { APP_VERSION } from '@/shared/utils/version';
 import { UserSettingsFactory } from '@/features/settings/factories/UserSettingsFactory';
+import { STANDARD_CATEGORIES } from '@/features/categories/data';
 
 const STORAGE_KEY = 'emergencySupplyTracker';
 
@@ -153,8 +154,8 @@ export function exportToJSON(data: AppData): string {
       itemCount: data.items?.length ?? 0,
       categoryCount:
         (data.customCategories?.length ?? 0) +
-        // Standard categories are always available (9 standard categories)
-        9,
+        // Standard categories are always available
+        STANDARD_CATEGORIES.length,
     },
   };
   return JSON.stringify(exportData, null, 2);


### PR DESCRIPTION
## Summary
- Replace hardcoded `9` with `STANDARD_CATEGORIES.length` in `exportToJSON` function
- Improves maintainability - category count updates automatically when categories are added/removed

## Test plan
- [x] All unit tests pass (1013 tests)
- [x] Build succeeds
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed category count accuracy in data exports to dynamically reflect the actual number of available categories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->