### PR TITLE
feat: add dismiss all alerts on dashboard

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -84,7 +84,8 @@
     "export": "Export",
     "import": "Import",
     "clear": "Clear",
-    "dismiss": "Dismiss"
+    "dismiss": "Dismiss",
+    "dismissAll": "Dismiss all"
   },
   "status": {
     "ok": "OK",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -84,7 +84,8 @@
     "export": "Vie",
     "import": "Tuo",
     "clear": "Tyhjennä",
-    "dismiss": "Hylkää"
+    "dismiss": "Hylkää",
+    "dismissAll": "Hylkää kaikki"
   },
   "status": {
     "ok": "OK",

--- a/src/features/alerts/components/AlertBanner.module.css
+++ b/src/features/alerts/components/AlertBanner.module.css
@@ -2,11 +2,41 @@
   margin-bottom: var(--spacing-xl);
 }
 
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
 .title {
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);
   color: var(--color-text);
-  margin: 0 0 var(--spacing-md) 0;
+  margin: 0;
+}
+
+.dismissAllButton {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition-base);
+  flex-shrink: 0;
+}
+
+.dismissAllButton:hover {
+  background-color: var(--color-primary-light);
+  color: var(--color-primary);
+}
+
+.dismissAllButton:focus-visible {
+  outline: var(--focus-ring-width) solid var(--color-focus);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .alerts {

--- a/src/features/alerts/components/AlertBanner.test.tsx
+++ b/src/features/alerts/components/AlertBanner.test.tsx
@@ -11,6 +11,7 @@ vi.mock('react-i18next', () => ({
       const translations: Record<string, string> = {
         'dashboard.alerts.title': 'Alerts',
         'actions.dismiss': 'Dismiss',
+        'actions.dismissAll': 'Dismiss all',
       };
       return translations[key] || key;
     },
@@ -119,5 +120,63 @@ describe('AlertBanner', () => {
     );
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders Dismiss all button when onDismissAll is provided', () => {
+    render(
+      <AlertBanner
+        alerts={[
+          { id: createAlertId('1'), type: 'warning', message: 'Alert 1' },
+          { id: createAlertId('2'), type: 'info', message: 'Alert 2' },
+        ]}
+        onDismiss={vi.fn()}
+        onDismissAll={vi.fn()}
+      />,
+    );
+
+    const dismissAllButton = screen.getByRole('button', {
+      name: 'Dismiss all',
+    });
+    expect(dismissAllButton).toBeInTheDocument();
+    expect(dismissAllButton).toHaveAttribute(
+      'data-testid',
+      'dismiss-all-alerts',
+    );
+  });
+
+  it('calls onDismissAll when Dismiss all button is clicked', async () => {
+    const user = userEvent.setup();
+    const onDismissAll = vi.fn();
+
+    render(
+      <AlertBanner
+        alerts={[
+          { id: createAlertId('1'), type: 'warning', message: 'Alert 1' },
+          { id: createAlertId('2'), type: 'info', message: 'Alert 2' },
+        ]}
+        onDismiss={vi.fn()}
+        onDismissAll={onDismissAll}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss all' }));
+
+    expect(onDismissAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render Dismiss all button when onDismissAll is not provided', () => {
+    render(
+      <AlertBanner
+        alerts={[
+          { id: createAlertId('1'), type: 'warning', message: 'Alert 1' },
+          { id: createAlertId('2'), type: 'info', message: 'Alert 2' },
+        ]}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Dismiss all' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/alerts/components/AlertBanner.tsx
+++ b/src/features/alerts/components/AlertBanner.tsx
@@ -6,6 +6,7 @@ import styles from './AlertBanner.module.css';
 export interface AlertBannerProps {
   alerts: Alert[];
   onDismiss?: (alertId: string) => void;
+  onDismissAll?: () => void;
 }
 
 const AlertIcon = ({ type }: { type: AlertType }): ReactNode => {
@@ -28,7 +29,11 @@ const getAlertTypeClassName = (type: AlertType): string => {
   return typeClassMap[type];
 };
 
-export const AlertBanner = ({ alerts, onDismiss }: AlertBannerProps) => {
+export const AlertBanner = ({
+  alerts,
+  onDismiss,
+  onDismissAll,
+}: AlertBannerProps) => {
   const { t } = useTranslation();
 
   if (alerts.length === 0) {
@@ -37,7 +42,20 @@ export const AlertBanner = ({ alerts, onDismiss }: AlertBannerProps) => {
 
   return (
     <div className={styles.container} data-testid="alerts-section">
-      <h2 className={styles.title}>{t('dashboard.alerts.title')}</h2>
+      <div className={styles.header}>
+        <h2 className={styles.title}>{t('dashboard.alerts.title')}</h2>
+        {onDismissAll && (
+          <button
+            type="button"
+            className={styles.dismissAllButton}
+            onClick={onDismissAll}
+            data-testid="dismiss-all-alerts"
+            aria-label={t('actions.dismissAll')}
+          >
+            {t('actions.dismissAll')}
+          </button>
+        )}
+      </div>
       <div className={styles.alerts}>
         {alerts.map((alert) => (
           <div

--- a/src/features/dashboard/hooks/useDashboardAlerts.test.ts
+++ b/src/features/dashboard/hooks/useDashboardAlerts.test.ts
@@ -227,6 +227,43 @@ describe('useDashboardAlerts', () => {
     expect(mockDismissBackupReminder).toHaveBeenCalled();
   });
 
+  it('should handle dismissing all alerts', () => {
+    const alert1 = createAlertId('alert-1');
+    const alert2 = createAlertId('alert-2');
+    const mockAlerts = [
+      { id: alert1, type: 'warning' as const, message: 'Alert 1' },
+      { id: alert2, type: 'critical' as const, message: 'Alert 2' },
+    ];
+    vi.mocked(generateDashboardAlerts).mockReturnValue(mockAlerts);
+
+    const { result } = renderHook(() => useDashboardAlerts());
+
+    act(() => {
+      result.current.handleDismissAllAlerts();
+    });
+
+    expect(mockDismissAlert).toHaveBeenCalledWith(alert1);
+    expect(mockDismissAlert).toHaveBeenCalledWith(alert2);
+    expect(mockDismissAlert).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle dismiss all including backup reminder', () => {
+    mockShouldShowBackupReminder.mockReturnValue(true);
+    const alert1 = createAlertId('alert-1');
+    vi.mocked(generateDashboardAlerts).mockReturnValue([
+      { id: alert1, type: 'warning' as const, message: 'Alert 1' },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAlerts());
+
+    act(() => {
+      result.current.handleDismissAllAlerts();
+    });
+
+    expect(mockDismissBackupReminder).toHaveBeenCalled();
+    expect(mockDismissAlert).toHaveBeenCalledWith(alert1);
+  });
+
   it('should handle showing all alerts', () => {
     const { result } = renderHook(() => useDashboardAlerts());
 

--- a/src/features/dashboard/hooks/useDashboardAlerts.ts
+++ b/src/features/dashboard/hooks/useDashboardAlerts.ts
@@ -14,6 +14,7 @@ export interface UseDashboardAlertsResult {
   activeAlerts: Alert[];
   hiddenAlertsCount: number;
   handleDismissAlert: (alertId: AlertId) => void;
+  handleDismissAllAlerts: () => void;
   handleShowAllAlerts: () => void;
 }
 
@@ -92,6 +93,10 @@ export function useDashboardAlerts(): UseDashboardAlertsResult {
     [dismissAlert, dismissBackup],
   );
 
+  const handleDismissAllAlerts = useCallback(() => {
+    activeAlerts.forEach((alert) => handleDismissAlert(alert.id));
+  }, [activeAlerts, handleDismissAlert]);
+
   const handleShowAllAlerts = useCallback(() => {
     reactivateAllAlerts();
   }, [reactivateAllAlerts]);
@@ -100,6 +105,7 @@ export function useDashboardAlerts(): UseDashboardAlertsResult {
     activeAlerts,
     hiddenAlertsCount,
     handleDismissAlert,
+    handleDismissAllAlerts,
     handleShowAllAlerts,
   };
 }

--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -35,6 +35,7 @@ export function Dashboard({ onNavigate }: DashboardProps = {}) {
     activeAlerts,
     hiddenAlertsCount,
     handleDismissAlert,
+    handleDismissAllAlerts,
     handleShowAllAlerts,
   } = useDashboardAlerts();
   const { handleExport: handleExportShoppingList } = useShoppingListExport();
@@ -68,7 +69,11 @@ export function Dashboard({ onNavigate }: DashboardProps = {}) {
       {/* Alerts Section */}
       {activeAlerts.length > 0 && (
         <section className={styles.alertsSection}>
-          <AlertBanner alerts={activeAlerts} onDismiss={onDismissAlert} />
+          <AlertBanner
+            alerts={activeAlerts}
+            onDismiss={onDismissAlert}
+            onDismissAll={handleDismissAllAlerts}
+          />
         </section>
       )}
 


### PR DESCRIPTION
## Summary

- Add **Dismiss all** button in the dashboard alerts section so users can hide all visible alerts in one click.
- Button is shown next to the "Alerts" heading when `onDismissAll` is provided.
- Covers both inventory-based alerts and the backup reminder.

## Changes

**Dashboard & hooks**
- `useDashboardAlerts`: added `handleDismissAllAlerts` that calls `handleDismissAlert` for each active alert (inventory + backup reminder).
- `Dashboard`: passes `onDismissAll={handleDismissAllAlerts}` to `AlertBanner`.

**AlertBanner**
- New optional prop `onDismissAll?: () => void`.
- Header row with title and "Dismiss all" button when `onDismissAll` is set.
- `AlertBanner.module.css`: `.header`, `.dismissAllButton` (aligned with "Show all" style).

**i18n**
- `actions.dismissAll`: "Dismiss all" (en), "Hylkää kaikki" (fi).

**Tests**
- `useDashboardAlerts.test.ts`: `handleDismissAllAlerts` for multiple alerts and for backup reminder + inventory alert.
- `AlertBanner.test.tsx`: "Dismiss all" rendered and `onDismissAll` called when provided; not rendered when `onDismissAll` is omitted.

## Test plan

- [x] All tests pass
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Dismiss all" button to the alert banner, allowing users to dismiss all active alerts at once. The button appears alongside existing individual dismiss options and is supported in both English and Finnish locales.

* **Tests**
  * Added comprehensive test coverage for the dismiss all functionality, including button rendering, interaction handling, and conditional display logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->