### PR TITLE
test: fix flaky tests

### DIFF
--- a/src/features/dashboard/utils/categoryStatus.test.ts
+++ b/src/features/dashboard/utils/categoryStatus.test.ts
@@ -24,7 +24,6 @@ import {
   randomQuantityFloat,
   randomLessThan,
   randomMoreThan,
-  randomPercentageLow,
   randomPercentageMid,
 } from '@/shared/utils/test/faker-helpers';
 
@@ -745,7 +744,10 @@ describe('calculateCategoryStatus - inventory-based status', () => {
       }),
     ];
 
-    const completionPercentage = randomPercentageLow();
+    // Use a fixed low percentage (25) that's strictly less than CRITICAL_PERCENTAGE_THRESHOLD (30)
+    // to ensure deterministic test behavior. randomPercentageLow() can return 30, which would
+    // not trigger the critical status check (completionPercentage < 30).
+    const completionPercentage = 25;
     const result = calculateCategoryStatus(
       waterCategory,
       items,
@@ -1157,9 +1159,10 @@ describe('getCategoryDisplayStatus', () => {
     const needed = Math.ceil(
       DAILY_WATER_PER_PERSON * peopleMultiplier * household.supplyDurationDays,
     );
-    // Use less than 30% of needed to guarantee 'critical' status
-    // (critical threshold is 30%)
-    const criticalPercentage = randomPercentageLow(); // 0-30%
+    // Use a fixed percentage (25%) that's strictly less than CRITICAL_PERCENTAGE_THRESHOLD (30%)
+    // to guarantee 'critical' status. randomPercentageLow() can return 30, which could result
+    // in exactly 30% completion, causing getStatusFromPercentage(30) to return 'warning' instead of 'critical'.
+    const criticalPercentage = 25; // Fixed value < 30% to ensure critical status
     const actual = Math.floor((needed * criticalPercentage) / 100);
 
     const items: InventoryItem[] = [

--- a/src/shared/utils/calculations/water.test.ts
+++ b/src/shared/utils/calculations/water.test.ts
@@ -175,7 +175,8 @@ describe('water calculations', () => {
         }),
       ];
       const expected = pastaQuantity * 1 + riceQuantity * 1.5;
-      expect(calculateTotalWaterRequired(items)).toBe(expected);
+      // Use toBeCloseTo() to handle potential floating-point precision issues with random values
+      expect(calculateTotalWaterRequired(items)).toBeCloseTo(expected, 10);
     });
 
     it('ignores items without water requirements', () => {
@@ -196,7 +197,11 @@ describe('water calculations', () => {
           productTemplateId: 'pasta',
         }),
       ];
-      expect(calculateTotalWaterRequired(items)).toBe(pastaQuantity * 1);
+      // Use toBeCloseTo() to handle potential floating-point precision issues with random values
+      expect(calculateTotalWaterRequired(items)).toBeCloseTo(
+        pastaQuantity * 1,
+        10,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes a flaky test in `categoryStatus.test.ts` that was intermittently failing.

## Problem

The test `should return critical for food category when totalActualCalories < totalNeededCalories` was using `randomPercentageLow()` which returns a random number between 0-30 (inclusive). When it returned exactly 30, the check `completionPercentage < CRITICAL_PERCENTAGE_THRESHOLD` (where threshold is 30) evaluated to `false`, causing the status to be 'warning' instead of 'critical'.

## Solution

Replaced `randomPercentageLow()` with a fixed value of 25, which is strictly less than the `CRITICAL_PERCENTAGE_THRESHOLD` of 30. This makes the test deterministic and ensures it always returns 'critical' when calories are insufficient.

## Testing

- Test now passes consistently (verified with multiple runs)
- All existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of category status calculation tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->