### PR TITLE
test: add household configuration to fix flaky ShoppingListExport tests

### DIFF
--- a/src/features/settings/components/ShoppingListExport.test.tsx
+++ b/src/features/settings/components/ShoppingListExport.test.tsx
@@ -78,7 +78,15 @@ describe('ShoppingListExport', () => {
     });
 
     renderWithProviders(<ShoppingListExport />, {
-      initialAppData: { items: [itemNeedingRestock] },
+      initialAppData: {
+        items: [itemNeedingRestock],
+        household: {
+          adults: 1,
+          children: 0,
+          supplyDurationDays: 3,
+          useFreezer: false,
+        },
+      },
     });
 
     const button = screen.getByText('settings.shoppingList.button');
@@ -102,7 +110,15 @@ describe('ShoppingListExport', () => {
     ];
 
     renderWithProviders(<ShoppingListExport />, {
-      initialAppData: { items },
+      initialAppData: {
+        items,
+        household: {
+          adults: 2,
+          children: 0,
+          supplyDurationDays: 3,
+          useFreezer: false,
+        },
+      },
     });
 
     expect(
@@ -141,7 +157,15 @@ describe('ShoppingListExport', () => {
     });
 
     renderWithProviders(<ShoppingListExport />, {
-      initialAppData: { items: [itemNeedingRestock] },
+      initialAppData: {
+        items: [itemNeedingRestock],
+        household: {
+          adults: 1,
+          children: 0,
+          supplyDurationDays: 3,
+          useFreezer: false,
+        },
+      },
     });
 
     const button = screen.getByText('settings.shoppingList.button');
@@ -164,7 +188,15 @@ describe('ShoppingListExport', () => {
     });
 
     renderWithProviders(<ShoppingListExport />, {
-      initialAppData: { items: [itemNeedingRestock] },
+      initialAppData: {
+        items: [itemNeedingRestock],
+        household: {
+          adults: 1,
+          children: 0,
+          supplyDurationDays: 3,
+          useFreezer: false,
+        },
+      },
     });
 
     const button = screen.getByText('settings.shoppingList.button');


### PR DESCRIPTION
- Add explicit household config to 4 tests that were flaky
- Tests now use deterministic household values instead of random defaults
- Ensures consistent recommended quantity calculations
- Fixes: should enable button when items need restocking
- Fixes: should show count of items needing restock
- Fixes: should export shopping list when button is clicked
- Fixes: should create blob with text content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to include comprehensive household data, improving test coverage and reliability for the ShoppingListExport component without affecting end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->