### PR TITLE
fix: position dashboard alert dismiss button in top right corner

### DIFF
--- a/src/features/alerts/components/AlertBanner.module.css
+++ b/src/features/alerts/components/AlertBanner.module.css
@@ -17,7 +17,7 @@
 
 .alert {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   padding: var(--spacing-md);
   border-radius: var(--radius-md);
@@ -26,6 +26,7 @@
   border: 1px solid var(--color-border);
   border-left-width: 4px;
   border-left-style: solid;
+  position: relative;
 }
 
 .alertCritical {
@@ -54,9 +55,10 @@
 
 .content {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--spacing-md);
   flex: 1;
+  padding-right: var(--spacing-sm);
 }
 
 .icon {
@@ -106,9 +108,16 @@
     flex-direction: column;
     align-items: flex-start;
     gap: var(--spacing-sm);
+    padding-right: calc(2rem + var(--spacing-md));
   }
 
   .dismissButton {
-    align-self: flex-end;
+    position: absolute;
+    top: var(--spacing-sm);
+    right: var(--spacing-sm);
+  }
+
+  .content {
+    padding-right: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Positions the dismiss button (✕) in the top right corner of dashboard alerts on both desktop and mobile viewports
- Changes flex alignment from `center` to `flex-start` to align content to top
- Uses absolute positioning for the dismiss button on mobile screens

Fixes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined alert banner content alignment and spacing for improved visual layout.
  * Enhanced responsive design behavior on mobile devices with optimized dismiss button positioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->