### PR TITLE
fix: add back button to all onboarding steps

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -179,8 +179,8 @@ test.describe('Onboarding Flow', () => {
     await page.getByTestId('preset-single').click();
     await expect(page.getByTestId('onboarding-household-form')).toBeVisible();
 
-    // Go back to Preset (button is "Cancel")
-    await page.getByTestId('household-cancel-button').click();
+    // Go back to Preset (button is "Back")
+    await page.getByRole('button', { name: /Back|Takaisin/i }).click();
     await expect(page.getByTestId('onboarding-preset-selector')).toBeVisible();
   });
 });

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -69,6 +69,7 @@
     "delete": "Delete",
     "save": "Save",
     "cancel": "Cancel",
+    "back": "Back",
     "export": "Export",
     "import": "Import",
     "clear": "Clear",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -69,6 +69,7 @@
     "delete": "Poista",
     "save": "Tallenna",
     "cancel": "Peruuta",
+    "back": "Takaisin",
     "export": "Vie",
     "import": "Tuo",
     "clear": "Tyhjennä",

--- a/src/features/onboarding/components/HouseholdForm.stories.tsx
+++ b/src/features/onboarding/components/HouseholdForm.stories.tsx
@@ -47,15 +47,15 @@ export const WithInitialData: Story = {
   },
 };
 
-export const WithCancel: Story = {
+export const WithBack: Story = {
   args: {
     onSubmit: (data) => {
       console.log('Form submitted:', data);
       alert(`Submitted: ${JSON.stringify(data, null, 2)}`);
     },
-    onCancel: () => {
-      console.log('Form cancelled');
-      alert('Form cancelled');
+    onBack: () => {
+      console.log('Back button clicked');
+      alert('Back button clicked');
     },
   },
 };

--- a/src/features/onboarding/components/HouseholdForm.test.tsx
+++ b/src/features/onboarding/components/HouseholdForm.test.tsx
@@ -20,7 +20,7 @@ vi.mock('react-i18next', () => ({
         'household.errors.supplyDaysMin': 'At least {{min}} day is required',
         'household.errors.supplyDaysMax': 'Maximum {{max}} days allowed',
         'actions.save': 'Save',
-        'actions.cancel': 'Cancel',
+        'actions.back': 'Back',
       };
       let result = translations[key] || key;
       if (params) {
@@ -155,23 +155,23 @@ describe('HouseholdForm', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders cancel button when onCancel is provided', () => {
+  it('renders back button when onBack is provided', () => {
     const onSubmit = vi.fn();
-    const onCancel = vi.fn();
-    render(<HouseholdForm onSubmit={onSubmit} onCancel={onCancel} />);
+    const onBack = vi.fn();
+    render(<HouseholdForm onSubmit={onSubmit} onBack={onBack} />);
 
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 
-  it('calls onCancel when cancel button is clicked', async () => {
+  it('calls onBack when back button is clicked', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
-    const onCancel = vi.fn();
-    render(<HouseholdForm onSubmit={onSubmit} onCancel={onCancel} />);
+    const onBack = vi.fn();
+    render(<HouseholdForm onSubmit={onSubmit} onBack={onBack} />);
 
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
-    await user.click(cancelButton);
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    await user.click(backButton);
 
-    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/onboarding/components/HouseholdForm.tsx
+++ b/src/features/onboarding/components/HouseholdForm.tsx
@@ -20,13 +20,13 @@ export interface HouseholdData {
 export interface HouseholdFormProps {
   initialData?: Partial<HouseholdData>;
   onSubmit: (data: HouseholdData) => void;
-  onCancel?: () => void;
+  onBack?: () => void;
 }
 
 export function HouseholdForm({
   initialData,
   onSubmit,
-  onCancel,
+  onBack,
 }: HouseholdFormProps) {
   const { t } = useTranslation();
   const [formData, setFormData] = useState<HouseholdData>({
@@ -180,14 +180,14 @@ export function HouseholdForm({
           </div>
 
           <div className={styles.actions}>
-            {onCancel && (
+            {onBack && (
               <Button
                 type="button"
                 variant="secondary"
-                onClick={onCancel}
-                data-testid="household-cancel-button"
+                onClick={onBack}
+                data-testid="household-back-button"
               >
-                {t('actions.cancel')}
+                {t('actions.back')}
               </Button>
             )}
             <Button

--- a/src/features/onboarding/components/HouseholdPresetSelector.module.css
+++ b/src/features/onboarding/components/HouseholdPresetSelector.module.css
@@ -108,6 +108,12 @@
   margin: 0;
 }
 
+.actions {
+  margin-top: var(--spacing-xl);
+  display: flex;
+  justify-content: flex-start;
+}
+
 @media (max-width: 640px) {
   .container {
     padding: var(--spacing-md);

--- a/src/features/onboarding/components/HouseholdPresetSelector.tsx
+++ b/src/features/onboarding/components/HouseholdPresetSelector.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Card } from '@/shared/components/Card';
+import { Button } from '@/shared/components/Button';
 import styles from './HouseholdPresetSelector.module.css';
 
 export interface HouseholdPreset {
@@ -11,6 +12,7 @@ export interface HouseholdPreset {
 export interface HouseholdPresetSelectorProps {
   selectedPreset?: string;
   onSelectPreset: (preset: HouseholdPreset) => void;
+  onBack?: () => void;
 }
 
 const PRESETS: HouseholdPreset[] = [
@@ -22,6 +24,7 @@ const PRESETS: HouseholdPreset[] = [
 export function HouseholdPresetSelector({
   selectedPreset,
   onSelectPreset,
+  onBack,
 }: HouseholdPresetSelectorProps) {
   const { t } = useTranslation();
 
@@ -89,6 +92,14 @@ export function HouseholdPresetSelector({
             </div>
           </Card>
         </div>
+
+        {onBack && (
+          <div className={styles.actions}>
+            <Button type="button" variant="secondary" onClick={onBack}>
+              {t('actions.back')}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/onboarding/components/Onboarding.test.tsx
+++ b/src/features/onboarding/components/Onboarding.test.tsx
@@ -37,7 +37,7 @@ vi.mock('react-i18next', () => ({
         'household.supplyDays': 'Supply Days',
         'household.useFreezer': 'I want to use my freezer',
         'actions.save': 'Save',
-        'actions.cancel': 'Cancel',
+        'actions.back': 'Back',
         'quickSetup.addItems': 'Add Selected Items',
         'quickSetup.skip': 'Skip',
         'quickSetup.showDetails': 'Show Details',
@@ -136,11 +136,11 @@ describe('Onboarding', () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByText('Cancel')).toBeInTheDocument();
+      expect(screen.getByText('Back')).toBeInTheDocument();
     });
 
     // Household -> Preset
-    const backButton = screen.getByText('Cancel');
+    const backButton = screen.getByText('Back');
     await user.click(backButton);
 
     await waitFor(() => {

--- a/src/features/onboarding/components/Onboarding.tsx
+++ b/src/features/onboarding/components/Onboarding.tsx
@@ -89,6 +89,7 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
         <HouseholdPresetSelector
           selectedPreset={selectedPreset?.id}
           onSelectPreset={handlePresetSelect}
+          onBack={() => setCurrentStep('welcome')}
         />
       )}
 
@@ -105,7 +106,7 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
               : undefined
           }
           onSubmit={handleHouseholdSubmit}
-          onCancel={() => setCurrentStep('preset')}
+          onBack={() => setCurrentStep('preset')}
         />
       )}
 
@@ -114,6 +115,7 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
           household={householdConfig}
           onAddItems={handleAddItems}
           onSkip={handleSkip}
+          onBack={() => setCurrentStep('household')}
         />
       )}
     </>

--- a/src/features/onboarding/components/QuickSetupScreen.tsx
+++ b/src/features/onboarding/components/QuickSetupScreen.tsx
@@ -9,12 +9,14 @@ export interface QuickSetupScreenProps {
   household: HouseholdConfig;
   onAddItems: (selectedItemIds: Set<string>) => void;
   onSkip: () => void;
+  onBack?: () => void;
 }
 
 export const QuickSetupScreen = ({
   household,
   onAddItems,
   onSkip,
+  onBack,
 }: QuickSetupScreenProps) => {
   const { t } = useTranslation(['common', 'categories', 'products', 'units']);
   const [showDetails, setShowDetails] = useState(false);
@@ -212,7 +214,13 @@ export const QuickSetupScreen = ({
         </div>
 
         <div className={styles.actions}>
+          {onBack && (
+            <Button type="button" variant="secondary" onClick={onBack}>
+              {t('actions.back')}
+            </Button>
+          )}
           <Button
+            type="button"
             variant="secondary"
             onClick={onSkip}
             data-testid="skip-quick-setup-button"
@@ -220,6 +228,7 @@ export const QuickSetupScreen = ({
             {t('quickSetup.skip')}
           </Button>
           <Button
+            type="button"
             variant="primary"
             onClick={handleAddItems}
             disabled={selectedCount === 0}


### PR DESCRIPTION
## Summary
- Added back button to all onboarding steps (except welcome screen)
- Changed HouseholdForm cancel button to back button with proper translation
- Updated all tests to reflect the back button changes
- Added 'back' translation to actions in both English and Finnish locales

## Changes

### Components
- **HouseholdPresetSelector**: Added back button that navigates back to welcome screen
- **HouseholdForm**: Changed 'Cancel' button to 'Back' button (renamed prop from `onCancel` to `onBack`)
- **QuickSetupScreen**: Added back button that navigates back to household form
- **Onboarding**: Updated to pass back handlers to all step components

### Translations
- Added `actions.back` key to English (`common.json`) - "Back"
- Added `actions.back` key to Finnish (`common.json`) - "Takaisin"

### Tests
- Updated `Onboarding.test.tsx` to use 'Back' instead of 'Cancel'
- Updated `HouseholdForm.test.tsx` to test `onBack` prop instead of `onCancel`
- Updated `HouseholdForm.stories.tsx` story from `WithCancel` to `WithBack`
- Updated E2E test `onboarding.spec.ts` to match 'Back' button text

### Styling
- Added `.actions` CSS class to `HouseholdPresetSelector.module.css` for back button layout

## Test plan
- [x] All tests pass (1127 tests)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes
- [x] i18n validation passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced onboarding experience with back navigation across all setup steps, allowing users to return to previous stages. Back buttons now replace cancel functionality for clearer navigation intent.

* **Chores**
  * Added localized back button labels in English and Finnish languages.
  * Updated styling for consistent action button layout presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->