### PR TITLE
fix: update dashboard title to match app branding

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -369,7 +369,7 @@
     "auto": "Auto"
   },
   "dashboard": {
-    "title": "Emergency Supplies Dashboard",
+    "title": "Emergency Supply Tracker",
     "subtitle": "Tracking supplies for {{people}} people for {{days}} days",
     "alerts": {
       "title": "Alerts"

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -369,7 +369,7 @@
     "auto": "Automaattinen"
   },
   "dashboard": {
-    "title": "Hätävarastojen hallinta",
+    "title": "Hätävarastojen seuranta",
     "subtitle": "Seurataan varastoja {{people}} henkilölle {{days}} päiväksi",
     "alerts": {
       "title": "Hälytykset"


### PR DESCRIPTION
## Summary
- Update dashboard title from "Emergency Supplies Dashboard" to "Emergency Supply Tracker" for consistent branding
- Update Finnish translation from "Hätävarastojen hallinta" to "Hätävarastojen seuranta" for consistency with the app title

Closes #92

## Changes
**English translations** (`public/locales/en/common.json`):
- Changed `dashboard.title` from "Emergency Supplies Dashboard" to "Emergency Supply Tracker"

**Finnish translations** (`public/locales/fi/common.json`):
- Changed `dashboard.title` from "Hätävarastojen hallinta" to "Hätävarastojen seuranta"

## Test plan
- [x] All tests pass (1748 unit tests, 160 storybook tests, 121 E2E tests)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dashboard title updated from "Emergency Supplies Dashboard" to "Emergency Supply Tracker"
  * Updated corresponding Finnish translation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->