### PR TITLE
feat: increase expiring soon alert threshold to 30 days

### DIFF
--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -89,9 +89,9 @@ export const MS_PER_DAY =
 export const EXPIRING_SOON_DAYS_THRESHOLD = 30;
 
 /**
- * Days threshold for generating "expiring soon" alerts (more urgent).
+ * Days threshold for generating "expiring soon" alerts.
  */
-export const EXPIRING_SOON_ALERT_DAYS = 7;
+export const EXPIRING_SOON_ALERT_DAYS = 30;
 
 // =============================================================================
 // STATUS THRESHOLD CONSTANTS


### PR DESCRIPTION
## Summary
- Increased `EXPIRING_SOON_ALERT_DAYS` from 7 to 30 days
- Users now get dashboard warning alerts for items expiring within 30 days
- Aligns alert threshold with the visual warning threshold used on item cards

## Test plan
- [x] All unit tests pass (1017 tests)
- [x] Build succeeds
- [ ] Manually verify expiring soon alerts appear for items within 30 days