### PR TITLE
fix: return 0 missing quantity when item marked as enough

### DIFF
--- a/src/features/inventory/utils/status.test.ts
+++ b/src/features/inventory/utils/status.test.ts
@@ -474,7 +474,7 @@ describe('calculateMissingQuantity', () => {
       expect(missing1).toBe(missing2);
     });
 
-    it('excludes items marked as enough from calculation', () => {
+    it('returns 0 when any matching item is marked as enough', () => {
       const item1 = createMockInventoryItem({
         ...baseItem,
         id: createItemId('1'),
@@ -485,14 +485,14 @@ describe('calculateMissingQuantity', () => {
         ...baseItem,
         id: createItemId('2'),
         quantity: 1,
-        markedAsEnough: true, // This should be excluded
+        markedAsEnough: true, // This marks the item type as enough
       });
       const allItems = [item1, item2];
 
-      // Only item1 counts: 2, recommended: 10, missing: 8
+      // When any item is marked as enough, there's no shortage
       expect(
         calculateTotalMissingQuantity(item1, allItems, baseRecommendedQuantity),
-      ).toBe(8);
+      ).toBe(0);
     });
 
     it('returns 0 when total quantity meets recommendation', () => {

--- a/src/features/inventory/utils/status.ts
+++ b/src/features/inventory/utils/status.ts
@@ -264,10 +264,14 @@ export function calculateTotalMissingQuantity(
     return 0;
   }
 
-  // Calculate total actual quantity (excluding items marked as enough)
-  const totalActual = matchingItems
-    .filter((i) => !i.markedAsEnough)
-    .reduce((sum, i) => sum + i.quantity, 0);
+  // If any matching item is marked as enough, treat as no shortage
+  const hasMarkedAsEnough = matchingItems.some((i) => i.markedAsEnough);
+  if (hasMarkedAsEnough) {
+    return 0;
+  }
+
+  // Calculate total actual quantity
+  const totalActual = matchingItems.reduce((sum, i) => sum + i.quantity, 0);
 
   // Check if the total has a quantity shortage (not expiration)
   // A shortage exists if:


### PR DESCRIPTION
## Summary
- Fix incorrect missing quantity display when an item is marked as "enough"
- Previously showed the full recommended amount as missing instead of 0

## Changes
- Add early return in `calculateTotalMissingQuantity()` when any matching item is marked as enough
- Update test to verify the correct behavior (return 0, not exclude from quantity sum)

## Test plan
- [x] All tests pass
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inventory shortage calculation to properly reflect when items are marked as sufficient, ensuring the total missing quantity is accurately reported when any matching item has adequate stock.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->