### PR TITLE
fix: default pet amount 0 for family preset and consolidate household presets

### DIFF
--- a/e2e/pets.spec.ts
+++ b/e2e/pets.spec.ts
@@ -38,7 +38,7 @@ test.describe('Pet Support', () => {
       await expect(petsInput).toHaveValue('2');
     });
 
-    test('should set pets to 1 when selecting family preset', async ({
+    test('should set pets to 0 when selecting family preset', async ({
       page,
     }) => {
       await page.getByTestId('nav-settings').click();
@@ -47,9 +47,9 @@ test.describe('Pet Support', () => {
       // Click family preset
       await page.getByTestId('preset-family').click();
 
-      // Pets should be set to 1
+      // Pets should be set to 0
       const petsInput = page.locator('#pets');
-      await expect(petsInput).toHaveValue('1');
+      await expect(petsInput).toHaveValue('0');
     });
 
     test('should set pets to 0 when selecting single preset', async ({
@@ -296,8 +296,8 @@ test.describe('Pet Support', () => {
       const petsInput = page.locator('#pets');
       await expect(petsInput).toBeVisible();
 
-      // Family preset sets pets to 1
-      await expect(petsInput).toHaveValue('1');
+      // Family preset sets pets to 0
+      await expect(petsInput).toHaveValue('0');
 
       // Set pets to 2
       await petsInput.fill('2');

--- a/src/features/household/factories/HouseholdConfigFactory.test.ts
+++ b/src/features/household/factories/HouseholdConfigFactory.test.ts
@@ -301,7 +301,7 @@ describe('HouseholdConfigFactory', () => {
 
       expect(config.adults).toBe(2);
       expect(config.children).toBe(2);
-      expect(config.pets).toBe(1);
+      expect(config.pets).toBe(0);
       expect(config.supplyDurationDays).toBe(3);
       expect(config.useFreezer).toBe(true);
     });

--- a/src/features/household/factories/HouseholdConfigFactory.ts
+++ b/src/features/household/factories/HouseholdConfigFactory.ts
@@ -1,15 +1,11 @@
 import type { HouseholdConfig } from '@/shared/types';
+import { HOUSEHOLD_PRESETS, type HouseholdPreset } from '../presets';
 import { HOUSEHOLD_LIMITS } from '../constants';
 
 /**
  * Input for creating a household configuration.
  */
 export type CreateHouseholdConfigInput = HouseholdConfig;
-
-/**
- * Options for creating household config from preset.
- */
-export type HouseholdPreset = 'single' | 'couple' | 'family';
 
 /**
  * Validation error thrown when household config creation fails validation.
@@ -116,31 +112,7 @@ export class HouseholdConfigFactory {
    * @returns HouseholdConfig for the preset
    */
   static createFromPreset(preset: HouseholdPreset): HouseholdConfig {
-    const presets: Record<HouseholdPreset, HouseholdConfig> = {
-      single: {
-        adults: 1,
-        children: 0,
-        pets: 0,
-        supplyDurationDays: 3,
-        useFreezer: false,
-      },
-      couple: {
-        adults: 2,
-        children: 0,
-        pets: 0,
-        supplyDurationDays: 3,
-        useFreezer: true,
-      },
-      family: {
-        adults: 2,
-        children: 2,
-        pets: 1,
-        supplyDurationDays: 3,
-        useFreezer: true,
-      },
-    };
-
-    return this.create(presets[preset]);
+    return this.create(HOUSEHOLD_PRESETS[preset]);
   }
 
   /**

--- a/src/features/household/index.ts
+++ b/src/features/household/index.ts
@@ -8,13 +8,12 @@ export { useHousehold } from './hooks';
 
 // Constants
 export { HOUSEHOLD_DEFAULTS, HOUSEHOLD_LIMITS } from './constants';
+export { HOUSEHOLD_PRESETS } from './presets';
+export type { HouseholdPreset } from './presets';
 
 // Factories
 export {
   HouseholdConfigFactory,
   HouseholdConfigValidationError,
 } from './factories/HouseholdConfigFactory';
-export type {
-  CreateHouseholdConfigInput,
-  HouseholdPreset,
-} from './factories/HouseholdConfigFactory';
+export type { CreateHouseholdConfigInput } from './factories/HouseholdConfigFactory';

--- a/src/features/household/presets.ts
+++ b/src/features/household/presets.ts
@@ -1,0 +1,32 @@
+import type { HouseholdConfig } from '@/shared/types';
+
+/** Preset identifier for single, couple, or family. */
+export type HouseholdPreset = 'single' | 'couple' | 'family';
+
+/**
+ * Full household configuration for each preset.
+ * Single source of truth for onboarding, settings, and HouseholdConfigFactory.
+ */
+export const HOUSEHOLD_PRESETS: Record<HouseholdPreset, HouseholdConfig> = {
+  single: {
+    adults: 1,
+    children: 0,
+    pets: 0,
+    supplyDurationDays: 3,
+    useFreezer: false,
+  },
+  couple: {
+    adults: 2,
+    children: 0,
+    pets: 0,
+    supplyDurationDays: 3,
+    useFreezer: true,
+  },
+  family: {
+    adults: 2,
+    children: 2,
+    pets: 0,
+    supplyDurationDays: 3,
+    useFreezer: true,
+  },
+};

--- a/src/features/household/provider.tsx
+++ b/src/features/household/provider.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import type { HouseholdConfig } from '@/shared/types';
 import { useLocalStorageSync } from '@/shared/hooks';
 import { HouseholdContext } from './context';
+import { HOUSEHOLD_PRESETS } from './presets';
 
 const DEFAULT_HOUSEHOLD: HouseholdConfig = {
   adults: 2,
@@ -9,33 +10,6 @@ const DEFAULT_HOUSEHOLD: HouseholdConfig = {
   pets: 0,
   supplyDurationDays: 3,
   useFreezer: false,
-};
-
-const HOUSEHOLD_PRESETS: Record<
-  'single' | 'couple' | 'family',
-  HouseholdConfig
-> = {
-  single: {
-    adults: 1,
-    children: 0,
-    pets: 0,
-    supplyDurationDays: 3,
-    useFreezer: false,
-  },
-  couple: {
-    adults: 2,
-    children: 0,
-    pets: 0,
-    supplyDurationDays: 3,
-    useFreezer: true,
-  },
-  family: {
-    adults: 2,
-    children: 2,
-    pets: 1,
-    supplyDurationDays: 3,
-    useFreezer: true,
-  },
 };
 
 export function HouseholdProvider({ children }: { children: ReactNode }) {

--- a/src/features/onboarding/components/HouseholdPresetSelector.test.tsx
+++ b/src/features/onboarding/components/HouseholdPresetSelector.test.tsx
@@ -176,7 +176,7 @@ describe('HouseholdPresetSelector', () => {
       id: 'family',
       adults: 2,
       children: 2,
-      pets: 1,
+      pets: 0,
     });
   });
 

--- a/src/features/onboarding/components/HouseholdPresetSelector.tsx
+++ b/src/features/onboarding/components/HouseholdPresetSelector.tsx
@@ -2,6 +2,8 @@ import { useTranslation } from 'react-i18next';
 import { Card } from '@/shared/components/Card';
 import { Button } from '@/shared/components/Button';
 import { useImportData } from '@/shared/hooks';
+import { HOUSEHOLD_PRESETS } from '@/features/household';
+import type { HouseholdPreset as HouseholdPresetId } from '@/features/household';
 import styles from './HouseholdPresetSelector.module.css';
 
 export interface HouseholdPreset {
@@ -17,11 +19,14 @@ export interface HouseholdPresetSelectorProps {
   onBack?: () => void;
 }
 
-const PRESETS: HouseholdPreset[] = [
-  { id: 'single', adults: 1, children: 0, pets: 0 },
-  { id: 'couple', adults: 2, children: 0, pets: 0 },
-  { id: 'family', adults: 2, children: 2, pets: 1 },
-];
+const PRESET_IDS: HouseholdPresetId[] = ['single', 'couple', 'family'];
+
+const PRESETS: HouseholdPreset[] = PRESET_IDS.map((id) => ({
+  id,
+  adults: HOUSEHOLD_PRESETS[id].adults,
+  children: HOUSEHOLD_PRESETS[id].children,
+  pets: HOUSEHOLD_PRESETS[id].pets,
+}));
 
 export function HouseholdPresetSelector({
   selectedPreset,

--- a/src/features/onboarding/components/Onboarding.tsx
+++ b/src/features/onboarding/components/Onboarding.tsx
@@ -9,8 +9,30 @@ import { QuickSetupScreen } from './QuickSetupScreen';
 import type { HouseholdConfig, InventoryItem } from '@/shared/types';
 import type { HouseholdPreset } from './HouseholdPresetSelector';
 import { useRecommendedItems } from '@/features/templates';
-import { HOUSEHOLD_DEFAULTS } from '@/features/household';
+import { HOUSEHOLD_DEFAULTS, HOUSEHOLD_PRESETS } from '@/features/household';
 import { InventoryItemFactory } from '@/features/inventory/factories/InventoryItemFactory';
+
+function getHouseholdInitialData(
+  preset: HouseholdPreset,
+): Partial<HouseholdData> {
+  if (preset.id === 'custom') {
+    return {
+      adults: preset.adults,
+      children: preset.children,
+      pets: preset.pets,
+      supplyDays: HOUSEHOLD_DEFAULTS.supplyDays,
+      useFreezer: HOUSEHOLD_DEFAULTS.useFreezer,
+    };
+  }
+  const p = HOUSEHOLD_PRESETS[preset.id];
+  return {
+    adults: p.adults,
+    children: p.children,
+    pets: p.pets,
+    supplyDays: p.supplyDurationDays,
+    useFreezer: p.useFreezer,
+  };
+}
 
 export interface OnboardingProps {
   onComplete: (household: HouseholdConfig, items: InventoryItem[]) => void;
@@ -123,15 +145,7 @@ export const Onboarding = ({ onComplete }: OnboardingProps) => {
       {currentStep === 'household' && (
         <HouseholdForm
           initialData={
-            selectedPreset
-              ? {
-                  adults: selectedPreset.adults,
-                  children: selectedPreset.children,
-                  pets: selectedPreset.pets,
-                  supplyDays: HOUSEHOLD_DEFAULTS.supplyDays,
-                  useFreezer: HOUSEHOLD_DEFAULTS.useFreezer,
-                }
-              : undefined
+            selectedPreset ? getHouseholdInitialData(selectedPreset) : undefined
           }
           onSubmit={handleHouseholdSubmit}
           onBack={() => setCurrentStep('preset')}

--- a/src/features/settings/components/HouseholdForm.test.tsx
+++ b/src/features/settings/components/HouseholdForm.test.tsx
@@ -152,7 +152,7 @@ describe('HouseholdForm', () => {
     ) as HTMLInputElement;
     expect(adultsInput.value).toBe('2');
     expect(childrenInput.value).toBe('2');
-    expect(petsInput.value).toBe('1');
+    expect(petsInput.value).toBe('0');
   });
 
   it('should update children value', () => {


### PR DESCRIPTION
## Summary

- **Default pet amount**: Family preset and onboarding now default pets to **0** (was 1) in all places: onboarding HouseholdPresetSelector, settings preset buttons (via HouseholdProvider), and HouseholdConfigFactory.
- **Consolidated household presets**: Single source of truth in `household/presets.ts` (`HOUSEHOLD_PRESETS`). Provider, HouseholdConfigFactory, HouseholdPresetSelector, and Onboarding use it. Onboarding now uses the preset’s `supplyDurationDays` and `useFreezer` when a preset is selected (previously used `HOUSEHOLD_DEFAULTS`), so behavior matches settings.

## Changes

**New**
- `src/features/household/presets.ts` – `HouseholdPreset` type and `HOUSEHOLD_PRESETS` (single, couple, family)

**Household**
- `provider.tsx`: use `HOUSEHOLD_PRESETS` from `./presets` instead of local copy
- `HouseholdConfigFactory.ts`: `createFromPreset` uses `HOUSEHOLD_PRESETS`; import `HouseholdPreset` from `presets`
- `index.ts`: export `HOUSEHOLD_PRESETS` and `HouseholdPreset` from `presets`

**Onboarding**
- `HouseholdPresetSelector.tsx`: build `PRESETS` from `HOUSEHOLD_PRESETS`
- `Onboarding.tsx`: `getHouseholdInitialData` uses `HOUSEHOLD_PRESETS` for single/couple/family (supplyDays, useFreezer from preset); `HOUSEHOLD_DEFAULTS` only for custom

**Settings**
- `HouseholdForm.test.tsx`: expect pets `0` when family preset is applied (was 1)

**Tests / E2E**
- `HouseholdConfigFactory.test.ts`: family preset `pets` expectation set to 0
- `HouseholdPresetSelector.test.tsx`: family preset `pets` expectation set to 0
- `e2e/pets.spec.ts`: family-preset test expects `0`; onboarding flow expects family preset to prefill `0` before user edits

## Test plan

- [x] All tests pass (`npm run test`)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Family preset now correctly initializes pet count to 0 instead of 1. This affects household configuration when the Family preset is selected during onboarding or in settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->