### PR TITLE
fix: clear all data now removes debug logs and analytics

### DIFF
--- a/src/features/settings/components/ClearDataButton.test.tsx
+++ b/src/features/settings/components/ClearDataButton.test.tsx
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ClearDataButton } from './ClearDataButton';
 import * as localStorage from '@/shared/utils/storage/localStorage';
+import * as errorLoggerStorage from '@/shared/utils/errorLogger/storage';
+import * as analyticsStorage from '@/shared/utils/analytics/storage';
 
 // Mock localStorage utilities
 vi.mock('@/shared/utils/storage/localStorage');
+vi.mock('@/shared/utils/errorLogger/storage');
+vi.mock('@/shared/utils/analytics/storage');
 
 // Store original console.error to restore later
 const originalConsoleError = console.error;
@@ -43,6 +47,8 @@ describe('ClearDataButton', () => {
 
     expect(globalThis.confirm).toHaveBeenCalledTimes(1);
     expect(localStorage.clearAppData).not.toHaveBeenCalled();
+    expect(errorLoggerStorage.clearErrorLogs).not.toHaveBeenCalled();
+    expect(analyticsStorage.clearAnalyticsData).not.toHaveBeenCalled();
   });
 
   it('should not clear data if second confirmation is cancelled', () => {
@@ -58,6 +64,8 @@ describe('ClearDataButton', () => {
 
     expect(globalThis.confirm).toHaveBeenCalledTimes(2);
     expect(localStorage.clearAppData).not.toHaveBeenCalled();
+    expect(errorLoggerStorage.clearErrorLogs).not.toHaveBeenCalled();
+    expect(analyticsStorage.clearAnalyticsData).not.toHaveBeenCalled();
   });
 
   it('should clear data when both confirmations are accepted', () => {
@@ -72,6 +80,8 @@ describe('ClearDataButton', () => {
 
     expect(globalThis.confirm).toHaveBeenCalledTimes(2);
     expect(localStorage.clearAppData).toHaveBeenCalled();
+    expect(errorLoggerStorage.clearErrorLogs).toHaveBeenCalled();
+    expect(analyticsStorage.clearAnalyticsData).toHaveBeenCalled();
     expect(globalThis.alert).toHaveBeenCalledWith('settings.clearData.success');
     // window.location.reload should be called
     expect(reloadSpy).toHaveBeenCalled();

--- a/src/features/settings/components/ClearDataButton.tsx
+++ b/src/features/settings/components/ClearDataButton.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/components/Button';
 import { clearAppData } from '@/shared/utils/storage/localStorage';
+import { clearErrorLogs } from '@/shared/utils/errorLogger/storage';
+import { clearAnalyticsData } from '@/shared/utils/analytics/storage';
 import styles from './ClearDataButton.module.css';
 
 export function ClearDataButton() {
@@ -10,6 +12,8 @@ export function ClearDataButton() {
     if (window.confirm(t('settings.clearData.confirmMessage'))) {
       if (window.confirm(t('settings.clearData.confirmAgain'))) {
         clearAppData();
+        clearErrorLogs();
+        clearAnalyticsData();
         alert(t('settings.clearData.success'));
         // Reload to reset to default state
         window.location.reload();


### PR DESCRIPTION
## Summary

- ClearDataButton now also clears error logs and analytics data when user confirms "Clear All Data"
- Previously only the main app data was cleared, leaving debug logs and analytics behind

## Changes

- `ClearDataButton.tsx`: Added calls to `clearErrorLogs()` and `clearAnalyticsData()` alongside existing `clearAppData()`
- `ClearDataButton.test.tsx`: Updated tests to verify all three clear functions are called

## Architecture Note

The clear functions are called directly from the UI component rather than having `clearAppData()` depend on error logger and analytics modules. This keeps proper dependency direction (UI → features, not core → features).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Clear Data function to also remove error logs and analytics data in addition to existing app data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->