### PR TITLE
refactor: improve recommended item display format

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -310,6 +310,8 @@
     "recommended": "Recommended",
     "showLess": "Show less",
     "showRecommended": "Show {{count}} recommended items",
+    "shortageFormat": "{{item}} – {{count}} {{unit}}",
+    "shortageFormatMissing": "{{item}} – {{count}} {{unit}} missing",
     "expired": "Expired",
     "expiresIn": "Expires in {{days}} days",
     "searchPlaceholder": "Search items...",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -310,6 +310,8 @@
     "recommended": "Suositeltu",
     "showLess": "Näytä vähemmän",
     "showRecommended": "Näytä {{count}} suositeltua tuotetta",
+    "shortageFormat": "{{item}} – {{count}} {{unit}}",
+    "shortageFormatMissing": "{{item}} – {{count}} {{unit}} puuttuu",
     "expired": "Vanhentunut",
     "expiresIn": "Vanhenee {{days}} päivässä",
     "searchPlaceholder": "Hae tuotteita...",

--- a/src/features/inventory/components/CategoryStatusSummary.tsx
+++ b/src/features/inventory/components/CategoryStatusSummary.tsx
@@ -98,7 +98,18 @@ export const CategoryStatusSummary = ({
       });
     }
     const unitLabel = t(shortage.unit, { ns: 'units' });
-    return `${shortage.missing} ${unitLabel} ${itemName}`;
+
+    // Use "missing" format when user has partial inventory
+    const hasPartialInventory = shortage.actual > 0;
+    const formatKey = hasPartialInventory
+      ? 'inventory.shortageFormatMissing'
+      : 'inventory.shortageFormat';
+
+    return t(formatKey, {
+      item: itemName,
+      count: shortage.missing,
+      unit: unitLabel,
+    });
   };
 
   const getVisibleShortages = (): CategoryShortage[] => {


### PR DESCRIPTION
## Summary
- Improved the display format for recommended items from quantity-first to item-first
- Added contextual "missing" suffix when user has partial inventory

## Changes

### Format Changes
- **Before:** `3 rolls Toilet Paper`
- **After (no inventory):** `Toilet paper – 3 rolls`
- **After (partial inventory):** `Toilet paper – 2 rolls missing`

### Files Modified
- `CategoryStatusSummary.tsx` - Updated `formatShortage()` function to use new translation keys and detect partial inventory
- `en/common.json` - Added `inventory.shortageFormat` and `inventory.shortageFormatMissing` translation keys
- `fi/common.json` - Added Finnish translations for new keys
- `CategoryStatusSummary.test.tsx` - Updated tests for new format and added test for "missing" suffix behavior

## Test plan
- [x] All tests pass (1018 tests)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes
- [x] i18n validation passes