### PR TITLE
feat: add theme selector to welcome screen

### DIFF
--- a/src/features/onboarding/components/WelcomeScreen.module.css
+++ b/src/features/onboarding/components/WelcomeScreen.module.css
@@ -65,8 +65,14 @@
   margin: 0;
 }
 
-.languageSection {
+.preferencesSection {
+  display: flex;
+  gap: var(--spacing-md);
   margin-bottom: var(--spacing-xl);
+}
+
+.preferencesSection > * {
+  flex: 1;
 }
 
 .sellingPoints {
@@ -175,5 +181,9 @@
 
   .sellingPoints {
     grid-template-columns: 1fr;
+  }
+
+  .preferencesSection {
+    flex-direction: column;
   }
 }

--- a/src/features/onboarding/components/WelcomeScreen.test.tsx
+++ b/src/features/onboarding/components/WelcomeScreen.test.tsx
@@ -13,6 +13,15 @@ vi.mock('react-i18next', () => ({
         'settings.language.label': 'Language',
         'settings.language.option.en': '🇬🇧 English',
         'settings.language.option.fi': '🇫🇮 Suomi',
+        'settings.theme.label': 'Theme',
+        'settings.theme.light': 'Light',
+        'settings.theme.dark': 'Dark',
+        'settings.theme.midnight': 'Midnight',
+        'settings.theme.ocean': 'Ocean',
+        'settings.theme.sunset': 'Sunset',
+        'settings.theme.forest': 'Forest',
+        'settings.theme.lavender': 'Lavender',
+        'settings.theme.minimal': 'Minimal',
         'landing.getStarted': 'Get Started',
         'landing.noSignup.title': 'No Signup Required',
         'landing.noSignup.description': 'Start using immediately',
@@ -42,7 +51,7 @@ const mockUpdateSettings = vi.fn();
 
 vi.mock('@/features/settings', () => ({
   useSettings: () => ({
-    settings: { language: 'en' },
+    settings: { language: 'en', theme: 'ocean' },
     updateSettings: mockUpdateSettings,
   }),
 }));
@@ -63,7 +72,7 @@ describe('WelcomeScreen', () => {
     render(<WelcomeScreen onContinue={onContinue} />);
 
     expect(screen.getByLabelText('Language')).toBeInTheDocument();
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getAllByRole('combobox')).toHaveLength(2);
   });
 
   it('renders feature highlights', () => {
@@ -117,10 +126,51 @@ describe('WelcomeScreen', () => {
     const onContinue = vi.fn();
     render(<WelcomeScreen onContinue={onContinue} />);
 
-    const languageSelect = screen.getByRole('combobox');
+    const languageSelect = screen.getByLabelText('Language');
     await user.selectOptions(languageSelect, 'fi');
 
     // The handleLanguageChange function should call updateSettings
     expect(mockUpdateSettings).toHaveBeenCalledWith({ language: 'fi' });
+  });
+
+  it('renders theme selector', () => {
+    const onContinue = vi.fn();
+    render(<WelcomeScreen onContinue={onContinue} />);
+
+    expect(screen.getByLabelText('Theme')).toBeInTheDocument();
+  });
+
+  it('renders theme options', () => {
+    const onContinue = vi.fn();
+    render(<WelcomeScreen onContinue={onContinue} />);
+
+    const themeSelect = screen.getByLabelText('Theme');
+    expect(themeSelect).toBeInTheDocument();
+
+    // Check that theme options are available
+    expect(screen.getByRole('option', { name: 'Light' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Dark' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Ocean' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Midnight' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Sunset' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Forest' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Lavender' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Minimal' })).toBeInTheDocument();
+  });
+
+  it('calls updateSettings when theme selector is changed', async () => {
+    mockUpdateSettings.mockClear();
+    const user = userEvent.setup();
+    const onContinue = vi.fn();
+    render(<WelcomeScreen onContinue={onContinue} />);
+
+    const themeSelect = screen.getByLabelText('Theme');
+    await user.selectOptions(themeSelect, 'dark');
+
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ theme: 'dark' });
   });
 });

--- a/src/features/onboarding/components/WelcomeScreen.tsx
+++ b/src/features/onboarding/components/WelcomeScreen.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/components/Button';
 import { Select } from '@/shared/components/Select';
 import { useSettings } from '@/features/settings';
+import { SELECTABLE_THEMES, type Theme } from '@/shared/types';
 import styles from './WelcomeScreen.module.css';
 
 export interface WelcomeScreenProps {
@@ -22,6 +23,12 @@ export function WelcomeScreen({ onContinue }: WelcomeScreenProps) {
     });
   };
 
+  const handleThemeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const theme = event.target.value as Theme;
+    updateSettings({ theme });
+    document.documentElement.dataset.theme = theme;
+  };
+
   return (
     <main className={styles.container} data-testid="onboarding-welcome">
       <div className={styles.content}>
@@ -30,10 +37,7 @@ export function WelcomeScreen({ onContinue }: WelcomeScreenProps) {
           <p className={styles.tagline}>{t('app.tagline')}</p>
         </header>
 
-        <section
-          className={styles.languageSection}
-          aria-labelledby="language-label"
-        >
+        <section className={styles.preferencesSection}>
           <Select
             id="language-select"
             label={t('settings.language.label')}
@@ -43,6 +47,16 @@ export function WelcomeScreen({ onContinue }: WelcomeScreenProps) {
               { value: 'en', label: t('settings.language.option.en') },
               { value: 'fi', label: t('settings.language.option.fi') },
             ]}
+          />
+          <Select
+            id="theme-select"
+            label={t('settings.theme.label')}
+            value={settings.theme}
+            onChange={handleThemeChange}
+            options={SELECTABLE_THEMES.map((theme) => ({
+              value: theme,
+              label: t(`settings.theme.${theme}`),
+            }))}
           />
         </section>
 

--- a/src/features/settings/components/ThemeSelector.tsx
+++ b/src/features/settings/components/ThemeSelector.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useSettings } from '@/features/settings';
+import { SELECTABLE_THEMES } from '@/shared/types';
 import styles from './ThemeSelector.module.css';
 
 export function ThemeSelector() {
@@ -37,14 +38,11 @@ export function ThemeSelector() {
         onChange={handleThemeChange}
         className={styles.select}
       >
-        <option value="light">{t('settings.theme.light')}</option>
-        <option value="dark">{t('settings.theme.dark')}</option>
-        <option value="midnight">{t('settings.theme.midnight')}</option>
-        <option value="ocean">{t('settings.theme.ocean')}</option>
-        <option value="sunset">{t('settings.theme.sunset')}</option>
-        <option value="forest">{t('settings.theme.forest')}</option>
-        <option value="lavender">{t('settings.theme.lavender')}</option>
-        <option value="minimal">{t('settings.theme.minimal')}</option>
+        {SELECTABLE_THEMES.map((theme) => (
+          <option key={theme} value={theme}>
+            {t(`settings.theme.${theme}`)}
+          </option>
+        ))}
       </select>
       <p className={styles.description}>{t('settings.theme.description')}</p>
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -96,6 +96,18 @@ export const VALID_THEMES = [
 
 export type Theme = (typeof VALID_THEMES)[number];
 
+/** Themes available for user selection (excludes 'auto') */
+export const SELECTABLE_THEMES = [
+  'light',
+  'dark',
+  'midnight',
+  'ocean',
+  'sunset',
+  'forest',
+  'lavender',
+  'minimal',
+] as const satisfies readonly Theme[];
+
 export interface UserSettings {
   language: 'en' | 'fi';
   theme: Theme;


### PR DESCRIPTION
## Summary
- Allow users to select their preferred theme during onboarding
- Create shared `SELECTABLE_THEMES` constant to eliminate duplication
- Theme selection persists and applies immediately

## Changes
**WelcomeScreen component:**
- Added theme selector dropdown next to language selector
- New `preferencesSection` layout groups both selectors
- Responsive design: side-by-side on desktop, stacked on mobile

**Shared types:**
- Added `SELECTABLE_THEMES` constant (excludes 'auto' theme)
- Both WelcomeScreen and ThemeSelector now use this shared constant

**Tests:**
- Added tests for theme selector rendering
- Added test for theme option availability
- Added test for theme change interaction

## Test plan
- [x] All tests pass
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme customization added to onboarding—users can pick from multiple named themes alongside language during setup.

* **Refactor**
  * Onboarding layout updated so language and theme controls are presented together with responsive behavior.
  * Theme selector now renders available theme options dynamically.

* **Tests**
  * Tests updated/added to cover the new theme selector and its behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->