### PR TITLE
fix: set default category when adding custom item

### DIFF
--- a/src/features/inventory/components/ItemForm.tsx
+++ b/src/features/inventory/components/ItemForm.tsx
@@ -30,6 +30,7 @@ export interface ItemFormProps {
   ) => void;
   onCancel: () => void;
   defaultRecommendedQuantity?: number;
+  defaultCategoryId?: string;
   templateWeightGramsPerUnit?: number;
   templateCaloriesPer100g?: number;
   templateRequiresWaterLiters?: number;
@@ -67,6 +68,7 @@ export const ItemForm = ({
   onSubmit,
   onCancel,
   defaultRecommendedQuantity = 1,
+  defaultCategoryId,
   templateWeightGramsPerUnit,
   templateCaloriesPer100g,
   templateRequiresWaterLiters,
@@ -106,7 +108,7 @@ export const ItemForm = ({
   const [formData, setFormData] = useState<FormData>(() => ({
     itemType: item?.itemType || '',
     name: item?.name || '',
-    categoryId: item?.categoryId || '',
+    categoryId: item?.categoryId || defaultCategoryId || '',
     quantity: item?.quantity?.toString() || '',
     unit: item?.unit || 'pieces',
     recommendedQuantity:

--- a/src/features/inventory/pages/Inventory.tsx
+++ b/src/features/inventory/pages/Inventory.tsx
@@ -371,6 +371,7 @@ export function Inventory({
             onSubmit={editingItem?.id ? handleUpdateItem : handleAddItem}
             onCancel={handleCancelForm}
             defaultRecommendedQuantity={getDefaultRecommendedQuantity()}
+            defaultCategoryId={selectedCategoryId}
             templateWeightGramsPerUnit={selectedTemplate?.weightGramsPerUnit}
             templateCaloriesPer100g={selectedTemplate?.caloriesPer100g}
             templateRequiresWaterLiters={selectedTemplate?.requiresWaterLiters}


### PR DESCRIPTION
## Summary
- Fixed issue where custom items defaulted to first category (water-beverages) instead of the currently selected category
- Added `defaultCategoryId` prop to ItemForm component to support category pre-selection
- Updated Inventory page to pass selected category as default when adding custom items

## Changes
- **ItemForm component**: Added optional `defaultCategoryId` prop and updated form initialization to use it when no item is being edited
- **Inventory page**: Pass `selectedCategoryId` as `defaultCategoryId` to ItemForm when adding new items

## Test plan
- [x] All tests pass (1202 tests passed)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes

## Behavior
When a user:
1. Views a specific category (e.g., "Food")
2. Clicks "Add Item" → "Custom Item"
3. The form now correctly shows the selected category (Food) instead of defaulting to "Water & Beverages"

This fix maintains backward compatibility - when editing existing items, the item's category is still used as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Item forms now automatically pre-select the current category when adding or editing inventory items, streamlining the workflow and reducing manual input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->