### PR TITLE
fix: eliminate duplicate provider nesting and ensure consistent provider order

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,19 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import App from './App';
 import { createMockAppData } from '@/shared/utils/test/factories';
-import { SettingsProvider } from '@/features/settings';
-import { HouseholdProvider } from '@/features/household';
-import { InventoryProvider } from '@/features/inventory';
-import { ThemeApplier } from './components/ThemeApplier';
-import { ErrorBoundary } from '@/shared/components/ErrorBoundary';
+import { renderWithProviders } from '@/test/render';
 import { STORAGE_KEY } from '@/shared/utils/storage/localStorage';
 
 // Mock i18next
+const mockT = (key: string) => key;
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: mockT,
     i18n: {
       language: 'en',
       changeLanguage: vi.fn(),
@@ -22,7 +20,7 @@ vi.mock('react-i18next', () => ({
   withTranslation:
     () => (Component: React.ComponentType<Record<string, unknown>>) => {
       const WrappedComponent = (props: Record<string, unknown>) => {
-        return <Component {...props} />;
+        return <Component {...props} t={mockT} />;
       };
       WrappedComponent.displayName = `withTranslation(${Component.displayName || Component.name || 'Component'})`;
       return WrappedComponent;
@@ -44,19 +42,12 @@ const setupCompletedOnboarding = () => {
 
 // Helper to render App with all required providers
 const renderApp = () => {
-  return render(
-    <ErrorBoundary>
-      <SettingsProvider>
-        <ThemeApplier>
-          <HouseholdProvider>
-            <InventoryProvider>
-              <App />
-            </InventoryProvider>
-          </HouseholdProvider>
-        </ThemeApplier>
-      </SettingsProvider>
-    </ErrorBoundary>,
-  );
+  return renderWithProviders(<App />, {
+    providers: {
+      errorBoundary: true,
+      themeApplier: true,
+    },
+  });
 };
 
 describe('App', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { trackAppLaunch } from '@/shared/utils/analytics';
-import { SettingsProvider, useSettings, Settings } from '@/features/settings';
-import { HouseholdProvider, useHousehold } from '@/features/household';
-import {
-  InventoryProvider,
-  useInventory,
-  Inventory,
-} from '@/features/inventory';
-import { RecommendedItemsProvider } from '@/features/templates';
-import { ThemeApplier } from './components/ThemeApplier';
-import { ErrorBoundary } from '@/shared/components/ErrorBoundary';
+import { useSettings, Settings } from '@/features/settings';
+import { useHousehold } from '@/features/household';
+import { useInventory, Inventory } from '@/features/inventory';
 import { Navigation, PageType } from '@/shared/components/Navigation';
 import { Dashboard } from '@/features/dashboard';
 import { Help } from '@/features/help';
@@ -98,21 +91,7 @@ function App() {
     trackAppLaunch();
   }, []);
 
-  return (
-    <ErrorBoundary>
-      <SettingsProvider>
-        <ThemeApplier>
-          <HouseholdProvider>
-            <RecommendedItemsProvider>
-              <InventoryProvider>
-                <AppContent />
-              </InventoryProvider>
-            </RecommendedItemsProvider>
-          </HouseholdProvider>
-        </ThemeApplier>
-      </SettingsProvider>
-    </ErrorBoundary>
-  );
+  return <AppContent />;
 }
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,7 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import './i18n/config';
 import App from './App.tsx';
-import { HouseholdProvider } from '@/features/household';
-import { InventoryProvider } from '@/features/inventory';
-import { SettingsProvider } from '@/features/settings';
-import { ErrorBoundary } from '@/shared/components/ErrorBoundary';
-import { ThemeApplier } from './components/ThemeApplier';
+import { AllProviders } from '@/shared/components/AllProviders';
 import * as serviceWorker from '@/shared/utils/serviceWorker';
 
 createRoot(document.getElementById('root')!).render(
@@ -17,17 +13,9 @@ createRoot(document.getElementById('root')!).render(
         <div style={{ padding: '2rem', textAlign: 'center' }}>Loading...</div>
       }
     >
-      <ErrorBoundary>
-        <SettingsProvider>
-          <ThemeApplier>
-            <HouseholdProvider>
-              <InventoryProvider>
-                <App />
-              </InventoryProvider>
-            </HouseholdProvider>
-          </ThemeApplier>
-        </SettingsProvider>
-      </ErrorBoundary>
+      <AllProviders>
+        <App />
+      </AllProviders>
     </Suspense>
   </StrictMode>,
 );

--- a/src/shared/components/AllProviders.test.tsx
+++ b/src/shared/components/AllProviders.test.tsx
@@ -1,38 +1,87 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { AllProviders } from './AllProviders';
+import { useSettings } from '@/features/settings';
+import { useHousehold } from '@/features/household';
+import { useInventory } from '@/features/inventory';
+
+// Track provider instances to detect duplicates
+const providerInstances = {
+  errorBoundary: 0,
+  settings: 0,
+  themeApplier: 0,
+  household: 0,
+  recommendedItems: 0,
+  inventory: 0,
+};
 
 // Mock the providers to avoid needing full context setup
+vi.mock('@/shared/components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => {
+    providerInstances.errorBoundary++;
+    return <div data-testid="error-boundary">{children}</div>;
+  },
+}));
+
+vi.mock('@/components/ThemeApplier', () => ({
+  ThemeApplier: ({ children }: { children: React.ReactNode }) => {
+    providerInstances.themeApplier++;
+    return <div data-testid="theme-applier">{children}</div>;
+  },
+}));
+
 vi.mock('@/features/settings', () => ({
-  SettingsProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="settings-provider">{children}</div>
-  ),
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => {
+    providerInstances.settings++;
+    return <div data-testid="settings-provider">{children}</div>;
+  },
+  useSettings: vi.fn(() => ({
+    settings: { theme: 'light', language: 'en' },
+    updateSettings: vi.fn(),
+  })),
 }));
 
 vi.mock('@/features/household', () => ({
-  HouseholdProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="household-provider">{children}</div>
-  ),
+  HouseholdProvider: ({ children }: { children: React.ReactNode }) => {
+    providerInstances.household++;
+    return <div data-testid="household-provider">{children}</div>;
+  },
+  useHousehold: vi.fn(() => ({
+    household: { adults: 1, children: 0, supplyDurationDays: 3 },
+    updateHousehold: vi.fn(),
+  })),
 }));
 
 vi.mock('@/features/templates', () => ({
-  RecommendedItemsProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="recommended-items-provider">{children}</div>
-  ),
+  RecommendedItemsProvider: ({ children }: { children: React.ReactNode }) => {
+    providerInstances.recommendedItems++;
+    return <div data-testid="recommended-items-provider">{children}</div>;
+  },
 }));
 
 vi.mock('@/features/inventory', () => ({
-  InventoryProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="inventory-provider">{children}</div>
-  ),
+  InventoryProvider: ({ children }: { children: React.ReactNode }) => {
+    providerInstances.inventory++;
+    return <div data-testid="inventory-provider">{children}</div>;
+  },
+  useInventory: vi.fn(() => ({
+    items: [],
+    addItems: vi.fn(),
+    updateItem: vi.fn(),
+    deleteItem: vi.fn(),
+  })),
 }));
 
 describe('AllProviders', () => {
   beforeEach(() => {
     localStorage.clear();
+    // Reset provider instance counts before each test
+    Object.keys(providerInstances).forEach(
+      (key) => (providerInstances[key as keyof typeof providerInstances] = 0),
+    );
   });
 
-  it('should render children with all providers in correct order', () => {
+  it('should render children with all providers in correct nesting order', () => {
     render(
       <AllProviders>
         <div data-testid="child-content">Test Content</div>
@@ -43,27 +92,88 @@ describe('AllProviders', () => {
     expect(screen.getByTestId('child-content')).toBeInTheDocument();
     expect(screen.getByText('Test Content')).toBeInTheDocument();
 
-    // Verify all providers are present in correct nesting order
-    // Order should be: Settings > Household > RecommendedItems > Inventory
+    // Verify all providers are present
+    const errorBoundary = screen.getByTestId('error-boundary');
     const settingsProvider = screen.getByTestId('settings-provider');
+    const themeApplier = screen.getByTestId('theme-applier');
     const householdProvider = screen.getByTestId('household-provider');
     const recommendedItemsProvider = screen.getByTestId(
       'recommended-items-provider',
     );
     const inventoryProvider = screen.getByTestId('inventory-provider');
 
+    expect(errorBoundary).toBeInTheDocument();
     expect(settingsProvider).toBeInTheDocument();
+    expect(themeApplier).toBeInTheDocument();
     expect(householdProvider).toBeInTheDocument();
     expect(recommendedItemsProvider).toBeInTheDocument();
     expect(inventoryProvider).toBeInTheDocument();
 
-    // Verify nesting order: child should be inside inventory, which is inside recommended items, etc.
+    // Verify nesting order (innermost to outermost):
+    // child -> inventory -> recommendedItems -> household -> themeApplier -> settings -> errorBoundary
     expect(inventoryProvider).toContainElement(
       screen.getByTestId('child-content'),
     );
     expect(recommendedItemsProvider).toContainElement(inventoryProvider);
     expect(householdProvider).toContainElement(recommendedItemsProvider);
-    expect(settingsProvider).toContainElement(householdProvider);
+    expect(themeApplier).toContainElement(householdProvider);
+    expect(settingsProvider).toContainElement(themeApplier);
+    expect(errorBoundary).toContainElement(settingsProvider);
+  });
+
+  it('should not create duplicate provider instances', () => {
+    render(
+      <AllProviders>
+        <div data-testid="child-content">Test Content</div>
+      </AllProviders>,
+    );
+
+    // Each provider should be instantiated exactly once
+    expect(providerInstances.errorBoundary).toBe(1);
+    expect(providerInstances.settings).toBe(1);
+    expect(providerInstances.themeApplier).toBe(1);
+    expect(providerInstances.household).toBe(1);
+    expect(providerInstances.recommendedItems).toBe(1);
+    expect(providerInstances.inventory).toBe(1);
+  });
+
+  it('should make all contexts accessible to children', () => {
+    function TestComponent() {
+      const settings = useSettings();
+      const household = useHousehold();
+      const inventory = useInventory();
+
+      return (
+        <div data-testid="test-component">
+          <div data-testid="settings-accessible">
+            {settings ? 'settings-ok' : 'settings-missing'}
+          </div>
+          <div data-testid="household-accessible">
+            {household ? 'household-ok' : 'household-missing'}
+          </div>
+          <div data-testid="inventory-accessible">
+            {inventory ? 'inventory-ok' : 'inventory-missing'}
+          </div>
+        </div>
+      );
+    }
+
+    render(
+      <AllProviders>
+        <TestComponent />
+      </AllProviders>,
+    );
+
+    // All contexts should be accessible
+    expect(screen.getByTestId('settings-accessible')).toHaveTextContent(
+      'settings-ok',
+    );
+    expect(screen.getByTestId('household-accessible')).toHaveTextContent(
+      'household-ok',
+    );
+    expect(screen.getByTestId('inventory-accessible')).toHaveTextContent(
+      'inventory-ok',
+    );
   });
 
   it('should handle multiple children', () => {
@@ -82,6 +192,7 @@ describe('AllProviders', () => {
     const { container } = render(<AllProviders>{null}</AllProviders>);
 
     // Should still render providers even with null children
+    expect(screen.getByTestId('error-boundary')).toBeInTheDocument();
     expect(screen.getByTestId('settings-provider')).toBeInTheDocument();
     expect(container).toBeInTheDocument();
   });

--- a/src/shared/components/AllProviders.tsx
+++ b/src/shared/components/AllProviders.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
+import { ErrorBoundary } from '@/shared/components/ErrorBoundary';
 import { SettingsProvider } from '@/features/settings';
+import { ThemeApplier } from '@/components/ThemeApplier';
 import { HouseholdProvider } from '@/features/household';
 import { RecommendedItemsProvider } from '@/features/templates';
 import { InventoryProvider } from '@/features/inventory';
@@ -10,16 +12,29 @@ interface AllProvidersProps {
 
 /**
  * Wraps children with all app providers in the correct order.
- * Used by Storybook stories and test utilities to provide consistent context.
+ *
+ * Provider nesting order (outermost to innermost):
+ * 1. ErrorBoundary - Catches React errors
+ * 2. SettingsProvider - Provides settings context (theme, language, etc.)
+ * 3. ThemeApplier - Applies theme CSS variables (requires SettingsProvider)
+ * 4. HouseholdProvider - Provides household configuration
+ * 5. RecommendedItemsProvider - Provides recommended item definitions
+ * 6. InventoryProvider - Provides inventory items and categories (innermost)
+ *
+ * Used by main.tsx, App.tsx, Storybook stories, and test utilities to provide consistent context.
  */
 export function AllProviders({ children }: AllProvidersProps) {
   return (
-    <SettingsProvider>
-      <HouseholdProvider>
-        <RecommendedItemsProvider>
-          <InventoryProvider>{children}</InventoryProvider>
-        </RecommendedItemsProvider>
-      </HouseholdProvider>
-    </SettingsProvider>
+    <ErrorBoundary>
+      <SettingsProvider>
+        <ThemeApplier>
+          <HouseholdProvider>
+            <RecommendedItemsProvider>
+              <InventoryProvider>{children}</InventoryProvider>
+            </RecommendedItemsProvider>
+          </HouseholdProvider>
+        </ThemeApplier>
+      </SettingsProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/test/render.test.tsx
+++ b/src/test/render.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from './render';
+import { useSettings } from '@/features/settings';
+import { useHousehold } from '@/features/household';
+import { useInventory } from '@/features/inventory';
+import { STORAGE_KEY } from '@/shared/utils/storage/localStorage';
+import type { AppData } from '@/shared/types';
+import {
+  createMockAppData,
+  createMockInventoryItem,
+} from '@/shared/utils/test/factories';
+
+/**
+ * Test component that uses all contexts and updates localStorage
+ */
+function TestComponent() {
+  const { settings, updateSettings } = useSettings();
+  const { household, updateHousehold } = useHousehold();
+  const { items } = useInventory();
+
+  return (
+    <div data-testid="test-component">
+      <div data-testid="settings-theme">{settings.theme}</div>
+      <div data-testid="household-adults">{household.adults}</div>
+      <div data-testid="items-count">{items.length}</div>
+      <button
+        data-testid="update-settings"
+        onClick={() => updateSettings({ theme: 'dark' })}
+      >
+        Update Settings
+      </button>
+      <button
+        data-testid="update-household"
+        onClick={() => updateHousehold({ ...household, adults: 3 })}
+      >
+        Update Household
+      </button>
+    </div>
+  );
+}
+
+describe('renderWithProviders localStorage persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should load initial data from localStorage', () => {
+    const initialData: Partial<AppData> = {
+      settings: {
+        theme: 'dark',
+        language: 'fi',
+        highContrast: false,
+        advancedFeatures: {
+          calorieTracking: false,
+          powerManagement: false,
+          waterTracking: false,
+        },
+      },
+      household: {
+        adults: 4,
+        children: 2,
+        supplyDurationDays: 7,
+        useFreezer: false,
+      },
+      items: [createMockInventoryItem({ name: 'Test Item' })],
+    };
+
+    const appData = createMockAppData(initialData);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(appData));
+
+    const { unmount } = renderWithProviders(<TestComponent />, {
+      initialAppData: initialData,
+    });
+
+    // Verify data was loaded from localStorage
+    expect(screen.getByTestId('settings-theme')).toHaveTextContent('dark');
+    expect(screen.getByTestId('household-adults')).toHaveTextContent('4');
+    expect(screen.getByTestId('items-count')).toHaveTextContent('1');
+
+    unmount();
+  });
+
+  it('should save updates to localStorage when providers update', async () => {
+    const user = userEvent.setup();
+
+    const { unmount } = renderWithProviders(<TestComponent />, {
+      initialAppData: {
+        settings: {
+          theme: 'light',
+          language: 'en',
+          highContrast: false,
+          advancedFeatures: {
+            calorieTracking: false,
+            powerManagement: false,
+            waterTracking: false,
+          },
+        },
+        household: {
+          adults: 1,
+          children: 0,
+          supplyDurationDays: 3,
+          useFreezer: false,
+        },
+      },
+    });
+
+    // Verify initial state
+    expect(screen.getByTestId('settings-theme')).toHaveTextContent('light');
+    expect(screen.getByTestId('household-adults')).toHaveTextContent('1');
+
+    // Update settings
+    await user.click(screen.getByTestId('update-settings'));
+
+    // Wait for localStorage to be updated
+    await waitFor(() => {
+      const savedData = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(savedData.settings?.theme).toBe('dark');
+    });
+
+    // Update household
+    await user.click(screen.getByTestId('update-household'));
+
+    // Wait for localStorage to be updated
+    await waitFor(() => {
+      const updatedData = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(updatedData.household?.adults).toBe(3);
+    });
+
+    unmount();
+  });
+
+  it('should clean up localStorage after unmount when initialAppData was provided', () => {
+    const initialData: Partial<AppData> = {
+      settings: {
+        theme: 'dark',
+        language: 'en',
+        highContrast: false,
+        advancedFeatures: {
+          calorieTracking: false,
+          powerManagement: false,
+          waterTracking: false,
+        },
+      },
+    };
+
+    const { unmount } = renderWithProviders(<TestComponent />, {
+      initialAppData: initialData,
+    });
+
+    // Verify localStorage has data
+    expect(localStorage.getItem(STORAGE_KEY)).toBeTruthy();
+
+    // Unmount should clean up
+    unmount();
+
+    // Verify localStorage was cleaned up
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('should not clean up localStorage if initialAppData was not provided', () => {
+    // Manually set localStorage
+    const appData = createMockAppData({
+      settings: {
+        theme: 'dark',
+        language: 'en',
+        highContrast: false,
+        advancedFeatures: {
+          calorieTracking: false,
+          powerManagement: false,
+          waterTracking: false,
+        },
+      },
+    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(appData));
+
+    const { unmount } = renderWithProviders(<TestComponent />);
+
+    // Verify localStorage still has data
+    expect(localStorage.getItem(STORAGE_KEY)).toBeTruthy();
+
+    // Unmount should NOT clean up (since we didn't provide initialAppData)
+    unmount();
+
+    // Verify localStorage was NOT cleaned up
+    expect(localStorage.getItem(STORAGE_KEY)).toBeTruthy();
+  });
+
+  it('should persist data across multiple renders with same initialAppData', () => {
+    const initialData: Partial<AppData> = {
+      household: {
+        adults: 2,
+        children: 1,
+        supplyDurationDays: 5,
+        useFreezer: false,
+      },
+    };
+
+    const { unmount: unmount1 } = renderWithProviders(<TestComponent />, {
+      initialAppData: initialData,
+    });
+
+    expect(screen.getByTestId('household-adults')).toHaveTextContent('2');
+    unmount1();
+
+    // Render again with same initial data
+    const { unmount: unmount2 } = renderWithProviders(<TestComponent />, {
+      initialAppData: initialData,
+    });
+
+    expect(screen.getByTestId('household-adults')).toHaveTextContent('2');
+    unmount2();
+  });
+});

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -145,7 +145,7 @@ export function renderWithProviders(
     let wrapped: ReactNode = children;
 
     // Build provider tree from inside out (reverse order of nesting)
-    // Order matches App.tsx: ErrorBoundary > Settings > ThemeApplier > Household > RecommendedItems > Inventory
+    // Order matches AllProviders.tsx: ErrorBoundary > Settings > ThemeApplier > Household > RecommendedItems > Inventory
     if (inventory) wrapped = <InventoryProvider>{wrapped}</InventoryProvider>;
     if (recommendedItems)
       wrapped = <RecommendedItemsProvider>{wrapped}</RecommendedItemsProvider>;


### PR DESCRIPTION
## Summary
- Eliminates duplicate provider nesting by centralizing all providers in `AllProviders` component
- Ensures consistent provider order across the codebase (main.tsx, App.tsx, tests)
- Adds comprehensive integration tests for provider nesting and localStorage persistence
- Fixes App.test.tsx to use the new provider structure

## Changes

### Core Provider Refactoring
- **AllProviders.tsx**: Updated to include `ErrorBoundary` and `ThemeApplier` in correct nesting order
  - Provider order: ErrorBoundary → SettingsProvider → ThemeApplier → HouseholdProvider → RecommendedItemsProvider → InventoryProvider
- **main.tsx**: Replaced manual provider nesting with `AllProviders` component
- **App.tsx**: Removed all provider nesting, now only contains `AppContent` logic

### Test Updates
- **test/render.tsx**: Updated comment to reference `AllProviders.tsx` provider order
- **AllProviders.test.tsx**: Enhanced with comprehensive integration tests
  - Tests provider nesting order
  - Verifies no duplicate provider instances
  - Tests context accessibility
- **render.test.tsx**: New test file for localStorage persistence with providers
  - Tests loading initial data from localStorage
  - Tests saving updates when providers update
  - Tests cleanup behavior
- **App.test.tsx**: Updated to use `renderWithProviders` with proper provider configuration

## Test plan
- [x] All tests pass (1134 tests)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes