### PR TITLE
chore: rename and update claude command files

### DIFF
--- a/.claude/commands/issue-implement.md
+++ b/.claude/commands/issue-implement.md
@@ -1,0 +1,60 @@
+---
+description: Implement a GitHub issue (accepts issue number or URL)
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Glob, Grep, Task, WebFetch
+---
+
+# Implement GitHub Issue
+
+Analyze and implement a GitHub issue. Accepts either an issue number or full GitHub URL.
+
+## Arguments
+
+`$ARGUMENTS` - Issue number (e.g., `42`) or GitHub URL (e.g., `https://github.com/owner/repo/issues/42`)
+
+## Instructions
+
+1. **Parse the input** to extract the issue number:
+   - If `$ARGUMENTS` is a number, use it directly
+   - If `$ARGUMENTS` is a URL, extract the issue number from the path
+   - If no argument provided, ask the user for the issue number
+
+2. **Fetch issue details** using GitHub CLI:
+
+   ```bash
+   gh issue view <issue_number> --json title,body,labels,state,comments
+   ```
+
+3. **Analyze the issue**:
+   - Understand what needs to be implemented
+   - Identify relevant files in the codebase
+   - Plan the implementation approach
+
+4. **Implement the solution**:
+   - Make necessary code changes
+   - Follow project conventions (see AGENTS.md)
+   - Write tests if applicable
+   - Update documentation if needed
+
+5. **Verify the implementation**:
+   - Run `/verify` to check lint, tests, and build
+
+6. **Stage and summarize changes**:
+   - Stage all changes with `git add -A`
+   - Provide a summary of what was done to implement the issue
+
+7. **Reference the issue properly**:
+   - Use closing keywords in commit messages: `Closes #<number>` or `Fixes #<number>`
+   - Valid closing keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`
+   - When creating a PR for this issue, include the same closing keyword in the PR body
+
+## Safety Rules
+
+- **NEVER** perform git write operations on `main` branch
+- Run verification before considering the implementation complete
+
+## Notes
+
+- If the issue is unclear, read comments for additional context
+- Use closing keywords (`Closes #<number>`) instead of just `Refs: #<number>` to auto-close the issue when merged
+- If the implementation requires multiple steps, use TodoWrite to track progress
+- For complex issues, consider using EnterPlanMode first

--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -21,12 +21,15 @@ Create a pull request for the current branch following our project conventions.
    - Run `git push -u origin <branch-name>`
 
 4. Create the PR using GitHub CLI with this format:
+
    ```bash
    gh pr create --repo ttu/emergency-supply-tracker \
      --title "<type>: <description>" \
      --body "$(cat <<'EOF'
    ## Summary
    <bullet points summarizing the changes>
+
+   Closes #<issue_number>   <!-- Include if implementing an issue -->
 
    ## Changes
    <grouped list of specific changes>
@@ -42,6 +45,10 @@ Create a pull request for the current branch following our project conventions.
      --base main \
      --head <branch-name>
    ```
+
+   **Issue linking**: If this PR implements a GitHub issue, include a closing keyword in the body:
+   - Valid keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`
+   - Example: `Closes #42` or `Fixes #42`
 
 5. Use conventional commit types for the title:
    - `feat`: New features

--- a/.claude/commands/pr-fix.md
+++ b/.claude/commands/pr-fix.md
@@ -1,26 +1,29 @@
 ---
 description: Fix CodeRabbit review issues from the current PR
-allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Glob, Grep
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Glob, Grep, WebFetch
 ---
 
 # Fix PR Review Issues
 
-Read CodeRabbit review comments from the current PR and fix the issues.
+Read CodeRabbit review comments, Codecov coverage reports, and SonarQube issues from the current PR and fix them.
 
 ## Instructions
 
 1. Get the current branch and find the associated PR:
+
    ```bash
    git branch --show-current
    gh pr view --json number,url
    ```
 
 2. Fetch all review comments from the PR:
+
    ```bash
    gh api repos/{owner}/{repo}/pulls/{pr_number}/comments
    ```
 
 3. Also check the PR reviews for inline comments:
+
    ```bash
    gh pr view {pr_number} --json reviews,comments
    ```
@@ -30,15 +33,30 @@ Read CodeRabbit review comments from the current PR and fix the issues.
    - Ignore comments marked with "✅ Addressed" as they are already resolved
    - Focus on unresolved issues that require code changes
 
-5. For each issue:
+5. Check Codecov coverage comments:
+   - Look for comments from "codecov" bot
+   - Identify files with decreased coverage or uncovered lines
+   - Check if new code needs additional tests
+
+6. Check SonarQube issues:
+   - Look for comments from "sonarcloud" or "sonarqube" bot
+   - Check the SonarQube dashboard link if provided in PR checks
+   - Run `gh pr checks {pr_number}` to find SonarQube status and links
+   - Identify code smells, bugs, security hotspots, and coverage issues
+
+7. For each issue:
    - Read the relevant file
    - Understand the suggested fix
    - Apply the fix
    - Mark the issue as addressed in your response
 
-6. After fixing all issues:
+8. After fixing all issues:
    - Run `/verify quick` to check lint and types
-   - Commit the fixes with message: `fix: address CodeRabbit review feedback`
+   - Commit the fixes with appropriate message:
+     - `fix: address CodeRabbit review feedback` for CodeRabbit issues
+     - `test: improve coverage for <area>` for Codecov issues
+     - `fix: address SonarQube issues` for SonarQube issues
+     - Or combine: `fix: address review feedback` if fixing multiple sources
    - Optionally run `/verify` for full verification if requested
 
 ## Safety Rules


### PR DESCRIPTION
## Summary
- Rename command files to follow consistent naming pattern (noun-verb to verb-noun grouping)
- Add GitHub issue closing keywords documentation
- Add Codecov and SonarQube checks to PR fix command

## Changes

**File renames:**
- `implement-issue.md` → `issue-implement.md`
- `pr.md` → `pr-create.md`
- `fix-pr.md` → `pr-fix.md`

**issue-implement.md:**
- Added step 7 for proper issue referencing with closing keywords
- Updated notes to recommend `Closes #<number>` over `Refs: #<number>`

**pr-create.md:**
- Added issue closing keyword placeholder in PR body template
- Added documentation for valid closing keywords

**pr-fix.md:**
- Added Codecov coverage comment checks (step 5)
- Added SonarQube issue checks (step 6)
- Updated commit message guidance for different issue sources
- Added WebFetch to allowed tools

## Test plan
- [ ] All tests pass
- [ ] TypeScript type-check passes
- [ ] Production build succeeds
- [ ] Lint passes