### PR TITLE
fix: set quantity to 1 for preselected items, 0 when all selected

### DIFF
--- a/src/features/onboarding/components/Onboarding.tsx
+++ b/src/features/onboarding/components/Onboarding.tsx
@@ -49,6 +49,19 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
   const handleAddItems = (selectedItemIds: Set<string>) => {
     if (!householdConfig) return;
 
+    // Calculate total available items (after filtering for freezer requirements)
+    const availableItems = RECOMMENDED_ITEMS.filter((item) => {
+      // Skip frozen items if not using freezer
+      if (item.requiresFreezer && !householdConfig.useFreezer) {
+        return false;
+      }
+      return true;
+    });
+
+    // Determine quantity: 0 if all items are selected, 1 if some are selected
+    const allItemsSelected = selectedItemIds.size === availableItems.length;
+    const quantity = allItemsSelected ? 0 : 1;
+
     // Calculate and create inventory items from selected recommended items
     const items: InventoryItem[] = RECOMMENDED_ITEMS.filter((item) => {
       // Only include selected items
@@ -64,10 +77,10 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
       // Translate item name
       const itemName = t(item.i18nKey.replace('products.', ''));
 
-      // Create item using factory - all items start with quantity 0
+      // Create item using factory with determined quantity
       return InventoryItemFactory.createFromTemplate(item, householdConfig, {
         name: itemName,
-        quantity: 0,
+        quantity,
       });
     });
 


### PR DESCRIPTION
## Summary
- If user preselects some items on onboarding, add them with quantity 1
- If all items are preselected, add them with quantity 0
- Add unit tests to verify the quantity logic

## Changes
- **Onboarding.tsx**: Updated `handleAddItems` to calculate quantity based on selection state (1 if some selected, 0 if all selected)
- **Onboarding.test.tsx**: Added two new test cases to verify quantity behavior:
  - Test that preselected items get quantity 1 when some items are selected
  - Test that preselected items get quantity 0 when all items are selected
- **Onboarding.test.tsx**: Added missing translation keys (`quickSetup.selectAll`, `quickSetup.deselectAll`) to test mocks

## Test plan
- [x] All tests pass (1129 tests passed)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes