### PR TITLE
feat: add example kits with custom translations

### DIFF
--- a/examples/recommendation-kit-nordic-winter.json
+++ b/examples/recommendation-kit-nordic-winter.json
@@ -1,0 +1,430 @@
+{
+  "meta": {
+    "name": "Nordic Winter Preparedness Kit",
+    "version": "1.0.0",
+    "description": "Emergency supplies tailored for harsh Nordic winter conditions including extreme cold, power outages, and snowstorms",
+    "source": "Custom",
+    "createdAt": "2026-01-27T10:00:00.000Z",
+    "language": "en"
+  },
+  "items": [
+    {
+      "id": "bottled-water",
+      "i18nKey": "products.bottled-water",
+      "category": "water-beverages",
+      "baseQuantity": 3,
+      "unit": "liters",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 12
+    },
+    {
+      "id": "hot-chocolate-mix",
+      "names": {
+        "en": "Hot Chocolate Mix",
+        "fi": "Kaakaojauhe"
+      },
+      "category": "water-beverages",
+      "baseQuantity": 0.5,
+      "unit": "kilograms",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 18
+    },
+    {
+      "id": "instant-warm-drinks",
+      "names": {
+        "en": "Instant Warm Drink Packets",
+        "fi": "Pikajuomajauheet"
+      },
+      "category": "water-beverages",
+      "baseQuantity": 10,
+      "unit": "packages",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "canned-soup",
+      "i18nKey": "products.canned-soup",
+      "category": "food",
+      "baseQuantity": 1,
+      "unit": "cans",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 24,
+      "weightGramsPerUnit": 400,
+      "caloriesPer100g": 50,
+      "caloriesPerUnit": 200
+    },
+    {
+      "id": "hearty-stew-cans",
+      "names": {
+        "en": "Hearty Beef Stew Cans",
+        "fi": "Lihapata-säilykkeet"
+      },
+      "category": "food",
+      "baseQuantity": 1,
+      "unit": "cans",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 36,
+      "weightGramsPerUnit": 500,
+      "caloriesPer100g": 120,
+      "caloriesPerUnit": 600
+    },
+    {
+      "id": "porridge-packets",
+      "names": {
+        "en": "Instant Porridge Packets",
+        "fi": "Pikakaurapuurot"
+      },
+      "category": "food",
+      "baseQuantity": 2,
+      "unit": "packages",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 12,
+      "weightGramsPerUnit": 35,
+      "caloriesPer100g": 370,
+      "caloriesPerUnit": 130,
+      "requiresWaterLiters": 0.2
+    },
+    {
+      "id": "energy-bars",
+      "i18nKey": "products.energy-bars",
+      "category": "food",
+      "baseQuantity": 2,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 12,
+      "weightGramsPerUnit": 50,
+      "caloriesPer100g": 500,
+      "caloriesPerUnit": 250
+    },
+    {
+      "id": "nuts",
+      "i18nKey": "products.nuts",
+      "category": "food",
+      "baseQuantity": 0.1,
+      "unit": "kilograms",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 12,
+      "weightGramsPerUnit": 1000,
+      "caloriesPer100g": 600,
+      "caloriesPerUnit": 6000
+    },
+    {
+      "id": "chocolate-bars",
+      "names": {
+        "en": "Chocolate Bars",
+        "fi": "Suklaapatukat"
+      },
+      "category": "food",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 12,
+      "weightGramsPerUnit": 100,
+      "caloriesPer100g": 550,
+      "caloriesPerUnit": 550
+    },
+    {
+      "id": "camping-stove",
+      "i18nKey": "products.camping-stove",
+      "category": "cooking-heat",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "stove-fuel",
+      "i18nKey": "products.stove-fuel",
+      "category": "cooking-heat",
+      "baseQuantity": 2,
+      "unit": "canisters",
+      "scaleWithPeople": false,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 60
+    },
+    {
+      "id": "hand-warmers",
+      "names": {
+        "en": "Disposable Hand Warmers",
+        "fi": "Kertakäyttöiset kädenlämmittimet"
+      },
+      "category": "cooking-heat",
+      "baseQuantity": 4,
+      "unit": "pairs",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "emergency-heat-packs",
+      "names": {
+        "en": "Body Heat Packs",
+        "fi": "Vartalonlämmittimet"
+      },
+      "category": "cooking-heat",
+      "baseQuantity": 2,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": true,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "matches",
+      "i18nKey": "products.matches",
+      "category": "cooking-heat",
+      "baseQuantity": 2,
+      "unit": "boxes",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 60
+    },
+    {
+      "id": "candles",
+      "i18nKey": "products.candles",
+      "category": "cooking-heat",
+      "baseQuantity": 20,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "flashlight",
+      "i18nKey": "products.flashlight",
+      "category": "light-power",
+      "baseQuantity": 2,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "headlamp",
+      "i18nKey": "products.headlamp",
+      "category": "light-power",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": false
+    },
+    {
+      "id": "batteries-aa",
+      "i18nKey": "products.batteries-aa",
+      "category": "light-power",
+      "baseQuantity": 24,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 60
+    },
+    {
+      "id": "power-bank",
+      "i18nKey": "products.power-bank",
+      "category": "light-power",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "lithium-batteries-cold-rated",
+      "names": {
+        "en": "Cold-Rated Lithium Batteries",
+        "fi": "Kylmänkestävät litiumparistot"
+      },
+      "category": "light-power",
+      "baseQuantity": 8,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 120
+    },
+    {
+      "id": "battery-radio",
+      "i18nKey": "products.battery-radio",
+      "category": "communication-info",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "first-aid-kit",
+      "i18nKey": "products.first-aid-kit",
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "frostbite-cream",
+      "names": {
+        "en": "Frostbite Prevention Cream",
+        "fi": "Paleltumien ehkäisyvoide"
+      },
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "tubes",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "lip-balm-cold-weather",
+      "names": {
+        "en": "Cold Weather Lip Balm",
+        "fi": "Huulirasva pakkaseen"
+      },
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "pain-relievers",
+      "i18nKey": "products.pain-relievers",
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "packages",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "toilet-paper",
+      "i18nKey": "products.toilet-paper",
+      "category": "hygiene-sanitation",
+      "baseQuantity": 1,
+      "unit": "rolls",
+      "scaleWithPeople": true,
+      "scaleWithDays": true
+    },
+    {
+      "id": "wet-wipes",
+      "i18nKey": "products.wet-wipes",
+      "category": "hygiene-sanitation",
+      "baseQuantity": 1,
+      "unit": "packages",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "hand-sanitizer",
+      "i18nKey": "products.hand-sanitizer",
+      "category": "hygiene-sanitation",
+      "baseQuantity": 1,
+      "unit": "bottles",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "emergency-blanket",
+      "names": {
+        "en": "Emergency Thermal Blanket",
+        "fi": "Hätäpeitto (avaruuspeitto)"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": false
+    },
+    {
+      "id": "wool-blanket",
+      "names": {
+        "en": "Wool Blanket",
+        "fi": "Villahuopa"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": false
+    },
+    {
+      "id": "snow-shovel",
+      "names": {
+        "en": "Collapsible Snow Shovel",
+        "fi": "Kokoontaitettava lumilapio"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "ice-scraper",
+      "names": {
+        "en": "Ice Scraper",
+        "fi": "Jääraappa"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "duct-tape",
+      "i18nKey": "products.duct-tape",
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "rolls",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "multi-tool",
+      "i18nKey": "products.multi-tool",
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "tow-rope",
+      "names": {
+        "en": "Heavy-Duty Tow Rope",
+        "fi": "Hinausköysi"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "cash",
+      "i18nKey": "products.cash",
+      "category": "cash-documents",
+      "baseQuantity": 300,
+      "unit": "euros",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "document-copies",
+      "i18nKey": "products.document-copies",
+      "category": "cash-documents",
+      "baseQuantity": 1,
+      "unit": "sets",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    }
+  ]
+}

--- a/examples/recommendation-kit-vehicle-emergency.json
+++ b/examples/recommendation-kit-vehicle-emergency.json
@@ -1,0 +1,404 @@
+{
+  "meta": {
+    "name": "Vehicle Emergency Kit",
+    "version": "1.0.0",
+    "description": "Essential supplies to keep in your car for roadside emergencies, breakdowns, and unexpected delays",
+    "source": "Custom",
+    "createdAt": "2026-01-27T10:00:00.000Z",
+    "language": "en"
+  },
+  "items": [
+    {
+      "id": "bottled-water",
+      "i18nKey": "products.bottled-water",
+      "category": "water-beverages",
+      "baseQuantity": 2,
+      "unit": "liters",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 12
+    },
+    {
+      "id": "electrolyte-drinks",
+      "names": {
+        "en": "Electrolyte Drink Packets",
+        "fi": "Elektrolyyttijuomajauheet"
+      },
+      "category": "water-beverages",
+      "baseQuantity": 4,
+      "unit": "packages",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "energy-bars",
+      "i18nKey": "products.energy-bars",
+      "category": "food",
+      "baseQuantity": 4,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 12,
+      "weightGramsPerUnit": 50,
+      "caloriesPer100g": 500,
+      "caloriesPerUnit": 250
+    },
+    {
+      "id": "trail-mix-pouches",
+      "names": {
+        "en": "Trail Mix Pouches",
+        "fi": "Polkusekoituspussit"
+      },
+      "category": "food",
+      "baseQuantity": 2,
+      "unit": "packages",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 12,
+      "weightGramsPerUnit": 100,
+      "caloriesPer100g": 450,
+      "caloriesPerUnit": 450
+    },
+    {
+      "id": "crackers",
+      "i18nKey": "products.crackers",
+      "category": "food",
+      "baseQuantity": 1,
+      "unit": "packages",
+      "scaleWithPeople": true,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 12,
+      "weightGramsPerUnit": 200,
+      "caloriesPer100g": 250,
+      "caloriesPerUnit": 500
+    },
+    {
+      "id": "hard-candy",
+      "names": {
+        "en": "Hard Candy",
+        "fi": "Kovaa karkkia"
+      },
+      "category": "food",
+      "baseQuantity": 1,
+      "unit": "packages",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24,
+      "weightGramsPerUnit": 200,
+      "caloriesPer100g": 390,
+      "caloriesPerUnit": 780
+    },
+    {
+      "id": "flashlight",
+      "i18nKey": "products.flashlight",
+      "category": "light-power",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "warning-triangle",
+      "names": {
+        "en": "Reflective Warning Triangle",
+        "fi": "Varoituskolmio"
+      },
+      "category": "light-power",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "emergency-road-flares",
+      "names": {
+        "en": "LED Emergency Road Flares",
+        "fi": "LED-hätävilkut"
+      },
+      "category": "light-power",
+      "baseQuantity": 3,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "batteries-aa",
+      "i18nKey": "products.batteries-aa",
+      "category": "light-power",
+      "baseQuantity": 8,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 60
+    },
+    {
+      "id": "car-phone-charger",
+      "names": {
+        "en": "Car Phone Charger",
+        "fi": "Autolaturi puhelimelle"
+      },
+      "category": "light-power",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "jump-starter-pack",
+      "names": {
+        "en": "Portable Jump Starter",
+        "fi": "Kannettava apukäynnistin"
+      },
+      "category": "light-power",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "first-aid-kit",
+      "i18nKey": "products.first-aid-kit",
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "motion-sickness-tablets",
+      "names": {
+        "en": "Motion Sickness Tablets",
+        "fi": "Matkapahoinvointitabletit"
+      },
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "packages",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "pain-relievers",
+      "i18nKey": "products.pain-relievers",
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "packages",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "sunscreen",
+      "names": {
+        "en": "Sunscreen SPF 30+",
+        "fi": "Aurinkovoide SPF 30+"
+      },
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "bottles",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "insect-repellent",
+      "names": {
+        "en": "Insect Repellent Spray",
+        "fi": "Hyönteiskarkote"
+      },
+      "category": "medical-health",
+      "baseQuantity": 1,
+      "unit": "bottles",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 36
+    },
+    {
+      "id": "wet-wipes",
+      "i18nKey": "products.wet-wipes",
+      "category": "hygiene-sanitation",
+      "baseQuantity": 1,
+      "unit": "packages",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "hand-sanitizer",
+      "i18nKey": "products.hand-sanitizer",
+      "category": "hygiene-sanitation",
+      "baseQuantity": 1,
+      "unit": "bottles",
+      "scaleWithPeople": false,
+      "scaleWithDays": false,
+      "defaultExpirationMonths": 24
+    },
+    {
+      "id": "tissues",
+      "names": {
+        "en": "Travel Tissue Packs",
+        "fi": "Matkaneulaliinoja"
+      },
+      "category": "hygiene-sanitation",
+      "baseQuantity": 3,
+      "unit": "packages",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "plastic-bags",
+      "i18nKey": "products.plastic-bags",
+      "category": "hygiene-sanitation",
+      "baseQuantity": 5,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "jumper-cables",
+      "names": {
+        "en": "Jumper Cables",
+        "fi": "Apukaapelit"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "tire-repair-kit",
+      "names": {
+        "en": "Tire Repair Kit",
+        "fi": "Rengaspaikkaussarja"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "tow-strap",
+      "names": {
+        "en": "Tow Strap",
+        "fi": "Hinausliina"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "multi-tool",
+      "i18nKey": "products.multi-tool",
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "duct-tape",
+      "i18nKey": "products.duct-tape",
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "rolls",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "work-gloves",
+      "i18nKey": "products.work-gloves",
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pairs",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "emergency-blanket",
+      "names": {
+        "en": "Emergency Mylar Blanket",
+        "fi": "Hätäpeitto"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": false
+    },
+    {
+      "id": "hi-vis-vest",
+      "names": {
+        "en": "High-Visibility Safety Vest",
+        "fi": "Heijastinliivi"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": true,
+      "scaleWithDays": false
+    },
+    {
+      "id": "windshield-washer-fluid",
+      "names": {
+        "en": "Windshield Washer Fluid",
+        "fi": "Tuulilasinpesuneste"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 2,
+      "unit": "liters",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "seatbelt-cutter-window-breaker",
+      "names": {
+        "en": "Seatbelt Cutter & Window Breaker",
+        "fi": "Turvavöiden leikkuri ja lasinrikkoija"
+      },
+      "category": "tools-supplies",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "cash",
+      "i18nKey": "products.cash",
+      "category": "cash-documents",
+      "baseQuantity": 100,
+      "unit": "euros",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "roadside-assistance-card",
+      "names": {
+        "en": "Roadside Assistance Card",
+        "fi": "Tiepalvelukortti"
+      },
+      "category": "cash-documents",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    },
+    {
+      "id": "paper-map",
+      "names": {
+        "en": "Paper Road Map",
+        "fi": "Paperinen tiekartta"
+      },
+      "category": "cash-documents",
+      "baseQuantity": 1,
+      "unit": "pieces",
+      "scaleWithPeople": false,
+      "scaleWithDays": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add two new recommendation kit examples demonstrating custom inline translations
- Examples show how to use both `i18nKey` (built-in) and `names` (custom) translation approaches

## Changes

### New Example Files
- `examples/recommendation-kit-nordic-winter.json`: 37 items for harsh winter conditions
  - Hand warmers, frostbite cream, thermal blankets, snow shovels
  - Cold-rated batteries, wool blankets, ice scrapers, tow ropes
- `examples/recommendation-kit-vehicle-emergency.json`: 35 items for roadside emergencies
  - Warning triangles, LED road flares, jump starters
  - Tire repair kit, jumper cables, hi-vis vests, seatbelt cutter

### Translation Examples
Both kits demonstrate:
- Items using `i18nKey` for existing built-in translations
- Items using `names` object with `en` and `fi` keys for custom inline translations

## Test plan
- [x] All tests pass
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a vehicle emergency kit reference manifest providing essential roadside supplies organized into categories (water, beverages, food, lighting, power, medical, hygiene, tools, and documents) with full multilingual support and adaptive quantity calculations based on group size and duration needs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->