### PR TITLE
feat: show missing quantity on inventory item cards

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -313,6 +313,7 @@
     "showRecommended": "Show {{count}} recommended items",
     "shortageFormat": "{{item}} – {{count}} {{unit}}",
     "shortageFormatMissing": "{{item}} – {{count}} {{unit}} missing",
+    "quantityMissing": "{{count}} {{unit}} missing",
     "expired": "Expired",
     "expiresIn": "Expires in {{days}} days",
     "searchPlaceholder": "Search items...",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -313,6 +313,7 @@
     "showRecommended": "Näytä {{count}} suositeltua tuotetta",
     "shortageFormat": "{{item}} – {{count}} {{unit}}",
     "shortageFormatMissing": "{{item}} – {{count}} {{unit}} puuttuu",
+    "quantityMissing": "{{count}} {{unit}} puuttuu",
     "expired": "Vanhentunut",
     "expiresIn": "Vanhenee {{days}} päivässä",
     "searchPlaceholder": "Hae tuotteita...",

--- a/src/features/inventory/components/ItemCard.module.css
+++ b/src/features/inventory/components/ItemCard.module.css
@@ -68,7 +68,8 @@
 .location,
 .calories,
 .capacity,
-.waterRequirement {
+.waterRequirement,
+.missingQuantity {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
@@ -79,6 +80,11 @@
 }
 
 .expiringSoon {
+  color: var(--color-warning);
+  font-weight: var(--font-weight-medium);
+}
+
+.missingQuantity {
   color: var(--color-warning);
   font-weight: var(--font-weight-medium);
 }

--- a/src/features/inventory/components/ItemCard.tsx
+++ b/src/features/inventory/components/ItemCard.tsx
@@ -7,14 +7,19 @@ import {
 } from '@/shared/utils/calculations/itemStatus';
 import { getWaterRequirementPerUnit } from '@/shared/utils/calculations/water';
 import { EXPIRING_SOON_DAYS_THRESHOLD } from '@/shared/utils/constants';
+import {
+  calculateMissingQuantity,
+  calculateTotalMissingQuantity,
+} from '../utils/status';
 import styles from './ItemCard.module.css';
 
 export interface ItemCardProps {
   item: InventoryItem;
+  allItems?: InventoryItem[]; // Optional: if provided, calculates total missing across all items of same type
   onClick?: () => void;
 }
 
-export const ItemCard = ({ item, onClick }: ItemCardProps) => {
+export const ItemCard = ({ item, allItems, onClick }: ItemCardProps) => {
   const { t } = useTranslation(['common', 'units', 'products']);
 
   const formatExpirationDate = (dateString?: string): string => {
@@ -28,6 +33,11 @@ export const ItemCard = ({ item, onClick }: ItemCardProps) => {
     item.expirationDate,
     item.neverExpires,
   );
+  // If allItems is provided, calculate total missing across all items of same type
+  // Otherwise, calculate missing for this individual item
+  const missingQuantity = allItems
+    ? calculateTotalMissingQuantity(item, allItems)
+    : calculateMissingQuantity(item);
 
   return (
     <div
@@ -55,6 +65,16 @@ export const ItemCard = ({ item, onClick }: ItemCardProps) => {
           <span className={styles.current}>{item.quantity}</span>
           <span className={styles.unit}>{t(item.unit, { ns: 'units' })}</span>
         </div>
+
+        {missingQuantity > 0 && (
+          <div className={styles.missingQuantity}>
+            ⚠️{' '}
+            {t('inventory.quantityMissing', {
+              count: missingQuantity,
+              unit: t(item.unit, { ns: 'units' }),
+            })}
+          </div>
+        )}
 
         {!item.neverExpires && item.expirationDate && (
           <div className={styles.expiration}>

--- a/src/features/inventory/components/ItemList.tsx
+++ b/src/features/inventory/components/ItemList.tsx
@@ -33,6 +33,7 @@ export const ItemList = ({
         <ItemCard
           key={item.id}
           item={item}
+          allItems={items}
           onClick={onItemClick ? () => onItemClick(item) : undefined}
         />
       ))}


### PR DESCRIPTION
## Summary
- Added missing quantity display on inventory item cards when items are in warning/critical status due to quantity
- Items of the same type now show the same total missing quantity (matching the recommendations list)
- Extracted business logic to utility functions with comprehensive test coverage

## Changes

### New Features
- **Missing quantity indicator**: Item cards now show "X units missing" when quantity is below recommended
- **Total missing calculation**: All items of the same type show the same total missing quantity across all instances
- **Translation support**: Added `inventory.quantityMissing` key for English and Finnish

### Code Quality
- **Utility functions**: Extracted `calculateMissingQuantity` and `calculateTotalMissingQuantity` to `src/features/inventory/utils/status.ts`
- **Comprehensive tests**: Added 19 new test cases covering all edge cases (expiration, markedAsEnough, zero quantities, etc.)
- **Simplified component**: ItemCard now uses utility functions instead of inline business logic

### Files Changed
- `src/features/inventory/utils/status.ts` - Added utility functions
- `src/features/inventory/utils/status.test.ts` - Added comprehensive tests
- `src/features/inventory/components/ItemCard.tsx` - Display missing quantity
- `src/features/inventory/components/ItemCard.module.css` - Styling for missing quantity
- `src/features/inventory/components/ItemList.tsx` - Pass allItems to ItemCard
- `public/locales/en/common.json` - Added translation key
- `public/locales/fi/common.json` - Added translation key

## Test plan
- [x] All tests pass (53 tests in status.test.ts, 20 tests in ItemCard.test.tsx)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes

## Examples
- Rope: 1 meter + 2 meters → Both show "7 meters missing" (10 - 3 = 7)
- Toilet paper: 1 roll → Shows "2 rolls missing" (3 - 1 = 2)
- Only shows when status is warning/critical due to quantity (not expiration)