### PR TITLE
ci: increase mutation testing workflow timeout to 3 hours

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   mutation-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 180
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Increase mutation testing CI workflow timeout from 1 hour to 3 hours to prevent premature job cancellation

## Changes
- `.github/workflows/mutation-testing.yml`: Changed `timeout-minutes` from 60 to 180

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure timeout configuration to support longer-running test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->