### PR TITLE
fix: use consistent input step pattern for water preparation field

### DIFF
--- a/src/features/inventory/components/ItemForm.test.tsx
+++ b/src/features/inventory/components/ItemForm.test.tsx
@@ -1036,4 +1036,28 @@ describe('ItemForm', () => {
     // Calories should be calculated: 100g * 50kcal/100g = 50kcal
     expect(caloriesInput).toHaveValue(50);
   });
+
+  it('should use continuous unit step for requiresWaterLiters field', () => {
+    render(
+      <ItemForm
+        categories={STANDARD_CATEGORIES}
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    const categorySelect = document.querySelector(
+      '#categoryId',
+    ) as HTMLSelectElement;
+
+    // Select food category to show water requirement field
+    fireEvent.change(categorySelect, { target: { value: 'food' } });
+
+    const waterRequirementInput = document.querySelector(
+      '#requiresWaterLiters',
+    ) as HTMLInputElement;
+
+    // Water requirement should use the same step as continuous units (like liters)
+    expect(waterRequirementInput).toHaveAttribute('step', '0.1');
+  });
 });

--- a/src/features/inventory/components/ItemForm.tsx
+++ b/src/features/inventory/components/ItemForm.tsx
@@ -394,7 +394,7 @@ export const ItemForm = ({
                 handleChange('requiresWaterLiters', e.target.value)
               }
               min="0"
-              step="0.1"
+              step={isContinuousUnit('liters') ? '0.1' : '1'}
             />
           </div>
         </>


### PR DESCRIPTION
## Summary
- Fixed the water preparation input field to use the same step pattern as the quantity field
- Ensures code consistency by using the `isContinuousUnit` function instead of hardcoded step value

Closes #86

## Changes
- **ItemForm.tsx**: Changed `requiresWaterLiters` input step from hardcoded `"0.1"` to `{isContinuousUnit('liters') ? '0.1' : '1'}` for consistency with the quantity field pattern
- **ItemForm.test.tsx**: Added test to verify the water requirement field uses the correct step value (0.1) matching continuous units

## Test plan
- [x] All tests pass (1749 unit tests)
- [x] TypeScript type-check passes (all 3 tsconfigs)
- [x] Production build succeeds
- [x] Lint passes
- [x] E2E tests pass (121 passed)
- [x] Storybook tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case verifying water liters input step behavior when a food category is selected.

* **Refactor**
  * Enhanced water liters input field with dynamic step calculation based on selected unit to support future unit variations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->