### PR TITLE
feat: add Microsoft OneDrive cloud sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Google OAuth Client ID for Cloud Sync
+# Get this from Google Cloud Console: https://console.cloud.google.com/
+# 1. Create a new project or select existing one
+# 2. Enable Google Drive API
+# 3. Configure OAuth consent screen
+# 4. Create OAuth 2.0 Client ID (Web application)
+# 5. Add authorized JavaScript origins (http://localhost:5173 for dev)
+VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,16 @@
 # 4. Create OAuth 2.0 Client ID (Web application)
 # 5. Add authorized JavaScript origins (http://localhost:5173 for dev)
 VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+
+# Microsoft (Azure AD) Client ID for OneDrive sync
+# Get this from the Azure portal: https://portal.azure.com/
+# 1. Microsoft Entra ID -> App registrations -> New registration
+# 2. Supported account types: "Personal Microsoft accounts only"
+#    (or "Accounts in any organizational directory and personal Microsoft accounts"
+#    if you need work/school + personal)
+# 3. Redirect URI: Single-page application (SPA) -> http://localhost:5173 for dev
+#    Add additional SPA redirect URIs for staging/production
+# 4. API permissions -> Microsoft Graph -> Delegated -> Files.ReadWrite.AppFolder
+#    (User.Read is included automatically for sign-in)
+# 5. Copy the Application (client) ID below
+VITE_MICROSOFT_CLIENT_ID=your-microsoft-client-id

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,8 @@ coverage:
         target: 80% # New code must have 80% coverage
   ignore:
     - 'src/test/**' # Test utilities are excluded from coverage
+    - 'src/features/cloudSync/services/googleDrive.ts' # External API integration (requires browser OAuth)
+    - 'src/features/cloudSync/__mocks__/**' # Mock implementations for testing
 
 comment:
   layout: 'reach,diff,flags,files'

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -580,7 +580,48 @@ Features:
 
 ---
 
-### 11. Debug & Error Logging
+### 11. Cloud Sync
+
+Optional cloud synchronization allows users to sync their data across multiple devices.
+
+#### Supported Providers
+
+- **Google Drive** (initial support)
+- Future: OneDrive, Dropbox
+
+#### How It Works
+
+1. **Connect**: User authenticates with Google via OAuth2
+2. **Manual Sync**: User clicks "Sync Now" to sync data
+3. **Conflict Resolution**: Last-write-wins based on `lastModified` timestamp
+4. **Data Storage**: App data stored as `emergency-supply-tracker.json` in user's Google Drive
+
+#### Features
+
+- **Manual sync only**: No automatic background sync (user controls when to sync)
+- **Last-write-wins**: Simple conflict resolution - most recent change takes precedence
+- **Minimal permissions**: Only accesses files created by the app (`drive.file` scope)
+- **Local data preserved**: Disconnecting from cloud keeps local data intact
+- **Token storage**: OAuth tokens stored separately from app data (never exported)
+
+#### Setup Requirements
+
+To use Google Drive sync, the app requires a Google Cloud Console project with:
+
+- OAuth 2.0 Client ID configured for the app's domain
+- Google Drive API enabled
+- OAuth consent screen configured
+
+#### Privacy
+
+- Data is stored in the user's own cloud storage account
+- App only has access to files it creates
+- No data passes through third-party servers
+- Users can disconnect and delete cloud data at any time
+
+---
+
+### 12. Debug & Error Logging
 
 **Debug Export:**
 
@@ -596,7 +637,7 @@ Features:
 - No external services used
 - Privacy-focused
 
-### 12. Internationalization (i18n)
+### 13. Internationalization (i18n)
 
 #### Supported Languages
 

--- a/docs/design-docs/014-onedrive-sync.md
+++ b/docs/design-docs/014-onedrive-sync.md
@@ -1,0 +1,85 @@
+# OneDrive Sync
+
+Adds Microsoft OneDrive as a second cloud sync provider alongside Google Drive. Users sign in with a Microsoft account; sync data is stored in the app's dedicated OneDrive **app folder** (`/Apps/Emergency Supply Tracker/`), so the app never sees the user's wider OneDrive contents.
+
+## Architecture
+
+The provider layer was already abstracted via `CloudStorageProvider`. OneDrive plugs in alongside Google Drive:
+
+```
+src/features/cloudSync/
+├── services/
+│   ├── googleDrive.ts       # existing
+│   ├── oneDrive.ts          # NEW — MSAL.js + Graph API
+│   ├── tokenStorage.ts      # shared (provider-keyed)
+│   └── cloudStorageProvider.ts  # registers both providers
+├── components/
+│   ├── ConnectGoogleDrive.tsx   # existing
+│   ├── ConnectOneDrive.tsx      # NEW — mirror component
+│   └── CloudSyncSection.tsx     # shows both choices when disconnected
+└── types.ts                  # CloudProvider = 'google-drive' | 'onedrive'
+```
+
+The active provider is recorded in `CloudSyncConfig.provider`. Only one provider is connected at a time — the `tokenStorage` design stores a single set of tokens keyed by provider. Switching providers requires explicit disconnect + reconnect.
+
+## Authentication: MSAL.js
+
+OneDrive uses **`@azure/msal-browser`** with the **PKCE** flow (no client secret needed for SPAs):
+
+- **Authority**: `https://login.microsoftonline.com/common` — accepts personal Microsoft accounts (`@outlook.com`, `@hotmail.com`, `@live.com`, etc.) and work/school accounts.
+- **Scopes**: `Files.ReadWrite.AppFolder` — restricts file access to the app's own folder.
+- **Cache**: `sessionStorage` (MSAL's own cache, separate from our `tokenStorage`). The access token is mirrored into our `tokenStorage` on login so the rest of the cloudSync layer treats both providers uniformly.
+- **Silent refresh**: On token expiry, `acquireTokenSilent` is attempted. If MSAL throws `InteractionRequiredAuthError`, the user must reconnect via the UI.
+
+## File operations: Microsoft Graph
+
+| Operation | Endpoint |
+|---|---|
+| Find sync file | `GET /me/drive/special/approot/children?$select=id,name,lastModifiedDateTime` |
+| Upload (new) | `PUT /me/drive/special/approot:/{filename}:/content` |
+| Upload (update) | `PUT /me/drive/items/{id}/content` |
+| Download | `GET /me/drive/items/{id}/content` |
+| Metadata | `GET /me/drive/items/{id}?$select=id,name,lastModifiedDateTime,size` |
+
+Graph supports plain `PUT` for content uploads — no multipart envelope needed (simpler than Google Drive's multipart create). Errors are mapped to `CloudSyncErrorCode` the same way as Google Drive: 401 → `TOKEN_EXPIRED`, 403 → `PERMISSION_DENIED`, 404 → `FILE_NOT_FOUND`, 507/509 → `QUOTA_EXCEEDED`.
+
+## Setup: Azure App Registration
+
+To enable OneDrive sync in a deployment, register an app in Azure:
+
+1. Go to <https://portal.azure.com/> → **Microsoft Entra ID** → **App registrations** → **New registration**.
+2. **Name**: e.g. `Emergency Supply Tracker`.
+3. **Supported account types**: choose one:
+   - *Personal Microsoft accounts only* — simplest; works with `outlook.com`, `hotmail.com`, etc.
+   - *Accounts in any organizational directory and personal Microsoft accounts* — required if you want work/school accounts too. Use the matching authority (`common`) — already configured in `oneDrive.ts`.
+4. **Redirect URI**: select platform **Single-page application (SPA)** and add:
+   - `http://localhost:5173` (dev)
+   - The production URL, e.g. `https://72tuntia.fi`
+   - Any staging URLs
+5. After creation, go to **API permissions** → **Add a permission** → **Microsoft Graph** → **Delegated permissions** → check `Files.ReadWrite.AppFolder`. (`User.Read` is added automatically for sign-in.)
+6. Click **Grant admin consent** if you registered under an organization (not needed for personal-only registrations).
+7. From the app's **Overview** page, copy the **Application (client) ID** into `.env.local`:
+   ```
+   VITE_MICROSOFT_CLIENT_ID=00000000-0000-0000-0000-000000000000
+   ```
+8. (Optional) Under **Authentication** → **Implicit grant and hybrid flows**, leave both checkboxes **off**. PKCE does not require them, and disabling them is the recommended hardening.
+
+The app folder (`/Apps/Emergency Supply Tracker/`) is created automatically on the first upload; no admin setup required.
+
+## What we don't do
+
+- **Refresh tokens are not stored locally**. MSAL keeps them in its own session cache; we only mirror the short-lived access token into `tokenStorage`. This trades smoother resumption for not having long-lived secrets sitting in `localStorage`.
+- **No cross-provider migration.** If the user disconnects Google Drive and connects OneDrive, no data is transferred between drives. Local data is the source of truth, so the next sync uploads it.
+- **No multi-account on the same provider.** MSAL supports multiple accounts; our state model assumes one. Adding it would be a follow-up.
+
+## Testing
+
+`oneDrive.test.ts` mocks `@azure/msal-browser` and `tokenStorage` and exercises:
+- Connect / cancel / missing-client-ID
+- Disconnect (cache clear, even when MSAL clearCache fails)
+- `isConnected` across token states
+- `getAccessToken` happy path + silent refresh + interaction-required
+- Find / upload (new + update) / download / metadata
+- Error mapping (401 / 404 / 507)
+
+The provider chooser UI is covered by existing `CloudSyncSection` integration tests (extended for the OneDrive button).

--- a/e2e/cloud-sync.spec.ts
+++ b/e2e/cloud-sync.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from './fixtures';
+
+test.describe('Cloud Sync', () => {
+  test.beforeEach(async ({ setupApp }) => {
+    await setupApp();
+  });
+
+  test('should display cloud sync section in settings', async ({ page }) => {
+    await page.getByTestId('nav-settings').click();
+
+    // Verify cloud sync section is visible
+    await expect(page.getByTestId('section-cloud-sync')).toBeVisible();
+  });
+
+  test('should display cloud sync status when disconnected', async ({
+    page,
+  }) => {
+    await page.getByTestId('nav-settings').click();
+
+    // Verify status section is visible
+    await expect(page.getByTestId('cloud-sync-status')).toBeVisible();
+
+    // Verify status text shows disconnected
+    const statusText = page.getByTestId('cloud-sync-status-text');
+    await expect(statusText).toBeVisible();
+    // Status should indicate disconnected state
+    const text = await statusText.textContent();
+    expect(text).toBeTruthy();
+  });
+
+  test('should display connect button when disconnected', async ({ page }) => {
+    await page.getByTestId('nav-settings').click();
+
+    // Verify connect button is visible
+    const connectButton = page.getByTestId('cloud-sync-connect-button');
+    await expect(connectButton).toBeVisible();
+
+    // Button should be enabled when disconnected
+    await expect(connectButton).toBeEnabled();
+  });
+
+  test('should show connect Google Drive component', async ({ page }) => {
+    await page.getByTestId('nav-settings').click();
+
+    // Verify connect Google Drive component is visible
+    await expect(page.getByTestId('connect-google-drive')).toBeVisible();
+  });
+
+  test('should display sync button when connected', async ({ page }) => {
+    // This test would require mocking Google Drive connection
+    // For now, we verify the UI structure exists
+    await page.getByTestId('nav-settings').click();
+
+    // When disconnected, the sync button might not be visible, but the section structure exists
+    // We verify the section is present
+    await expect(page.getByTestId('section-cloud-sync')).toBeVisible();
+  });
+
+  test('should display status indicator', async ({ page }) => {
+    await page.getByTestId('nav-settings').click();
+
+    // Verify status indicator is visible
+    const indicator = page.getByTestId('cloud-sync-status-indicator');
+    await expect(indicator).toBeVisible();
+  });
+
+  test('should navigate to cloud sync section from settings', async ({
+    page,
+  }) => {
+    await page.getByTestId('nav-settings').click();
+
+    // Verify we're on settings page
+    await expect(page.getByTestId('page-settings')).toBeVisible();
+
+    // Scroll to cloud sync section if needed (it's at the bottom)
+    await page.getByTestId('section-cloud-sync').scrollIntoViewIfNeeded();
+
+    // Verify cloud sync section is visible
+    await expect(page.getByTestId('section-cloud-sync')).toBeVisible();
+  });
+});

--- a/e2e/cloud-sync.spec.ts
+++ b/e2e/cloud-sync.spec.ts
@@ -5,8 +5,15 @@ test.describe('Cloud Sync', () => {
     await setupApp();
   });
 
-  test('should display cloud sync section in settings', async ({ page }) => {
+  // Helper function to navigate to cloud sync section
+  async function navigateToCloudSync(page: import('@playwright/test').Page) {
     await page.getByTestId('nav-settings').click();
+    // Click on the cloudSync menu item in the sidebar
+    await page.getByTestId('sidemenu-item-cloudSync').click();
+  }
+
+  test('should display cloud sync section in settings', async ({ page }) => {
+    await navigateToCloudSync(page);
 
     // Verify cloud sync section is visible
     await expect(page.getByTestId('section-cloud-sync')).toBeVisible();
@@ -15,7 +22,7 @@ test.describe('Cloud Sync', () => {
   test('should display cloud sync status when disconnected', async ({
     page,
   }) => {
-    await page.getByTestId('nav-settings').click();
+    await navigateToCloudSync(page);
 
     // Verify status section is visible
     await expect(page.getByTestId('cloud-sync-status')).toBeVisible();
@@ -29,7 +36,7 @@ test.describe('Cloud Sync', () => {
   });
 
   test('should display connect button when disconnected', async ({ page }) => {
-    await page.getByTestId('nav-settings').click();
+    await navigateToCloudSync(page);
 
     // Verify connect button is visible
     const connectButton = page.getByTestId('cloud-sync-connect-button');
@@ -40,7 +47,7 @@ test.describe('Cloud Sync', () => {
   });
 
   test('should show connect Google Drive component', async ({ page }) => {
-    await page.getByTestId('nav-settings').click();
+    await navigateToCloudSync(page);
 
     // Verify connect Google Drive component is visible
     await expect(page.getByTestId('connect-google-drive')).toBeVisible();
@@ -49,7 +56,7 @@ test.describe('Cloud Sync', () => {
   test('should display sync button when connected', async ({ page }) => {
     // This test would require mocking Google Drive connection
     // For now, we verify the UI structure exists
-    await page.getByTestId('nav-settings').click();
+    await navigateToCloudSync(page);
 
     // When disconnected, the sync button might not be visible, but the section structure exists
     // We verify the section is present
@@ -57,7 +64,7 @@ test.describe('Cloud Sync', () => {
   });
 
   test('should display status indicator', async ({ page }) => {
-    await page.getByTestId('nav-settings').click();
+    await navigateToCloudSync(page);
 
     // Verify status indicator is visible
     const indicator = page.getByTestId('cloud-sync-status-indicator');
@@ -72,8 +79,8 @@ test.describe('Cloud Sync', () => {
     // Verify we're on settings page
     await expect(page.getByTestId('page-settings')).toBeVisible();
 
-    // Scroll to cloud sync section if needed (it's at the bottom)
-    await page.getByTestId('section-cloud-sync').scrollIntoViewIfNeeded();
+    // Click on cloud sync menu item
+    await page.getByTestId('sidemenu-item-cloudSync').click();
 
     // Verify cloud sync section is visible
     await expect(page.getByTestId('section-cloud-sync')).toBeVisible();

--- a/e2e/cloud-sync.spec.ts
+++ b/e2e/cloud-sync.spec.ts
@@ -1,16 +1,19 @@
 import { test, expect } from './fixtures';
 
+// Helper function to navigate to cloud sync section
+async function navigateToCloudSync(page: import('@playwright/test').Page) {
+  await page.getByTestId('nav-settings').click();
+  // Click on the cloudSync menu item in the sidebar (scope to avoid drawer duplicate)
+  await page
+    .getByTestId('sidemenu-sidebar')
+    .getByTestId('sidemenu-item-cloudSync')
+    .click();
+}
+
 test.describe('Cloud Sync', () => {
   test.beforeEach(async ({ setupApp }) => {
     await setupApp();
   });
-
-  // Helper function to navigate to cloud sync section
-  async function navigateToCloudSync(page: import('@playwright/test').Page) {
-    await page.getByTestId('nav-settings').click();
-    // Click on the cloudSync menu item in the sidebar
-    await page.getByTestId('sidemenu-item-cloudSync').click();
-  }
 
   test('should display cloud sync section in settings', async ({ page }) => {
     await navigateToCloudSync(page);
@@ -79,8 +82,11 @@ test.describe('Cloud Sync', () => {
     // Verify we're on settings page
     await expect(page.getByTestId('page-settings')).toBeVisible();
 
-    // Click on cloud sync menu item
-    await page.getByTestId('sidemenu-item-cloudSync').click();
+    // Click on cloud sync menu item (scope to sidebar)
+    await page
+      .getByTestId('sidemenu-sidebar')
+      .getByTestId('sidemenu-item-cloudSync')
+      .click();
 
     // Verify cloud sync section is visible
     await expect(page.getByTestId('section-cloud-sync')).toBeVisible();

--- a/index.html
+++ b/index.html
@@ -96,6 +96,9 @@
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />
 
+    <!-- Google Identity Services (for Google Drive sync) -->
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+
     <!-- Structured Data (JSON-LD) -->
     <script type="application/ld+json">
       {

--- a/index.html
+++ b/index.html
@@ -96,7 +96,12 @@
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />
 
-    <!-- Google Identity Services (for Google Drive sync) -->
+    <!--
+      Google Identity Services (for Google Drive sync)
+      Note: SRI (integrity) attribute is intentionally omitted.
+      Google dynamically updates this script and doesn't provide stable hashes.
+      OAuth2 security is ensured through authorized origins and client validation.
+    -->
     <script src="https://accounts.google.com/gsi/client" async defer></script>
 
     <!-- Structured Data (JSON-LD) -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "emergency-supply-tracker",
       "version": "0.0.0",
       "dependencies": {
+        "@azure/msal-browser": "^5.9.0",
         "i18next": "^25.7.3",
         "i18next-http-backend": "^3.0.2",
         "react": "^19.2.3",
@@ -98,6 +99,27 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.9.0.tgz",
+      "integrity": "sha512-CzE+4PefDSJWj26zU7G1bKchlGRRHMBFreG4tAlGuzyI8hAPiYGobaJvZBgZBf6L63iphX7VH+ityL8VgEQz9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.5.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "vitest-axe": "^1.0.0-pre.5"
   },
   "dependencies": {
+    "@azure/msal-browser": "^5.9.0",
     "i18next": "^25.7.3",
     "i18next-http-backend": "^3.0.2",
     "react": "^19.2.3",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -812,7 +812,8 @@
       "lastSync": "Last synced: {{date}} at {{time}}"
     },
     "providers": {
-      "google-drive": "Google Drive"
+      "google-drive": "Google Drive",
+      "onedrive": "OneDrive"
     },
     "section": {
       "connectTitle": "Connect to Cloud",
@@ -834,6 +835,12 @@
       "connecting": "Connecting...",
       "connected": "Connected to Google Drive",
       "description": "Sign in with your Google account to sync data to your Google Drive."
+    },
+    "onedrive": {
+      "connect": "Connect OneDrive",
+      "connecting": "Connecting...",
+      "connected": "Connected to OneDrive",
+      "description": "Sign in with your Microsoft account to sync data to your OneDrive."
     },
     "disconnect": {
       "button": "Disconnect",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -31,8 +31,8 @@
       "description": "Access your supplies anytime, even without internet"
     },
     "cloudSync": {
-      "title": "Cloud Sync (Coming Soon)",
-      "description": "Optional sync to your own cloud provider"
+      "title": "Cloud Sync",
+      "description": "Optional sync to your own Google Drive"
     },
     "openSource": {
       "title": "Open Source",
@@ -177,7 +177,8 @@
         "about": "About",
         "dangerZone": "Danger Zone",
         "recommendationKits": "Recommendation Kits",
-        "customTemplates": "Custom Templates"
+        "customTemplates": "Custom Templates",
+        "cloudSync": "Cloud Sync"
       }
     },
     "nutrition": {
@@ -799,6 +800,45 @@
       "nameRequired": "At least one name is required",
       "idExists": "An item with this ID already exists",
       "quantityPositive": "Quantity must be greater than 0"
+    }
+  },
+  "cloudSync": {
+    "status": {
+      "disconnected": "Not connected",
+      "connected": "Connected",
+      "syncing": "Syncing...",
+      "error": "Sync error",
+      "neverSynced": "Never synced",
+      "lastSync": "Last synced: {{date}} at {{time}}"
+    },
+    "providers": {
+      "google-drive": "Google Drive"
+    },
+    "section": {
+      "connectTitle": "Connect to Cloud",
+      "syncTitle": "Sync Data",
+      "accountTitle": "Connected Account"
+    },
+    "button": {
+      "sync": "Sync Now",
+      "syncing": "Syncing...",
+      "description": "Manually sync your data with the cloud. Uses last-write-wins for conflicts."
+    },
+    "result": {
+      "uploaded": "Data uploaded to cloud",
+      "downloaded": "Data downloaded from cloud",
+      "noChanges": "Already in sync, no changes needed"
+    },
+    "google": {
+      "connect": "Connect Google Drive",
+      "connecting": "Connecting...",
+      "connected": "Connected to Google Drive",
+      "description": "Sign in with your Google account to sync data to your Google Drive."
+    },
+    "disconnect": {
+      "button": "Disconnect",
+      "disconnecting": "Disconnecting...",
+      "confirm": "Disconnect from cloud sync? Your local data will be kept, but cloud sync will be disabled."
     }
   }
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -812,7 +812,8 @@
       "lastSync": "Viimeksi synkronoitu: {{date}} klo {{time}}"
     },
     "providers": {
-      "google-drive": "Google Drive"
+      "google-drive": "Google Drive",
+      "onedrive": "OneDrive"
     },
     "section": {
       "connectTitle": "Yhdistä pilveen",
@@ -834,6 +835,12 @@
       "connecting": "Yhdistetään...",
       "connected": "Yhdistetty Google Driveen",
       "description": "Kirjaudu sisään Google-tililläsi synkronoidaksesi tiedot Google Driveen."
+    },
+    "onedrive": {
+      "connect": "Yhdistä OneDrive",
+      "connecting": "Yhdistetään...",
+      "connected": "Yhdistetty OneDriveen",
+      "description": "Kirjaudu sisään Microsoft-tililläsi synkronoidaksesi tiedot OneDriveen."
     },
     "disconnect": {
       "button": "Katkaise yhteys",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -31,8 +31,8 @@
       "description": "Käytä varastotietojasi milloin tahansa, myös ilman internet-yhteyttä"
     },
     "cloudSync": {
-      "title": "Pilvisynkronointi (tulossa)",
-      "description": "Valinnainen synkronointi omaan pilvipalveluun"
+      "title": "Pilvisynkronointi",
+      "description": "Valinnainen synkronointi omaan Google Driveen"
     },
     "openSource": {
       "title": "Avoin lähdekoodi",
@@ -177,7 +177,8 @@
         "about": "Tietoja",
         "dangerZone": "Vaaravyöhyke",
         "recommendationKits": "Suosituspaketit",
-        "customTemplates": "Omat mallit"
+        "customTemplates": "Omat mallit",
+        "cloudSync": "Pilvisynkronointi"
       }
     },
     "nutrition": {
@@ -799,6 +800,45 @@
       "nameRequired": "Vähintään yksi nimi vaaditaan",
       "idExists": "Tuote tällä tunnuksella on jo olemassa",
       "quantityPositive": "Määrän on oltava suurempi kuin 0"
+    }
+  },
+  "cloudSync": {
+    "status": {
+      "disconnected": "Ei yhdistetty",
+      "connected": "Yhdistetty",
+      "syncing": "Synkronoidaan...",
+      "error": "Synkronointivirhe",
+      "neverSynced": "Ei koskaan synkronoitu",
+      "lastSync": "Viimeksi synkronoitu: {{date}} klo {{time}}"
+    },
+    "providers": {
+      "google-drive": "Google Drive"
+    },
+    "section": {
+      "connectTitle": "Yhdistä pilveen",
+      "syncTitle": "Synkronoi tiedot",
+      "accountTitle": "Yhdistetty tili"
+    },
+    "button": {
+      "sync": "Synkronoi nyt",
+      "syncing": "Synkronoidaan...",
+      "description": "Synkronoi tietosi manuaalisesti pilveen. Käyttää viimeinen-voittaa -periaatetta ristiriidoissa."
+    },
+    "result": {
+      "uploaded": "Tiedot ladattu pilveen",
+      "downloaded": "Tiedot ladattu pilvestä",
+      "noChanges": "Jo synkronoitu, ei muutoksia"
+    },
+    "google": {
+      "connect": "Yhdistä Google Drive",
+      "connecting": "Yhdistetään...",
+      "connected": "Yhdistetty Google Driveen",
+      "description": "Kirjaudu sisään Google-tililläsi synkronoidaksesi tiedot Google Driveen."
+    },
+    "disconnect": {
+      "button": "Katkaise yhteys",
+      "disconnecting": "Katkaistaan yhteyttä...",
+      "confirm": "Katkaistaanko pilvisynkronointi? Paikalliset tietosi säilyvät, mutta pilvisynkronointi poistetaan käytöstä."
     }
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,6 +27,15 @@ vi.mock('react-i18next', () => ({
     },
 }));
 
+// Mock cloudSync services to avoid initializing Google Drive in tests
+vi.mock('@/features/cloudSync/services', () => ({
+  initializeProviders: vi.fn(),
+  getProvider: vi.fn(() => null),
+  getAvailableProviders: vi.fn(() => []),
+  isProviderAvailable: vi.fn(() => false),
+  resetProviders: vi.fn(),
+}));
+
 // Helper to set up localStorage with onboarding completed (use saveAppData for root/inventory set shape)
 const setupCompletedOnboarding = () => {
   const appData = createMockAppData({

--- a/src/features/cloudSync/__mocks__/services/cloudStorageProvider.ts
+++ b/src/features/cloudSync/__mocks__/services/cloudStorageProvider.ts
@@ -1,0 +1,42 @@
+/**
+ * Mock cloud storage provider for tests.
+ */
+
+import type { CloudProvider, CloudStorageProvider } from '../../types';
+import { GoogleDriveService } from './googleDrive';
+
+const providerRegistry: Map<CloudProvider, () => CloudStorageProvider> =
+  new Map();
+
+export function registerProvider(
+  providerId: CloudProvider,
+  factory: () => CloudStorageProvider,
+): void {
+  providerRegistry.set(providerId, factory);
+}
+
+export function getProvider(
+  providerId: CloudProvider,
+): CloudStorageProvider | null {
+  const factory = providerRegistry.get(providerId);
+  if (!factory) {
+    return null;
+  }
+  return factory();
+}
+
+export function getAvailableProviders(): CloudProvider[] {
+  return Array.from(providerRegistry.keys());
+}
+
+export function isProviderAvailable(providerId: CloudProvider): boolean {
+  return providerRegistry.has(providerId);
+}
+
+export function initializeProviders(): void {
+  registerProvider('google-drive', () => new GoogleDriveService());
+}
+
+export function resetProviders(): void {
+  providerRegistry.clear();
+}

--- a/src/features/cloudSync/__mocks__/services/cloudStorageProvider.ts
+++ b/src/features/cloudSync/__mocks__/services/cloudStorageProvider.ts
@@ -4,6 +4,7 @@
 
 import type { CloudProvider, CloudStorageProvider } from '../../types';
 import { GoogleDriveService } from './googleDrive';
+import { OneDriveService } from './oneDrive';
 
 const providerRegistry: Map<CloudProvider, () => CloudStorageProvider> =
   new Map();
@@ -35,6 +36,7 @@ export function isProviderAvailable(providerId: CloudProvider): boolean {
 
 export function initializeProviders(): void {
   registerProvider('google-drive', () => new GoogleDriveService());
+  registerProvider('onedrive', () => new OneDriveService());
 }
 
 export function resetProviders(): void {

--- a/src/features/cloudSync/__mocks__/services/googleDrive.ts
+++ b/src/features/cloudSync/__mocks__/services/googleDrive.ts
@@ -1,0 +1,41 @@
+/**
+ * Mock Google Drive service for tests.
+ */
+
+import type { CloudStorageProvider, CloudFileMetadata } from '../../types';
+
+export class GoogleDriveService implements CloudStorageProvider {
+  readonly providerId = 'google-drive' as const;
+
+  async connect(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async disconnect(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+
+  async getAccessToken(): Promise<string | null> {
+    return null;
+  }
+
+  async upload(_data: string, _existingFileId?: string): Promise<string> {
+    return 'mock-file-id';
+  }
+
+  async download(_fileId: string): Promise<string> {
+    return '{}';
+  }
+
+  async getFileMetadata(_fileId: string): Promise<CloudFileMetadata | null> {
+    return null;
+  }
+
+  async findSyncFile(): Promise<string | null> {
+    return null;
+  }
+}

--- a/src/features/cloudSync/__mocks__/services/googleDrive.ts
+++ b/src/features/cloudSync/__mocks__/services/googleDrive.ts
@@ -8,11 +8,11 @@ export class GoogleDriveService implements CloudStorageProvider {
   readonly providerId = 'google-drive' as const;
 
   async connect(): Promise<void> {
-    return Promise.resolve();
+    // No-op for mock
   }
 
   async disconnect(): Promise<void> {
-    return Promise.resolve();
+    // No-op for mock
   }
 
   isConnected(): boolean {

--- a/src/features/cloudSync/__mocks__/services/index.ts
+++ b/src/features/cloudSync/__mocks__/services/index.ts
@@ -1,0 +1,17 @@
+export { GoogleDriveService } from './googleDrive';
+export {
+  storeTokens,
+  getStoredTokens,
+  clearTokens,
+  areTokensExpired,
+  updateAccessToken,
+  getTokensForProvider,
+} from '../../services/tokenStorage';
+export {
+  registerProvider,
+  getProvider,
+  getAvailableProviders,
+  isProviderAvailable,
+  initializeProviders,
+  resetProviders,
+} from './cloudStorageProvider';

--- a/src/features/cloudSync/__mocks__/services/index.ts
+++ b/src/features/cloudSync/__mocks__/services/index.ts
@@ -1,4 +1,5 @@
 export { GoogleDriveService } from './googleDrive';
+export { OneDriveService } from './oneDrive';
 export {
   storeTokens,
   getStoredTokens,

--- a/src/features/cloudSync/__mocks__/services/oneDrive.ts
+++ b/src/features/cloudSync/__mocks__/services/oneDrive.ts
@@ -1,0 +1,41 @@
+/**
+ * Mock OneDrive service for tests.
+ */
+
+import type { CloudStorageProvider, CloudFileMetadata } from '../../types';
+
+export class OneDriveService implements CloudStorageProvider {
+  readonly providerId = 'onedrive' as const;
+
+  async connect(): Promise<void> {
+    // No-op for mock
+  }
+
+  async disconnect(): Promise<void> {
+    // No-op for mock
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+
+  async getAccessToken(): Promise<string | null> {
+    return null;
+  }
+
+  async upload(_data: string, _existingFileId?: string): Promise<string> {
+    return 'mock-onedrive-file-id';
+  }
+
+  async download(_fileId: string): Promise<string> {
+    return '{}';
+  }
+
+  async getFileMetadata(_fileId: string): Promise<CloudFileMetadata | null> {
+    return null;
+  }
+
+  async findSyncFile(): Promise<string | null> {
+    return null;
+  }
+}

--- a/src/features/cloudSync/components/CloudSyncButton.module.css
+++ b/src/features/cloudSync/components/CloudSyncButton.module.css
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.result {
+  margin: 0;
+  color: var(--color-success);
+  font-size: 0.875rem;
+}
+
+.description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}

--- a/src/features/cloudSync/components/CloudSyncButton.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncButton.test.tsx
@@ -1,0 +1,226 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CloudSyncButton } from './CloudSyncButton';
+import { CloudSyncContext } from '../context';
+import type {
+  CloudSyncContextValue,
+  CloudSyncState,
+  SyncResult,
+} from '../types';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const defaultState: CloudSyncState = {
+  provider: 'google-drive',
+  lastSyncTimestamp: null,
+  remoteFileId: null,
+  state: 'connected',
+  error: null,
+};
+
+const createMockContext = (
+  state: Partial<CloudSyncState> = {},
+  overrides: Partial<CloudSyncContextValue> = {},
+): CloudSyncContextValue => ({
+  state: { ...defaultState, ...state },
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  syncNow: jest.fn().mockResolvedValue({
+    success: true,
+    direction: 'none',
+    timestamp: new Date().toISOString(),
+  }),
+  clearError: jest.fn(),
+  ...overrides,
+});
+
+const renderWithContext = (contextValue: CloudSyncContextValue) => {
+  return render(
+    <CloudSyncContext.Provider value={contextValue}>
+      <CloudSyncButton />
+    </CloudSyncContext.Provider>,
+  );
+};
+
+describe('CloudSyncButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('button state', () => {
+    it('should be disabled when disconnected', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('should be disabled when syncing', () => {
+      renderWithContext(createMockContext({ state: 'syncing' }));
+
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('should be enabled when connected', () => {
+      renderWithContext(createMockContext({ state: 'connected' }));
+
+      expect(screen.getByRole('button')).toBeEnabled();
+    });
+
+    it('should be enabled when in error state', () => {
+      renderWithContext(createMockContext({ state: 'error' }));
+
+      expect(screen.getByRole('button')).toBeEnabled();
+    });
+  });
+
+  describe('button text', () => {
+    it('should show sync text when not syncing', () => {
+      renderWithContext(createMockContext({ state: 'connected' }));
+
+      expect(screen.getByText('cloudSync.button.sync')).toBeInTheDocument();
+    });
+
+    it('should show syncing text when syncing', () => {
+      renderWithContext(createMockContext({ state: 'syncing' }));
+
+      expect(screen.getByText('cloudSync.button.syncing')).toBeInTheDocument();
+    });
+  });
+
+  describe('sync action', () => {
+    it('should call syncNow and clearError when clicked', async () => {
+      const user = userEvent.setup();
+      const mockSyncNow = jest.fn().mockResolvedValue({
+        success: true,
+        direction: 'none',
+        timestamp: new Date().toISOString(),
+      } as SyncResult);
+      const mockClearError = jest.fn();
+
+      renderWithContext(
+        createMockContext(
+          {},
+          { syncNow: mockSyncNow, clearError: mockClearError },
+        ),
+      );
+
+      await user.click(screen.getByRole('button'));
+
+      expect(mockClearError).toHaveBeenCalled();
+      expect(mockSyncNow).toHaveBeenCalled();
+    });
+
+    it('should show uploaded result on successful upload', async () => {
+      const user = userEvent.setup();
+      const mockSyncNow = jest.fn().mockResolvedValue({
+        success: true,
+        direction: 'upload',
+        timestamp: new Date().toISOString(),
+      } as SyncResult);
+
+      renderWithContext(createMockContext({}, { syncNow: mockSyncNow }));
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('cloudSync.result.uploaded'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should show downloaded result on successful download', async () => {
+      const user = userEvent.setup();
+      const mockSyncNow = jest.fn().mockResolvedValue({
+        success: true,
+        direction: 'download',
+        timestamp: new Date().toISOString(),
+      } as SyncResult);
+
+      renderWithContext(createMockContext({}, { syncNow: mockSyncNow }));
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('cloudSync.result.downloaded'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should show no changes result when none direction', async () => {
+      const user = userEvent.setup();
+      const mockSyncNow = jest.fn().mockResolvedValue({
+        success: true,
+        direction: 'none',
+        timestamp: new Date().toISOString(),
+      } as SyncResult);
+
+      renderWithContext(createMockContext({}, { syncNow: mockSyncNow }));
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('cloudSync.result.noChanges'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should not show result on failure', async () => {
+      const user = userEvent.setup();
+      const mockSyncNow = jest.fn().mockResolvedValue({
+        success: false,
+        direction: 'none',
+        timestamp: new Date().toISOString(),
+        error: 'Sync failed',
+      } as SyncResult);
+
+      renderWithContext(createMockContext({}, { syncNow: mockSyncNow }));
+
+      await user.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        expect(mockSyncNow).toHaveBeenCalled();
+      });
+
+      expect(
+        screen.queryByText('cloudSync.result.uploaded'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('cloudSync.result.downloaded'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('cloudSync.result.noChanges'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('description', () => {
+    it('should show description text', () => {
+      renderWithContext(createMockContext());
+
+      expect(
+        screen.getByText('cloudSync.button.description'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('aria attributes', () => {
+    it('should have aria-busy when syncing', () => {
+      renderWithContext(createMockContext({ state: 'syncing' }));
+
+      expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('should not have aria-busy when not syncing', () => {
+      renderWithContext(createMockContext({ state: 'connected' }));
+
+      expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'false');
+    });
+  });
+});

--- a/src/features/cloudSync/components/CloudSyncButton.tsx
+++ b/src/features/cloudSync/components/CloudSyncButton.tsx
@@ -43,16 +43,21 @@ export function CloudSyncButton() {
   const isLoading = state.state === 'syncing';
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-testid="cloud-sync-button">
       <Button
         variant="primary"
         onClick={handleSync}
         disabled={isDisabled}
         aria-busy={isLoading}
+        data-testid="cloud-sync-button-trigger"
       >
         {isLoading ? t('cloudSync.button.syncing') : t('cloudSync.button.sync')}
       </Button>
-      {lastResult && <p className={styles.result}>{lastResult}</p>}
+      {lastResult && (
+        <p className={styles.result} data-testid="cloud-sync-result">
+          {lastResult}
+        </p>
+      )}
       <p className={styles.description}>{t('cloudSync.button.description')}</p>
     </div>
   );

--- a/src/features/cloudSync/components/CloudSyncButton.tsx
+++ b/src/features/cloudSync/components/CloudSyncButton.tsx
@@ -26,6 +26,10 @@ export function CloudSyncButton() {
           break;
         case 'download':
           setLastResult(t('cloudSync.result.downloaded'));
+          // Reload page to reflect downloaded data
+          if (result.requiresReload) {
+            window.location.reload();
+          }
           break;
         case 'none':
           setLastResult(t('cloudSync.result.noChanges'));

--- a/src/features/cloudSync/components/CloudSyncButton.tsx
+++ b/src/features/cloudSync/components/CloudSyncButton.tsx
@@ -28,7 +28,7 @@ export function CloudSyncButton() {
           setLastResult(t('cloudSync.result.downloaded'));
           // Reload page to reflect downloaded data
           if (result.requiresReload) {
-            window.location.reload();
+            globalThis.location.reload();
           }
           break;
         case 'none':

--- a/src/features/cloudSync/components/CloudSyncButton.tsx
+++ b/src/features/cloudSync/components/CloudSyncButton.tsx
@@ -25,10 +25,12 @@ export function CloudSyncButton() {
           setLastResult(t('cloudSync.result.uploaded'));
           break;
         case 'download':
-          setLastResult(t('cloudSync.result.downloaded'));
           // Reload page to reflect downloaded data
           if (result.requiresReload) {
             globalThis.location.reload();
+          } else {
+            // Only show message if no reload needed
+            setLastResult(t('cloudSync.result.downloaded'));
           }
           break;
         case 'none':

--- a/src/features/cloudSync/components/CloudSyncButton.tsx
+++ b/src/features/cloudSync/components/CloudSyncButton.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/components/Button';
+import { useCloudSync } from '../hooks';
+import styles from './CloudSyncButton.module.css';
+
+/**
+ * Button to trigger manual sync operation.
+ * Disabled when disconnected or currently syncing.
+ */
+export function CloudSyncButton() {
+  const { t } = useTranslation();
+  const { state, syncNow, clearError } = useCloudSync();
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  const handleSync = async () => {
+    setLastResult(null);
+    clearError();
+
+    const result = await syncNow();
+
+    if (result.success) {
+      switch (result.direction) {
+        case 'upload':
+          setLastResult(t('cloudSync.result.uploaded'));
+          break;
+        case 'download':
+          setLastResult(t('cloudSync.result.downloaded'));
+          break;
+        case 'none':
+          setLastResult(t('cloudSync.result.noChanges'));
+          break;
+      }
+    }
+  };
+
+  const isDisabled =
+    state.state === 'disconnected' || state.state === 'syncing';
+  const isLoading = state.state === 'syncing';
+
+  return (
+    <div className={styles.container}>
+      <Button
+        variant="primary"
+        onClick={handleSync}
+        disabled={isDisabled}
+        aria-busy={isLoading}
+      >
+        {isLoading ? t('cloudSync.button.syncing') : t('cloudSync.button.sync')}
+      </Button>
+      {lastResult && <p className={styles.result}>{lastResult}</p>}
+      <p className={styles.description}>{t('cloudSync.button.description')}</p>
+    </div>
+  );
+}

--- a/src/features/cloudSync/components/CloudSyncButton.tsx
+++ b/src/features/cloudSync/components/CloudSyncButton.tsx
@@ -17,26 +17,30 @@ export function CloudSyncButton() {
     setLastResult(null);
     clearError();
 
-    const result = await syncNow();
+    try {
+      const result = await syncNow();
 
-    if (result.success) {
-      switch (result.direction) {
-        case 'upload':
-          setLastResult(t('cloudSync.result.uploaded'));
-          break;
-        case 'download':
-          // Reload page to reflect downloaded data
-          if (result.requiresReload) {
-            globalThis.location.reload();
-          } else {
-            // Only show message if no reload needed
-            setLastResult(t('cloudSync.result.downloaded'));
-          }
-          break;
-        case 'none':
-          setLastResult(t('cloudSync.result.noChanges'));
-          break;
+      if (result.success) {
+        switch (result.direction) {
+          case 'upload':
+            setLastResult(t('cloudSync.result.uploaded'));
+            break;
+          case 'download':
+            // Reload page to reflect downloaded data
+            if (result.requiresReload) {
+              globalThis.location.reload();
+            } else {
+              // Only show message if no reload needed
+              setLastResult(t('cloudSync.result.downloaded'));
+            }
+            break;
+          case 'none':
+            setLastResult(t('cloudSync.result.noChanges'));
+            break;
+        }
       }
+    } catch {
+      // Error state is managed by the provider via state.error
     }
   };
 

--- a/src/features/cloudSync/components/CloudSyncSection.module.css
+++ b/src/features/cloudSync/components/CloudSyncSection.module.css
@@ -1,0 +1,29 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.divider {
+  height: 1px;
+  background-color: var(--color-border);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.actionGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.actionTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}

--- a/src/features/cloudSync/components/CloudSyncSection.module.css
+++ b/src/features/cloudSync/components/CloudSyncSection.module.css
@@ -27,3 +27,9 @@
   font-weight: 500;
   color: var(--color-text-primary);
 }
+
+.providerChoices {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}

--- a/src/features/cloudSync/components/CloudSyncSection.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.test.tsx
@@ -1,24 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CloudSyncSection } from './CloudSyncSection';
 import { CloudSyncContext } from '../context';
 import type { CloudSyncContextValue, CloudSyncState } from '../types';
 
-jest.mock('react-i18next', () => ({
+vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
   }),
 }));
 
 // Mock child components to simplify testing
-jest.mock('./CloudSyncStatus', () => ({
+vi.mock('./CloudSyncStatus', () => ({
   CloudSyncStatus: () => <div data-testid="cloud-sync-status">Status</div>,
 }));
 
-jest.mock('./CloudSyncButton', () => ({
+vi.mock('./CloudSyncButton', () => ({
   CloudSyncButton: () => <div data-testid="cloud-sync-button">Button</div>,
 }));
 
-jest.mock('./ConnectGoogleDrive', () => ({
+vi.mock('./ConnectGoogleDrive', () => ({
   ConnectGoogleDrive: () => (
     <div data-testid="connect-google-drive">Connect</div>
   ),
@@ -36,10 +37,10 @@ const createMockContext = (
   state: Partial<CloudSyncState> = {},
 ): CloudSyncContextValue => ({
   state: { ...defaultState, ...state },
-  connect: jest.fn(),
-  disconnect: jest.fn(),
-  syncNow: jest.fn(),
-  clearError: jest.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  syncNow: vi.fn(),
+  clearError: vi.fn(),
 });
 
 const renderWithContext = (contextValue: CloudSyncContextValue) => {
@@ -52,7 +53,7 @@ const renderWithContext = (contextValue: CloudSyncContextValue) => {
 
 describe('CloudSyncSection', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('should always render CloudSyncStatus', () => {

--- a/src/features/cloudSync/components/CloudSyncSection.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen } from '@testing-library/react';
+import { CloudSyncSection } from './CloudSyncSection';
+import { CloudSyncContext } from '../context';
+import type { CloudSyncContextValue, CloudSyncState } from '../types';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Mock child components to simplify testing
+jest.mock('./CloudSyncStatus', () => ({
+  CloudSyncStatus: () => <div data-testid="cloud-sync-status">Status</div>,
+}));
+
+jest.mock('./CloudSyncButton', () => ({
+  CloudSyncButton: () => <div data-testid="cloud-sync-button">Button</div>,
+}));
+
+jest.mock('./ConnectGoogleDrive', () => ({
+  ConnectGoogleDrive: () => (
+    <div data-testid="connect-google-drive">Connect</div>
+  ),
+}));
+
+const defaultState: CloudSyncState = {
+  provider: null,
+  lastSyncTimestamp: null,
+  remoteFileId: null,
+  state: 'disconnected',
+  error: null,
+};
+
+const createMockContext = (
+  state: Partial<CloudSyncState> = {},
+): CloudSyncContextValue => ({
+  state: { ...defaultState, ...state },
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  syncNow: jest.fn(),
+  clearError: jest.fn(),
+});
+
+const renderWithContext = (contextValue: CloudSyncContextValue) => {
+  return render(
+    <CloudSyncContext.Provider value={contextValue}>
+      <CloudSyncSection />
+    </CloudSyncContext.Provider>,
+  );
+};
+
+describe('CloudSyncSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should always render CloudSyncStatus', () => {
+    renderWithContext(createMockContext());
+
+    expect(screen.getByTestId('cloud-sync-status')).toBeInTheDocument();
+  });
+
+  describe('when disconnected', () => {
+    it('should show connect title', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(
+        screen.getByText('cloudSync.section.connectTitle'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show ConnectGoogleDrive component', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(screen.getByTestId('connect-google-drive')).toBeInTheDocument();
+    });
+
+    it('should not show CloudSyncButton', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(screen.queryByTestId('cloud-sync-button')).not.toBeInTheDocument();
+    });
+
+    it('should not show account section', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(
+        screen.queryByText('cloudSync.section.accountTitle'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when connected', () => {
+    it('should show sync title', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.section.syncTitle'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show CloudSyncButton', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      expect(screen.getByTestId('cloud-sync-button')).toBeInTheDocument();
+    });
+
+    it('should show account section with title', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.section.accountTitle'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show ConnectGoogleDrive in account section only', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      // When connected, ConnectGoogleDrive only appears in the account section
+      // (the main action shows CloudSyncButton instead)
+      const connectComponents = screen.getAllByTestId('connect-google-drive');
+      expect(connectComponents).toHaveLength(1);
+    });
+  });
+
+  describe('when syncing', () => {
+    it('should show sync title', () => {
+      renderWithContext(
+        createMockContext({ state: 'syncing', provider: 'google-drive' }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.section.syncTitle'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show CloudSyncButton and account section', () => {
+      renderWithContext(
+        createMockContext({ state: 'syncing', provider: 'google-drive' }),
+      );
+
+      expect(screen.getByTestId('cloud-sync-button')).toBeInTheDocument();
+      expect(
+        screen.getByText('cloudSync.section.accountTitle'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('when error with provider', () => {
+    it('should show sync title when provider is set', () => {
+      renderWithContext(
+        createMockContext({
+          state: 'error',
+          provider: 'google-drive',
+          error: 'Some error',
+        }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.section.syncTitle'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show CloudSyncButton and account section', () => {
+      renderWithContext(
+        createMockContext({
+          state: 'error',
+          provider: 'google-drive',
+          error: 'Some error',
+        }),
+      );
+
+      expect(screen.getByTestId('cloud-sync-button')).toBeInTheDocument();
+      expect(
+        screen.getByText('cloudSync.section.accountTitle'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('when error without provider', () => {
+    it('should show connect title', () => {
+      renderWithContext(
+        createMockContext({
+          state: 'error',
+          provider: null,
+          error: 'Some error',
+        }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.section.connectTitle'),
+      ).toBeInTheDocument();
+    });
+
+    it('should not show account section', () => {
+      renderWithContext(
+        createMockContext({
+          state: 'error',
+          provider: null,
+          error: 'Some error',
+        }),
+      );
+
+      expect(
+        screen.queryByText('cloudSync.section.accountTitle'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/cloudSync/components/CloudSyncSection.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.test.tsx
@@ -25,6 +25,10 @@ vi.mock('./ConnectGoogleDrive', () => ({
   ),
 }));
 
+vi.mock('./ConnectOneDrive', () => ({
+  ConnectOneDrive: () => <div data-testid="connect-onedrive">Connect</div>,
+}));
+
 const defaultState: CloudSyncState = {
   provider: null,
   lastSyncTimestamp: null,
@@ -75,6 +79,20 @@ describe('CloudSyncSection', () => {
       renderWithContext(createMockContext({ state: 'disconnected' }));
 
       expect(screen.getByTestId('connect-google-drive')).toBeInTheDocument();
+    });
+
+    it('should show ConnectOneDrive component', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(screen.getByTestId('connect-onedrive')).toBeInTheDocument();
+    });
+
+    it('should render both providers in a chooser group', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(
+        screen.getByTestId('cloud-sync-provider-choices'),
+      ).toBeInTheDocument();
     });
 
     it('should not show CloudSyncButton', () => {
@@ -130,6 +148,18 @@ describe('CloudSyncSection', () => {
       // (the main action shows CloudSyncButton instead)
       const connectComponents = screen.getAllByTestId('connect-google-drive');
       expect(connectComponents).toHaveLength(1);
+      expect(screen.queryByTestId('connect-onedrive')).not.toBeInTheDocument();
+    });
+
+    it('should render OneDrive disconnect when provider is onedrive', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'onedrive' }),
+      );
+
+      expect(screen.getByTestId('connect-onedrive')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('connect-google-drive'),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/cloudSync/components/CloudSyncSection.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.tsx
@@ -19,7 +19,7 @@ export function CloudSyncSection() {
     (state.state === 'error' && state.provider !== null);
 
   return (
-    <div className={styles.container} data-testid="section-cloud-sync">
+    <div className={styles.container} data-testid="cloud-sync-content">
       <CloudSyncStatus />
 
       <div className={styles.divider} />

--- a/src/features/cloudSync/components/CloudSyncSection.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.tsx
@@ -19,7 +19,7 @@ export function CloudSyncSection() {
     (state.state === 'error' && state.provider !== null);
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-testid="section-cloud-sync">
       <CloudSyncStatus />
 
       <div className={styles.divider} />

--- a/src/features/cloudSync/components/CloudSyncSection.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+import { CloudSyncStatus } from './CloudSyncStatus';
+import { CloudSyncButton } from './CloudSyncButton';
+import { ConnectGoogleDrive } from './ConnectGoogleDrive';
+import { useCloudSync } from '../hooks';
+import styles from './CloudSyncSection.module.css';
+
+/**
+ * Complete cloud sync section for Settings page.
+ * Combines status, connection, and sync controls.
+ */
+export function CloudSyncSection() {
+  const { t } = useTranslation();
+  const { state } = useCloudSync();
+
+  const isConnected =
+    state.state === 'connected' ||
+    state.state === 'syncing' ||
+    (state.state === 'error' && state.provider !== null);
+
+  return (
+    <div className={styles.container}>
+      <CloudSyncStatus />
+
+      <div className={styles.divider} />
+
+      <div className={styles.actions}>
+        <div className={styles.actionGroup}>
+          <h3 className={styles.actionTitle}>
+            {isConnected
+              ? t('cloudSync.section.syncTitle')
+              : t('cloudSync.section.connectTitle')}
+          </h3>
+          {isConnected ? <CloudSyncButton /> : <ConnectGoogleDrive />}
+        </div>
+
+        {isConnected && (
+          <div className={styles.actionGroup}>
+            <h3 className={styles.actionTitle}>
+              {t('cloudSync.section.accountTitle')}
+            </h3>
+            <ConnectGoogleDrive />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/cloudSync/components/CloudSyncSection.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.tsx
@@ -2,12 +2,17 @@ import { useTranslation } from 'react-i18next';
 import { CloudSyncStatus } from './CloudSyncStatus';
 import { CloudSyncButton } from './CloudSyncButton';
 import { ConnectGoogleDrive } from './ConnectGoogleDrive';
+import { ConnectOneDrive } from './ConnectOneDrive';
 import { useCloudSync } from '../hooks';
 import styles from './CloudSyncSection.module.css';
 
 /**
  * Complete cloud sync section for Settings page.
- * Combines status, connection, and sync controls.
+ * Combines status, provider selection, and sync controls.
+ *
+ * When disconnected, shows all available providers as a chooser.
+ * When connected, shows sync controls plus the active provider's
+ * disconnect button.
  */
 export function CloudSyncSection() {
   const { t } = useTranslation();
@@ -17,6 +22,11 @@ export function CloudSyncSection() {
     state.state === 'connected' ||
     state.state === 'syncing' ||
     (state.state === 'error' && state.provider !== null);
+
+  const renderActiveProviderControls = () => {
+    if (state.provider === 'onedrive') return <ConnectOneDrive />;
+    return <ConnectGoogleDrive />;
+  };
 
   return (
     <div className={styles.container} data-testid="cloud-sync-content">
@@ -31,7 +41,17 @@ export function CloudSyncSection() {
               ? t('cloudSync.section.syncTitle')
               : t('cloudSync.section.connectTitle')}
           </h3>
-          {isConnected ? <CloudSyncButton /> : <ConnectGoogleDrive />}
+          {isConnected ? (
+            <CloudSyncButton />
+          ) : (
+            <div
+              className={styles.providerChoices}
+              data-testid="cloud-sync-provider-choices"
+            >
+              <ConnectGoogleDrive />
+              <ConnectOneDrive />
+            </div>
+          )}
         </div>
 
         {isConnected && (
@@ -39,7 +59,7 @@ export function CloudSyncSection() {
             <h3 className={styles.actionTitle}>
               {t('cloudSync.section.accountTitle')}
             </h3>
-            <ConnectGoogleDrive />
+            {renderActiveProviderControls()}
           </div>
         )}
       </div>

--- a/src/features/cloudSync/components/CloudSyncStatus.module.css
+++ b/src/features/cloudSync/components/CloudSyncStatus.module.css
@@ -1,0 +1,67 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.statusRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.disconnected {
+  background-color: var(--color-text-secondary);
+}
+
+.connected {
+  background-color: var(--color-success);
+}
+
+.syncing {
+  background-color: var(--color-warning);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.error {
+  background-color: var(--color-error);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.statusText {
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.provider {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.lastSync {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.errorMessage {
+  margin: 0;
+  color: var(--color-error);
+  font-size: 0.875rem;
+}

--- a/src/features/cloudSync/components/CloudSyncStatus.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncStatus.test.tsx
@@ -13,6 +13,7 @@ const mockTranslation = jest.fn((key: string, params?: object) => {
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: mockTranslation,
+    i18n: { language: 'en' },
   }),
 }));
 

--- a/src/features/cloudSync/components/CloudSyncStatus.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncStatus.test.tsx
@@ -1,16 +1,17 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CloudSyncStatus } from './CloudSyncStatus';
 import { CloudSyncContext } from '../context';
 import type { CloudSyncContextValue, CloudSyncState } from '../types';
 
-const mockTranslation = jest.fn((key: string, params?: object) => {
+const mockTranslation = vi.fn((key: string, params?: object) => {
   if (params) {
     return `${key} ${JSON.stringify(params)}`;
   }
   return key;
 });
 
-jest.mock('react-i18next', () => ({
+vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: mockTranslation,
     i18n: { language: 'en' },
@@ -29,10 +30,10 @@ const createMockContext = (
   state: Partial<CloudSyncState> = {},
 ): CloudSyncContextValue => ({
   state: { ...defaultState, ...state },
-  connect: jest.fn(),
-  disconnect: jest.fn(),
-  syncNow: jest.fn(),
-  clearError: jest.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  syncNow: vi.fn(),
+  clearError: vi.fn(),
 });
 
 const renderWithContext = (
@@ -47,7 +48,7 @@ const renderWithContext = (
 
 describe('CloudSyncStatus', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('status text', () => {

--- a/src/features/cloudSync/components/CloudSyncStatus.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncStatus.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from '@testing-library/react';
+import { CloudSyncStatus } from './CloudSyncStatus';
+import { CloudSyncContext } from '../context';
+import type { CloudSyncContextValue, CloudSyncState } from '../types';
+
+const mockTranslation = jest.fn((key: string, params?: object) => {
+  if (params) {
+    return `${key} ${JSON.stringify(params)}`;
+  }
+  return key;
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockTranslation,
+  }),
+}));
+
+const defaultState: CloudSyncState = {
+  provider: null,
+  lastSyncTimestamp: null,
+  remoteFileId: null,
+  state: 'disconnected',
+  error: null,
+};
+
+const createMockContext = (
+  state: Partial<CloudSyncState> = {},
+): CloudSyncContextValue => ({
+  state: { ...defaultState, ...state },
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  syncNow: jest.fn(),
+  clearError: jest.fn(),
+});
+
+const renderWithContext = (
+  contextValue: CloudSyncContextValue = createMockContext(),
+) => {
+  return render(
+    <CloudSyncContext.Provider value={contextValue}>
+      <CloudSyncStatus />
+    </CloudSyncContext.Provider>,
+  );
+};
+
+describe('CloudSyncStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('status text', () => {
+    it('should show disconnected status', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(
+        screen.getByText('cloudSync.status.disconnected'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show connected status', () => {
+      renderWithContext(createMockContext({ state: 'connected' }));
+
+      expect(
+        screen.getByText('cloudSync.status.connected'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show syncing status', () => {
+      renderWithContext(createMockContext({ state: 'syncing' }));
+
+      expect(screen.getByText('cloudSync.status.syncing')).toBeInTheDocument();
+    });
+
+    it('should show error status', () => {
+      renderWithContext(createMockContext({ state: 'error' }));
+
+      expect(screen.getByText('cloudSync.status.error')).toBeInTheDocument();
+    });
+  });
+
+  describe('provider display', () => {
+    it('should not show provider when not set', () => {
+      renderWithContext(createMockContext({ provider: null }));
+
+      expect(
+        screen.queryByText(/cloudSync\.providers\./),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show provider name when connected', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      expect(
+        screen.getByText('(cloudSync.providers.google-drive)'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('last sync display', () => {
+    it('should not show last sync when disconnected', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(
+        screen.queryByText(/cloudSync\.status\.lastSync/),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/cloudSync\.status\.neverSynced/),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show never synced when connected with no timestamp', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', lastSyncTimestamp: null }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.status.neverSynced'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show last sync time when available', () => {
+      const timestamp = '2024-01-15T10:30:00Z';
+      renderWithContext(
+        createMockContext({
+          state: 'connected',
+          lastSyncTimestamp: timestamp,
+        }),
+      );
+
+      // The translation mock returns the key with params
+      expect(mockTranslation).toHaveBeenCalledWith(
+        'cloudSync.status.lastSync',
+        {
+          date: expect.any(String),
+          time: expect.any(String),
+        },
+      );
+    });
+  });
+
+  describe('error display', () => {
+    it('should not show error when none exists', () => {
+      renderWithContext(createMockContext({ error: null }));
+
+      // Error message element should not exist
+      const errorElements = document.querySelectorAll(
+        '[class*="errorMessage"]',
+      );
+      expect(errorElements.length).toBe(0);
+    });
+
+    it('should show error message when error exists', () => {
+      const errorMessage = 'Connection failed';
+      renderWithContext(
+        createMockContext({ state: 'error', error: errorMessage }),
+      );
+
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/cloudSync/components/CloudSyncStatus.tsx
+++ b/src/features/cloudSync/components/CloudSyncStatus.tsx
@@ -53,20 +53,34 @@ export function CloudSyncStatus() {
   };
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-testid="cloud-sync-status">
       <div className={styles.statusRow}>
-        <span className={`${styles.indicator} ${getStatusClass()}`} />
-        <span className={styles.statusText}>{getStatusText()}</span>
+        <span
+          className={`${styles.indicator} ${getStatusClass()}`}
+          data-testid="cloud-sync-status-indicator"
+        />
+        <span
+          className={styles.statusText}
+          data-testid="cloud-sync-status-text"
+        >
+          {getStatusText()}
+        </span>
         {state.provider && (
-          <span className={styles.provider}>
+          <span className={styles.provider} data-testid="cloud-sync-provider">
             ({t(`cloudSync.providers.${state.provider}`)})
           </span>
         )}
       </div>
       {state.state !== 'disconnected' && (
-        <p className={styles.lastSync}>{formatLastSync()}</p>
+        <p className={styles.lastSync} data-testid="cloud-sync-last-sync">
+          {formatLastSync()}
+        </p>
       )}
-      {state.error && <p className={styles.errorMessage}>{state.error}</p>}
+      {state.error && (
+        <p className={styles.errorMessage} data-testid="cloud-sync-error">
+          {state.error}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/features/cloudSync/components/CloudSyncStatus.tsx
+++ b/src/features/cloudSync/components/CloudSyncStatus.tsx
@@ -7,7 +7,7 @@ import styles from './CloudSyncStatus.module.css';
  * Shows connection state, last sync time, and any errors.
  */
 export function CloudSyncStatus() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { state } = useCloudSync();
 
   const getStatusText = () => {
@@ -47,8 +47,8 @@ export function CloudSyncStatus() {
 
     const date = new Date(state.lastSyncTimestamp);
     return t('cloudSync.status.lastSync', {
-      date: date.toLocaleDateString(),
-      time: date.toLocaleTimeString(),
+      date: date.toLocaleDateString(i18n.language),
+      time: date.toLocaleTimeString(i18n.language),
     });
   };
 

--- a/src/features/cloudSync/components/CloudSyncStatus.tsx
+++ b/src/features/cloudSync/components/CloudSyncStatus.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next';
+import { useCloudSync } from '../hooks';
+import styles from './CloudSyncStatus.module.css';
+
+/**
+ * Displays the current cloud sync status.
+ * Shows connection state, last sync time, and any errors.
+ */
+export function CloudSyncStatus() {
+  const { t } = useTranslation();
+  const { state } = useCloudSync();
+
+  const getStatusText = () => {
+    switch (state.state) {
+      case 'disconnected':
+        return t('cloudSync.status.disconnected');
+      case 'connected':
+        return t('cloudSync.status.connected');
+      case 'syncing':
+        return t('cloudSync.status.syncing');
+      case 'error':
+        return t('cloudSync.status.error');
+      default:
+        return t('cloudSync.status.disconnected');
+    }
+  };
+
+  const getStatusClass = () => {
+    switch (state.state) {
+      case 'disconnected':
+        return styles.disconnected;
+      case 'connected':
+        return styles.connected;
+      case 'syncing':
+        return styles.syncing;
+      case 'error':
+        return styles.error;
+      default:
+        return styles.disconnected;
+    }
+  };
+
+  const formatLastSync = () => {
+    if (!state.lastSyncTimestamp) {
+      return t('cloudSync.status.neverSynced');
+    }
+
+    const date = new Date(state.lastSyncTimestamp);
+    return t('cloudSync.status.lastSync', {
+      date: date.toLocaleDateString(),
+      time: date.toLocaleTimeString(),
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.statusRow}>
+        <span className={`${styles.indicator} ${getStatusClass()}`} />
+        <span className={styles.statusText}>{getStatusText()}</span>
+        {state.provider && (
+          <span className={styles.provider}>
+            ({t(`cloudSync.providers.${state.provider}`)})
+          </span>
+        )}
+      </div>
+      {state.state !== 'disconnected' && (
+        <p className={styles.lastSync}>{formatLastSync()}</p>
+      )}
+      {state.error && <p className={styles.errorMessage}>{state.error}</p>}
+    </div>
+  );
+}

--- a/src/features/cloudSync/components/ConnectGoogleDrive.module.css
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.module.css
@@ -1,0 +1,36 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.googleButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.connectedInfo {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
+}
+
+.providerIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.connectedText {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}

--- a/src/features/cloudSync/components/ConnectGoogleDrive.test.tsx
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.test.tsx
@@ -1,0 +1,263 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConnectGoogleDrive } from './ConnectGoogleDrive';
+import { CloudSyncContext } from '../context';
+import type { CloudSyncContextValue, CloudSyncState } from '../types';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const defaultState: CloudSyncState = {
+  provider: null,
+  lastSyncTimestamp: null,
+  remoteFileId: null,
+  state: 'disconnected',
+  error: null,
+};
+
+const createMockContext = (
+  state: Partial<CloudSyncState> = {},
+  overrides: Partial<CloudSyncContextValue> = {},
+): CloudSyncContextValue => ({
+  state: { ...defaultState, ...state },
+  connect: jest.fn().mockResolvedValue(undefined),
+  disconnect: jest.fn().mockResolvedValue(undefined),
+  syncNow: jest.fn(),
+  clearError: jest.fn(),
+  ...overrides,
+});
+
+const renderWithContext = (contextValue: CloudSyncContextValue) => {
+  return render(
+    <CloudSyncContext.Provider value={contextValue}>
+      <ConnectGoogleDrive />
+    </CloudSyncContext.Provider>,
+  );
+};
+
+describe('ConnectGoogleDrive', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when disconnected', () => {
+    it('should show connect button', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(screen.getByText('cloudSync.google.connect')).toBeInTheDocument();
+    });
+
+    it('should show description', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(
+        screen.getByText('cloudSync.google.description'),
+      ).toBeInTheDocument();
+    });
+
+    it('should call connect when clicked', async () => {
+      const user = userEvent.setup();
+      const mockConnect = jest.fn().mockResolvedValue(undefined);
+
+      renderWithContext(createMockContext({}, { connect: mockConnect }));
+
+      await user.click(screen.getByText('cloudSync.google.connect'));
+
+      expect(mockConnect).toHaveBeenCalledWith('google-drive');
+    });
+
+    it('should show connecting text during connection', async () => {
+      const user = userEvent.setup();
+      let resolveConnect: () => void;
+      const connectPromise = new Promise<void>((resolve) => {
+        resolveConnect = resolve;
+      });
+      const mockConnect = jest.fn().mockReturnValue(connectPromise);
+
+      renderWithContext(createMockContext({}, { connect: mockConnect }));
+
+      await user.click(screen.getByText('cloudSync.google.connect'));
+
+      expect(
+        screen.getByText('cloudSync.google.connecting'),
+      ).toBeInTheDocument();
+
+      resolveConnect!();
+      await waitFor(() => {
+        expect(
+          screen.queryByText('cloudSync.google.connecting'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('should disable button during connection', async () => {
+      const user = userEvent.setup();
+      let resolveConnect: () => void;
+      const connectPromise = new Promise<void>((resolve) => {
+        resolveConnect = resolve;
+      });
+      const mockConnect = jest.fn().mockReturnValue(connectPromise);
+
+      renderWithContext(createMockContext({}, { connect: mockConnect }));
+
+      await user.click(screen.getByText('cloudSync.google.connect'));
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons[0]).toBeDisabled();
+
+      resolveConnect!();
+      await waitFor(() => {
+        expect(buttons[0]).toBeEnabled();
+      });
+    });
+  });
+
+  describe('when connected', () => {
+    it('should show connected info', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.google.connected'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show disconnect button', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.disconnect.button'),
+      ).toBeInTheDocument();
+    });
+
+    it('should show confirmation dialog on disconnect', async () => {
+      const user = userEvent.setup();
+      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'google-drive' }),
+      );
+
+      await user.click(screen.getByText('cloudSync.disconnect.button'));
+
+      expect(mockConfirm).toHaveBeenCalledWith('cloudSync.disconnect.confirm');
+
+      mockConfirm.mockRestore();
+    });
+
+    it('should call disconnect when confirmed', async () => {
+      const user = userEvent.setup();
+      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      const mockDisconnect = jest.fn().mockResolvedValue(undefined);
+
+      renderWithContext(
+        createMockContext(
+          { state: 'connected', provider: 'google-drive' },
+          { disconnect: mockDisconnect },
+        ),
+      );
+
+      await user.click(screen.getByText('cloudSync.disconnect.button'));
+
+      expect(mockDisconnect).toHaveBeenCalled();
+
+      mockConfirm.mockRestore();
+    });
+
+    it('should not call disconnect when cancelled', async () => {
+      const user = userEvent.setup();
+      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(false);
+      const mockDisconnect = jest.fn().mockResolvedValue(undefined);
+
+      renderWithContext(
+        createMockContext(
+          { state: 'connected', provider: 'google-drive' },
+          { disconnect: mockDisconnect },
+        ),
+      );
+
+      await user.click(screen.getByText('cloudSync.disconnect.button'));
+
+      expect(mockDisconnect).not.toHaveBeenCalled();
+
+      mockConfirm.mockRestore();
+    });
+
+    it('should show disconnecting text during disconnect', async () => {
+      const user = userEvent.setup();
+      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      let resolveDisconnect: () => void;
+      const disconnectPromise = new Promise<void>((resolve) => {
+        resolveDisconnect = resolve;
+      });
+      const mockDisconnect = jest.fn().mockReturnValue(disconnectPromise);
+
+      renderWithContext(
+        createMockContext(
+          { state: 'connected', provider: 'google-drive' },
+          { disconnect: mockDisconnect },
+        ),
+      );
+
+      await user.click(screen.getByText('cloudSync.disconnect.button'));
+
+      expect(
+        screen.getByText('cloudSync.disconnect.disconnecting'),
+      ).toBeInTheDocument();
+
+      resolveDisconnect!();
+      await waitFor(() => {
+        expect(
+          screen.queryByText('cloudSync.disconnect.disconnecting'),
+        ).not.toBeInTheDocument();
+      });
+
+      mockConfirm.mockRestore();
+    });
+
+    it('should disable disconnect button while syncing', () => {
+      renderWithContext(
+        createMockContext({ state: 'syncing', provider: 'google-drive' }),
+      );
+
+      expect(screen.getByText('cloudSync.disconnect.button')).toBeDisabled();
+    });
+  });
+
+  describe('when in error state with provider', () => {
+    it('should show as connected if provider is google-drive', () => {
+      renderWithContext(
+        createMockContext({
+          state: 'error',
+          provider: 'google-drive',
+          error: 'Some error',
+        }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.google.connected'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('cloudSync.disconnect.button'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('syncing state', () => {
+    it('should show as connected when syncing', () => {
+      renderWithContext(
+        createMockContext({ state: 'syncing', provider: 'google-drive' }),
+      );
+
+      expect(
+        screen.getByText('cloudSync.google.connected'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/cloudSync/components/ConnectGoogleDrive.test.tsx
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.test.tsx
@@ -1,10 +1,11 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConnectGoogleDrive } from './ConnectGoogleDrive';
 import { CloudSyncContext } from '../context';
 import type { CloudSyncContextValue, CloudSyncState } from '../types';
 
-jest.mock('react-i18next', () => ({
+vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
   }),
@@ -23,10 +24,10 @@ const createMockContext = (
   overrides: Partial<CloudSyncContextValue> = {},
 ): CloudSyncContextValue => ({
   state: { ...defaultState, ...state },
-  connect: jest.fn().mockResolvedValue(undefined),
-  disconnect: jest.fn().mockResolvedValue(undefined),
-  syncNow: jest.fn(),
-  clearError: jest.fn(),
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+  syncNow: vi.fn(),
+  clearError: vi.fn(),
   ...overrides,
 });
 
@@ -40,7 +41,7 @@ const renderWithContext = (contextValue: CloudSyncContextValue) => {
 
 describe('ConnectGoogleDrive', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('when disconnected', () => {
@@ -60,7 +61,7 @@ describe('ConnectGoogleDrive', () => {
 
     it('should call connect when clicked', async () => {
       const user = userEvent.setup();
-      const mockConnect = jest.fn().mockResolvedValue(undefined);
+      const mockConnect = vi.fn().mockResolvedValue(undefined);
 
       renderWithContext(createMockContext({}, { connect: mockConnect }));
 
@@ -75,7 +76,7 @@ describe('ConnectGoogleDrive', () => {
       const connectPromise = new Promise<void>((resolve) => {
         resolveConnect = resolve;
       });
-      const mockConnect = jest.fn().mockReturnValue(connectPromise);
+      const mockConnect = vi.fn().mockReturnValue(connectPromise);
 
       renderWithContext(createMockContext({}, { connect: mockConnect }));
 
@@ -99,7 +100,7 @@ describe('ConnectGoogleDrive', () => {
       const connectPromise = new Promise<void>((resolve) => {
         resolveConnect = resolve;
       });
-      const mockConnect = jest.fn().mockReturnValue(connectPromise);
+      const mockConnect = vi.fn().mockReturnValue(connectPromise);
 
       renderWithContext(createMockContext({}, { connect: mockConnect }));
 
@@ -138,7 +139,7 @@ describe('ConnectGoogleDrive', () => {
 
     it('should show confirmation dialog on disconnect', async () => {
       const user = userEvent.setup();
-      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(false);
+      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
 
       renderWithContext(
         createMockContext({ state: 'connected', provider: 'google-drive' }),
@@ -153,8 +154,8 @@ describe('ConnectGoogleDrive', () => {
 
     it('should call disconnect when confirmed', async () => {
       const user = userEvent.setup();
-      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
-      const mockDisconnect = jest.fn().mockResolvedValue(undefined);
+      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const mockDisconnect = vi.fn().mockResolvedValue(undefined);
 
       renderWithContext(
         createMockContext(
@@ -172,8 +173,8 @@ describe('ConnectGoogleDrive', () => {
 
     it('should not call disconnect when cancelled', async () => {
       const user = userEvent.setup();
-      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(false);
-      const mockDisconnect = jest.fn().mockResolvedValue(undefined);
+      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      const mockDisconnect = vi.fn().mockResolvedValue(undefined);
 
       renderWithContext(
         createMockContext(
@@ -191,12 +192,12 @@ describe('ConnectGoogleDrive', () => {
 
     it('should show disconnecting text during disconnect', async () => {
       const user = userEvent.setup();
-      const mockConfirm = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
       let resolveDisconnect: () => void;
       const disconnectPromise = new Promise<void>((resolve) => {
         resolveDisconnect = resolve;
       });
-      const mockDisconnect = jest.fn().mockReturnValue(disconnectPromise);
+      const mockDisconnect = vi.fn().mockReturnValue(disconnectPromise);
 
       renderWithContext(
         createMockContext(

--- a/src/features/cloudSync/components/ConnectGoogleDrive.test.tsx
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.test.tsx
@@ -139,7 +139,9 @@ describe('ConnectGoogleDrive', () => {
 
     it('should show confirmation dialog on disconnect', async () => {
       const user = userEvent.setup();
-      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      const mockConfirm = vi
+        .spyOn(globalThis, 'confirm')
+        .mockReturnValue(false);
 
       renderWithContext(
         createMockContext({ state: 'connected', provider: 'google-drive' }),
@@ -154,7 +156,7 @@ describe('ConnectGoogleDrive', () => {
 
     it('should call disconnect when confirmed', async () => {
       const user = userEvent.setup();
-      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const mockConfirm = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
       const mockDisconnect = vi.fn().mockResolvedValue(undefined);
 
       renderWithContext(
@@ -173,7 +175,9 @@ describe('ConnectGoogleDrive', () => {
 
     it('should not call disconnect when cancelled', async () => {
       const user = userEvent.setup();
-      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      const mockConfirm = vi
+        .spyOn(globalThis, 'confirm')
+        .mockReturnValue(false);
       const mockDisconnect = vi.fn().mockResolvedValue(undefined);
 
       renderWithContext(
@@ -192,7 +196,7 @@ describe('ConnectGoogleDrive', () => {
 
     it('should show disconnecting text during disconnect', async () => {
       const user = userEvent.setup();
-      const mockConfirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const mockConfirm = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
       let resolveDisconnect: () => void;
       const disconnectPromise = new Promise<void>((resolve) => {
         resolveDisconnect = resolve;

--- a/src/features/cloudSync/components/ConnectGoogleDrive.tsx
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.tsx
@@ -30,7 +30,7 @@ export function ConnectGoogleDrive() {
   };
 
   const handleDisconnect = async () => {
-    const confirmed = window.confirm(t('cloudSync.disconnect.confirm'));
+    const confirmed = globalThis.confirm(t('cloudSync.disconnect.confirm'));
     if (!confirmed) return;
 
     setIsDisconnecting(true);

--- a/src/features/cloudSync/components/ConnectGoogleDrive.tsx
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/components/Button';
+import { useCloudSync } from '../hooks';
+import styles from './ConnectGoogleDrive.module.css';
+
+/**
+ * Component to connect/disconnect from Google Drive.
+ * Shows Google sign-in button when disconnected,
+ * disconnect option when connected.
+ */
+export function ConnectGoogleDrive() {
+  const { t } = useTranslation();
+  const { state, connect, disconnect } = useCloudSync();
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const isConnected =
+    state.state === 'connected' ||
+    state.state === 'syncing' ||
+    (state.state === 'error' && state.provider === 'google-drive');
+
+  const handleConnect = async () => {
+    setIsConnecting(true);
+    try {
+      await connect('google-drive');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    const confirmed = window.confirm(t('cloudSync.disconnect.confirm'));
+    if (!confirmed) return;
+
+    setIsDisconnecting(true);
+    try {
+      await disconnect();
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  if (isConnected) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.connectedInfo}>
+          <span className={styles.providerIcon}>
+            <GoogleDriveIcon />
+          </span>
+          <span className={styles.connectedText}>
+            {t('cloudSync.google.connected')}
+          </span>
+        </div>
+        <Button
+          variant="secondary"
+          onClick={handleDisconnect}
+          disabled={isDisconnecting || state.state === 'syncing'}
+        >
+          {isDisconnecting
+            ? t('cloudSync.disconnect.disconnecting')
+            : t('cloudSync.disconnect.button')}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <Button
+        variant="secondary"
+        onClick={handleConnect}
+        disabled={isConnecting}
+        className={styles.googleButton}
+      >
+        <GoogleDriveIcon />
+        <span>
+          {isConnecting
+            ? t('cloudSync.google.connecting')
+            : t('cloudSync.google.connect')}
+        </span>
+      </Button>
+      <p className={styles.description}>{t('cloudSync.google.description')}</p>
+    </div>
+  );
+}
+
+/**
+ * Google Drive icon SVG component.
+ */
+function GoogleDriveIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path d="M7.71 3.5L1.15 15L4.58 21L11.13 9.5L7.71 3.5Z" fill="#0066DA" />
+      <path d="M16.29 3.5H7.71L14.27 15H22.85L16.29 3.5Z" fill="#00AC47" />
+      <path d="M1.15 15L4.58 21H19.42L22.85 15H1.15Z" fill="#FFBA00" />
+    </svg>
+  );
+}

--- a/src/features/cloudSync/components/ConnectGoogleDrive.tsx
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.tsx
@@ -43,7 +43,7 @@ export function ConnectGoogleDrive() {
 
   if (isConnected) {
     return (
-      <div className={styles.container}>
+      <div className={styles.container} data-testid="connect-google-drive">
         <div className={styles.connectedInfo}>
           <span className={styles.providerIcon}>
             <GoogleDriveIcon />
@@ -56,6 +56,7 @@ export function ConnectGoogleDrive() {
           variant="secondary"
           onClick={handleDisconnect}
           disabled={isDisconnecting || state.state === 'syncing'}
+          data-testid="cloud-sync-disconnect-button"
         >
           {isDisconnecting
             ? t('cloudSync.disconnect.disconnecting')
@@ -66,12 +67,13 @@ export function ConnectGoogleDrive() {
   }
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-testid="connect-google-drive">
       <Button
         variant="secondary"
         onClick={handleConnect}
         disabled={isConnecting}
         className={styles.googleButton}
+        data-testid="cloud-sync-connect-button"
       >
         <GoogleDriveIcon />
         <span>

--- a/src/features/cloudSync/components/ConnectGoogleDrive.tsx
+++ b/src/features/cloudSync/components/ConnectGoogleDrive.tsx
@@ -16,9 +16,10 @@ export function ConnectGoogleDrive() {
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
   const isConnected =
-    state.state === 'connected' ||
-    state.state === 'syncing' ||
-    (state.state === 'error' && state.provider === 'google-drive');
+    state.provider === 'google-drive' &&
+    (state.state === 'connected' ||
+      state.state === 'syncing' ||
+      state.state === 'error');
 
   const handleConnect = async () => {
     setIsConnecting(true);

--- a/src/features/cloudSync/components/ConnectOneDrive.module.css
+++ b/src/features/cloudSync/components/ConnectOneDrive.module.css
@@ -1,0 +1,36 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.oneDriveButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.connectedInfo {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
+}
+
+.providerIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.connectedText {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}

--- a/src/features/cloudSync/components/ConnectOneDrive.tsx
+++ b/src/features/cloudSync/components/ConnectOneDrive.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/components/Button';
+import { useCloudSync } from '../hooks';
+import styles from './ConnectOneDrive.module.css';
+
+/**
+ * Component to connect/disconnect from Microsoft OneDrive.
+ * Mirrors ConnectGoogleDrive — shows connect button when disconnected,
+ * disconnect option when connected.
+ */
+export function ConnectOneDrive() {
+  const { t } = useTranslation();
+  const { state, connect, disconnect } = useCloudSync();
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const isConnected =
+    state.provider === 'onedrive' &&
+    (state.state === 'connected' ||
+      state.state === 'syncing' ||
+      state.state === 'error');
+
+  const handleConnect = async () => {
+    setIsConnecting(true);
+    try {
+      await connect('onedrive');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    const confirmed = globalThis.confirm(t('cloudSync.disconnect.confirm'));
+    if (!confirmed) return;
+
+    setIsDisconnecting(true);
+    try {
+      await disconnect();
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  if (isConnected) {
+    return (
+      <div className={styles.container} data-testid="connect-onedrive">
+        <div className={styles.connectedInfo}>
+          <span className={styles.providerIcon}>
+            <OneDriveIcon />
+          </span>
+          <span className={styles.connectedText}>
+            {t('cloudSync.onedrive.connected')}
+          </span>
+        </div>
+        <Button
+          variant="secondary"
+          onClick={handleDisconnect}
+          disabled={isDisconnecting || state.state === 'syncing'}
+          data-testid="cloud-sync-disconnect-button"
+        >
+          {isDisconnecting
+            ? t('cloudSync.disconnect.disconnecting')
+            : t('cloudSync.disconnect.button')}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container} data-testid="connect-onedrive">
+      <Button
+        variant="secondary"
+        onClick={handleConnect}
+        disabled={isConnecting}
+        className={styles.oneDriveButton}
+        data-testid="cloud-sync-connect-onedrive-button"
+      >
+        <OneDriveIcon />
+        <span>
+          {isConnecting
+            ? t('cloudSync.onedrive.connecting')
+            : t('cloudSync.onedrive.connect')}
+        </span>
+      </Button>
+      <p className={styles.description}>
+        {t('cloudSync.onedrive.description')}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * OneDrive icon SVG (Microsoft cloud emblem in OneDrive blue).
+ */
+function OneDriveIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M14.5 8.5C13.7 6.5 11.7 5 9.5 5C6.7 5 4.4 7.1 4.1 9.8C2.3 10.2 1 11.7 1 13.5C1 15.4 2.6 17 4.5 17H17.5C19.4 17 21 15.4 21 13.5C21 11.9 19.9 10.6 18.4 10.2C18.5 9.8 18.5 9.4 18.5 9C18.5 6.5 16.5 4.5 14 4.5C13.4 4.5 12.9 4.6 12.4 4.8"
+        fill="#0078D4"
+      />
+      <path
+        d="M5 13L8 11L11 12.5L14 10L19 13L17.5 17H4.5L5 13Z"
+        fill="#28A8EA"
+      />
+    </svg>
+  );
+}

--- a/src/features/cloudSync/components/index.test.ts
+++ b/src/features/cloudSync/components/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+// Test that all exports are properly re-exported from the index file
+import * as componentsExports from './index';
+
+describe('components/index exports', () => {
+  it('should export CloudSyncSection', () => {
+    expect(componentsExports.CloudSyncSection).toBeDefined();
+  });
+
+  it('should export CloudSyncStatus', () => {
+    expect(componentsExports.CloudSyncStatus).toBeDefined();
+  });
+
+  it('should export CloudSyncButton', () => {
+    expect(componentsExports.CloudSyncButton).toBeDefined();
+  });
+
+  it('should export ConnectGoogleDrive', () => {
+    expect(componentsExports.ConnectGoogleDrive).toBeDefined();
+  });
+});

--- a/src/features/cloudSync/components/index.ts
+++ b/src/features/cloudSync/components/index.ts
@@ -1,0 +1,4 @@
+export { CloudSyncSection } from './CloudSyncSection';
+export { CloudSyncStatus } from './CloudSyncStatus';
+export { CloudSyncButton } from './CloudSyncButton';
+export { ConnectGoogleDrive } from './ConnectGoogleDrive';

--- a/src/features/cloudSync/components/index.ts
+++ b/src/features/cloudSync/components/index.ts
@@ -2,3 +2,4 @@ export { CloudSyncSection } from './CloudSyncSection';
 export { CloudSyncStatus } from './CloudSyncStatus';
 export { CloudSyncButton } from './CloudSyncButton';
 export { ConnectGoogleDrive } from './ConnectGoogleDrive';
+export { ConnectOneDrive } from './ConnectOneDrive';

--- a/src/features/cloudSync/context.ts
+++ b/src/features/cloudSync/context.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+import type { CloudSyncContextValue } from './types';
+
+/**
+ * React context for cloud sync functionality.
+ * Provides access to sync state and operations.
+ */
+export const CloudSyncContext = createContext<CloudSyncContextValue | null>(
+  null,
+);

--- a/src/features/cloudSync/hooks/index.ts
+++ b/src/features/cloudSync/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useCloudSync } from './useCloudSync';

--- a/src/features/cloudSync/hooks/useCloudSync.test.tsx
+++ b/src/features/cloudSync/hooks/useCloudSync.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCloudSync } from './useCloudSync';
+import { CloudSyncContext } from '../context';
+import type { CloudSyncContextValue } from '../types';
+import type { ReactNode } from 'react';
+
+describe('useCloudSync', () => {
+  it('should throw error when used outside provider', () => {
+    // Suppress console.error for expected error
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useCloudSync());
+    }).toThrow('useCloudSync must be used within a CloudSyncProvider');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should return context value when used within provider', () => {
+    const mockContextValue: CloudSyncContextValue = {
+      state: {
+        provider: 'google-drive',
+        lastSyncTimestamp: null,
+        remoteFileId: null,
+        state: 'connected',
+        error: null,
+      },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      syncNow: vi.fn(),
+      clearError: vi.fn(),
+    };
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CloudSyncContext.Provider value={mockContextValue}>
+        {children}
+      </CloudSyncContext.Provider>
+    );
+
+    const { result } = renderHook(() => useCloudSync(), { wrapper });
+
+    expect(result.current).toBe(mockContextValue);
+    expect(result.current.state.state).toBe('connected');
+    expect(result.current.state.provider).toBe('google-drive');
+  });
+});

--- a/src/features/cloudSync/hooks/useCloudSync.ts
+++ b/src/features/cloudSync/hooks/useCloudSync.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { CloudSyncContext } from '../context';
+import type { CloudSyncContextValue } from '../types';
+
+/**
+ * Hook to access cloud sync functionality.
+ * Must be used within a CloudSyncProvider.
+ */
+export function useCloudSync(): CloudSyncContextValue {
+  const context = useContext(CloudSyncContext);
+
+  if (!context) {
+    throw new Error('useCloudSync must be used within a CloudSyncProvider');
+  }
+
+  return context;
+}

--- a/src/features/cloudSync/index.ts
+++ b/src/features/cloudSync/index.ts
@@ -1,0 +1,24 @@
+// Components
+export { CloudSyncProvider } from './provider';
+export { CloudSyncSection } from './components/CloudSyncSection';
+export { CloudSyncStatus } from './components/CloudSyncStatus';
+export { CloudSyncButton } from './components/CloudSyncButton';
+export { ConnectGoogleDrive } from './components/ConnectGoogleDrive';
+
+// Hooks
+export { useCloudSync } from './hooks';
+
+// Types
+export type {
+  CloudProvider,
+  SyncState,
+  SyncDirection,
+  SyncResult,
+  CloudSyncConfig,
+  CloudSyncState,
+  CloudSyncContextValue,
+  CloudStorageProvider,
+  CloudFileMetadata,
+  CloudSyncErrorCode,
+} from './types';
+export { CloudSyncError } from './types';

--- a/src/features/cloudSync/provider.test.tsx
+++ b/src/features/cloudSync/provider.test.tsx
@@ -64,7 +64,7 @@ describe('CloudSyncProvider', () => {
   let initializeProvidersSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    window.localStorage.clear();
+    globalThis.localStorage.clear();
     cloudStorageProvider.resetProviders();
 
     // Create fresh mock provider for each test
@@ -113,7 +113,7 @@ describe('CloudSyncProvider', () => {
       lastSyncTimestamp: '2024-01-01T00:00:00Z',
       remoteFileId: 'file-123',
     };
-    window.localStorage.setItem(
+    globalThis.localStorage.setItem(
       'emergencySupplyTracker_cloudSyncConfig',
       JSON.stringify(config),
     );
@@ -125,7 +125,7 @@ describe('CloudSyncProvider', () => {
       expiresAt: Date.now() + 3600000,
       provider: 'google-drive',
     };
-    window.localStorage.setItem(
+    globalThis.localStorage.setItem(
       'emergencySupplyTracker_cloudTokens',
       JSON.stringify(tokens),
     );
@@ -142,7 +142,7 @@ describe('CloudSyncProvider', () => {
 
   it('should handle invalid JSON in config gracefully', () => {
     // Store invalid JSON
-    window.localStorage.setItem(
+    globalThis.localStorage.setItem(
       'emergencySupplyTracker_cloudSyncConfig',
       'invalid json{',
     );
@@ -194,8 +194,9 @@ describe('CloudSyncProvider', () => {
 
       // Check that config was saved with file ID
       const savedConfig = JSON.parse(
-        window.localStorage.getItem('emergencySupplyTracker_cloudSyncConfig') ??
-          '{}',
+        globalThis.localStorage.getItem(
+          'emergencySupplyTracker_cloudSyncConfig',
+        ) ?? '{}',
       );
       expect(savedConfig.remoteFileId).toBe('existing-file-id');
     });
@@ -331,7 +332,7 @@ describe('CloudSyncProvider', () => {
         <CloudSyncProvider>
           <TestConsumer
             onStateChange={(cs) => {
-              (window as unknown as Record<string, unknown>).testSyncNow =
+              (globalThis as unknown as Record<string, unknown>).testSyncNow =
                 cs.syncNow;
             }}
           />
@@ -339,7 +340,7 @@ describe('CloudSyncProvider', () => {
       );
 
       const syncResult = await (
-        window as unknown as { testSyncNow: () => Promise<unknown> }
+        globalThis as unknown as { testSyncNow: () => Promise<unknown> }
       ).testSyncNow();
 
       expect(syncResult).toEqual(
@@ -539,7 +540,7 @@ describe('CloudSyncProvider', () => {
       mockLocalStorage.getAppData.mockReturnValue(localData);
 
       // Store config with file ID that will be deleted
-      window.localStorage.setItem(
+      globalThis.localStorage.setItem(
         'emergencySupplyTracker_cloudSyncConfig',
         JSON.stringify({
           provider: 'google-drive',
@@ -549,7 +550,7 @@ describe('CloudSyncProvider', () => {
       );
 
       // Store tokens to appear connected
-      window.localStorage.setItem(
+      globalThis.localStorage.setItem(
         'emergencySupplyTracker_cloudTokens',
         JSON.stringify({
           accessToken: 'token',

--- a/src/features/cloudSync/provider.test.tsx
+++ b/src/features/cloudSync/provider.test.tsx
@@ -351,7 +351,7 @@ describe('CloudSyncProvider', () => {
       );
     });
 
-    it('should return error result when no local data without changing state', async () => {
+    it('should return error result and set error state when no local data', async () => {
       const user = userEvent.setup();
       mockLocalStorage.getAppData.mockReturnValue(null);
 
@@ -372,7 +372,7 @@ describe('CloudSyncProvider', () => {
         expect(screen.getByTestId('state')).toHaveTextContent('connected');
       });
 
-      // Sync with no data - should return error result but not change state
+      // Sync with no data - should return error result and set error state
       const result = await capturedSyncNow!();
       expect(result).toEqual(
         expect.objectContaining({
@@ -381,8 +381,9 @@ describe('CloudSyncProvider', () => {
         }),
       );
 
-      // State should stay connected (not changed to error)
-      expect(screen.getByTestId('state')).toHaveTextContent('connected');
+      await waitFor(() => {
+        expect(screen.getByTestId('state')).toHaveTextContent('error');
+      });
     });
 
     it('should upload when local is newer', async () => {
@@ -659,9 +660,12 @@ describe('CloudSyncProvider', () => {
       // Now provider reports disconnected
       await user.click(screen.getByText('Sync'));
 
-      // Should handle gracefully - state remains connected
+      // State should reflect the error so the UI is not misleading
       await waitFor(() => {
-        expect(screen.getByTestId('state')).toHaveTextContent('connected');
+        expect(screen.getByTestId('state')).toHaveTextContent('error');
+        expect(screen.getByTestId('error')).toHaveTextContent(
+          'Not connected to cloud provider',
+        );
       });
     });
   });

--- a/src/features/cloudSync/provider.tsx
+++ b/src/features/cloudSync/provider.tsx
@@ -274,13 +274,11 @@ export function CloudSyncProvider({ children }: CloudSyncProviderProps) {
           error: null,
         });
 
-        // Trigger page reload to reflect new data
-        window.location.reload();
-
         return {
           success: true,
           direction: 'download',
           timestamp,
+          requiresReload: true,
         };
       } else {
         // No changes needed

--- a/src/features/cloudSync/provider.tsx
+++ b/src/features/cloudSync/provider.tsx
@@ -335,7 +335,13 @@ export function CloudSyncProvider({ children }: CloudSyncProviderProps) {
     try {
       const localData = getAppData();
       if (!localData) {
-        return createErrorResult('No local data to sync');
+        const errorMessage = 'No local data to sync';
+        setState((prev) => ({
+          ...prev,
+          state: 'error',
+          error: errorMessage,
+        }));
+        return createErrorResult(errorMessage);
       }
 
       const localModified = new Date(localData.lastModified).getTime();

--- a/src/features/cloudSync/provider.tsx
+++ b/src/features/cloudSync/provider.tsx
@@ -1,0 +1,353 @@
+import { useState, useCallback, useEffect, type ReactNode } from 'react';
+import { CloudSyncContext } from './context';
+import type {
+  CloudProvider,
+  CloudSyncState,
+  CloudSyncConfig,
+  SyncResult,
+  CloudStorageProvider,
+} from './types';
+import { CloudSyncError, createDefaultCloudSyncState } from './types';
+import {
+  getProvider,
+  initializeProviders,
+  getTokensForProvider,
+} from './services';
+import { getAppData, saveAppData } from '@/shared/utils/storage/localStorage';
+
+// Storage key for cloud sync config (separate from app data)
+const CLOUD_SYNC_CONFIG_KEY = 'emergencySupplyTracker_cloudSyncConfig';
+
+/**
+ * Load cloud sync config from localStorage.
+ */
+function loadCloudSyncConfig(): CloudSyncConfig {
+  try {
+    const json = localStorage.getItem(CLOUD_SYNC_CONFIG_KEY);
+    if (!json) {
+      return {
+        provider: null,
+        lastSyncTimestamp: null,
+        remoteFileId: null,
+      };
+    }
+    return JSON.parse(json) as CloudSyncConfig;
+  } catch {
+    return {
+      provider: null,
+      lastSyncTimestamp: null,
+      remoteFileId: null,
+    };
+  }
+}
+
+/**
+ * Save cloud sync config to localStorage.
+ */
+function saveCloudSyncConfig(config: CloudSyncConfig): void {
+  try {
+    localStorage.setItem(CLOUD_SYNC_CONFIG_KEY, JSON.stringify(config));
+  } catch (error) {
+    console.error('Failed to save cloud sync config:', error);
+  }
+}
+
+/**
+ * Clear cloud sync config from localStorage.
+ */
+function clearCloudSyncConfig(): void {
+  try {
+    localStorage.removeItem(CLOUD_SYNC_CONFIG_KEY);
+  } catch (error) {
+    console.error('Failed to clear cloud sync config:', error);
+  }
+}
+
+interface CloudSyncProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Provider component for cloud sync functionality.
+ * Manages connection state, sync operations, and error handling.
+ */
+export function CloudSyncProvider({ children }: CloudSyncProviderProps) {
+  const [state, setState] = useState<CloudSyncState>(() => {
+    const config = loadCloudSyncConfig();
+    const tokens = config.provider
+      ? getTokensForProvider(config.provider)
+      : null;
+
+    return {
+      ...config,
+      state: tokens ? 'connected' : 'disconnected',
+      error: null,
+    };
+  });
+
+  // Initialize providers on mount
+  useEffect(() => {
+    initializeProviders();
+  }, []);
+
+  /**
+   * Connect to a cloud provider.
+   */
+  const connect = useCallback(async (providerId: CloudProvider) => {
+    const provider = getProvider(providerId);
+    if (!provider) {
+      setState((prev) => ({
+        ...prev,
+        state: 'error',
+        error: `Provider not available: ${providerId}`,
+      }));
+      return;
+    }
+
+    setState((prev) => ({ ...prev, state: 'syncing', error: null }));
+
+    try {
+      await provider.connect();
+
+      const newConfig: CloudSyncConfig = {
+        provider: providerId,
+        lastSyncTimestamp: null,
+        remoteFileId: null,
+      };
+
+      // Try to find existing sync file
+      const existingFileId = await provider.findSyncFile();
+      if (existingFileId) {
+        newConfig.remoteFileId = existingFileId;
+      }
+
+      saveCloudSyncConfig(newConfig);
+
+      setState({
+        ...newConfig,
+        state: 'connected',
+        error: null,
+      });
+    } catch (error) {
+      const message =
+        error instanceof CloudSyncError
+          ? error.message
+          : 'Failed to connect to cloud provider';
+
+      setState((prev) => ({
+        ...prev,
+        state: 'error',
+        error: message,
+      }));
+    }
+  }, []);
+
+  /**
+   * Disconnect from current cloud provider.
+   */
+  const disconnect = useCallback(async () => {
+    if (state.provider) {
+      const provider = getProvider(state.provider);
+      if (provider) {
+        try {
+          await provider.disconnect();
+        } catch (error) {
+          console.error('Error during disconnect:', error);
+        }
+      }
+    }
+
+    clearCloudSyncConfig();
+
+    setState(createDefaultCloudSyncState());
+  }, [state.provider]);
+
+  /**
+   * Perform sync operation (last-write-wins).
+   */
+  const syncNow = useCallback(async (): Promise<SyncResult> => {
+    if (!state.provider) {
+      return {
+        success: false,
+        direction: 'none',
+        timestamp: new Date().toISOString(),
+        error: 'Not connected to a cloud provider',
+      };
+    }
+
+    const provider = getProvider(state.provider) as CloudStorageProvider;
+    if (!provider || !provider.isConnected()) {
+      return {
+        success: false,
+        direction: 'none',
+        timestamp: new Date().toISOString(),
+        error: 'Not connected to cloud provider',
+      };
+    }
+
+    setState((prev) => ({ ...prev, state: 'syncing', error: null }));
+
+    try {
+      const localData = getAppData();
+      if (!localData) {
+        return {
+          success: false,
+          direction: 'none',
+          timestamp: new Date().toISOString(),
+          error: 'No local data to sync',
+        };
+      }
+
+      const localModified = new Date(localData.lastModified).getTime();
+      let remoteModified = 0;
+      let remoteFileId = state.remoteFileId;
+
+      // Check if remote file exists and get its modification time
+      if (remoteFileId) {
+        const metadata = await provider.getFileMetadata(remoteFileId);
+        if (metadata) {
+          remoteModified = new Date(metadata.modifiedTime).getTime();
+        } else {
+          // File was deleted remotely
+          remoteFileId = null;
+        }
+      }
+
+      // If no remote file, try to find one
+      if (!remoteFileId) {
+        remoteFileId = await provider.findSyncFile();
+        if (remoteFileId) {
+          const metadata = await provider.getFileMetadata(remoteFileId);
+          if (metadata) {
+            remoteModified = new Date(metadata.modifiedTime).getTime();
+          }
+        }
+      }
+
+      const timestamp = new Date().toISOString();
+
+      // Determine sync direction using last-write-wins
+      if (!remoteFileId || localModified > remoteModified) {
+        // Upload: local is newer or no remote file
+        const dataJson = JSON.stringify(localData, null, 2);
+        const newFileId = await provider.upload(
+          dataJson,
+          remoteFileId || undefined,
+        );
+
+        const newConfig: CloudSyncConfig = {
+          provider: state.provider,
+          lastSyncTimestamp: timestamp,
+          remoteFileId: newFileId,
+        };
+        saveCloudSyncConfig(newConfig);
+
+        setState({
+          ...newConfig,
+          state: 'connected',
+          error: null,
+        });
+
+        return {
+          success: true,
+          direction: 'upload',
+          timestamp,
+        };
+      } else if (remoteModified > localModified) {
+        // Download: remote is newer
+        const remoteDataJson = await provider.download(remoteFileId);
+        const remoteData = JSON.parse(remoteDataJson);
+
+        // Save remote data to localStorage
+        saveAppData(remoteData);
+
+        const newConfig: CloudSyncConfig = {
+          provider: state.provider,
+          lastSyncTimestamp: timestamp,
+          remoteFileId,
+        };
+        saveCloudSyncConfig(newConfig);
+
+        setState({
+          ...newConfig,
+          state: 'connected',
+          error: null,
+        });
+
+        // Trigger page reload to reflect new data
+        window.location.reload();
+
+        return {
+          success: true,
+          direction: 'download',
+          timestamp,
+        };
+      } else {
+        // No changes needed
+        const newConfig: CloudSyncConfig = {
+          provider: state.provider,
+          lastSyncTimestamp: timestamp,
+          remoteFileId,
+        };
+        saveCloudSyncConfig(newConfig);
+
+        setState({
+          ...newConfig,
+          state: 'connected',
+          error: null,
+        });
+
+        return {
+          success: true,
+          direction: 'none',
+          timestamp,
+        };
+      }
+    } catch (error) {
+      const message =
+        error instanceof CloudSyncError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'Sync failed';
+
+      setState((prev) => ({
+        ...prev,
+        state: 'error',
+        error: message,
+      }));
+
+      return {
+        success: false,
+        direction: 'none',
+        timestamp: new Date().toISOString(),
+        error: message,
+      };
+    }
+  }, [state.provider, state.remoteFileId]);
+
+  /**
+   * Clear current error state.
+   */
+  const clearError = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      state: prev.provider ? 'connected' : 'disconnected',
+      error: null,
+    }));
+  }, []);
+
+  return (
+    <CloudSyncContext.Provider
+      value={{
+        state,
+        connect,
+        disconnect,
+        syncNow,
+        clearError,
+      }}
+    >
+      {children}
+    </CloudSyncContext.Provider>
+  );
+}

--- a/src/features/cloudSync/provider.tsx
+++ b/src/features/cloudSync/provider.tsx
@@ -141,6 +141,9 @@ async function getRemoteFileInfo(
       const metadata = await provider.getFileMetadata(fileId);
       if (metadata) {
         modifiedTime = new Date(metadata.modifiedTime).getTime();
+      } else {
+        // File ID was returned but metadata fetch failed - treat as not found
+        fileId = null;
       }
     }
   }
@@ -191,6 +194,13 @@ async function performSync(
   if (remoteModified > localModified) {
     const remoteDataJson = await provider.download(remoteFileId);
     const remoteData = JSON.parse(remoteDataJson);
+    if (!remoteData || typeof remoteData !== 'object') {
+      throw new CloudSyncError(
+        'Invalid remote data format',
+        'PARSE_ERROR',
+        false,
+      );
+    }
     saveAppData(remoteData);
 
     const newConfig: CloudSyncConfig = {
@@ -327,7 +337,9 @@ export function CloudSyncProvider({ children }: CloudSyncProviderProps) {
 
     const provider = getProvider(state.provider) as CloudStorageProvider;
     if (!provider?.isConnected()) {
-      return createErrorResult('Not connected to cloud provider');
+      const message = 'Not connected to cloud provider';
+      setState((prev) => ({ ...prev, state: 'error', error: message }));
+      return createErrorResult(message);
     }
 
     setState((prev) => ({ ...prev, state: 'syncing', error: null }));
@@ -345,6 +357,15 @@ export function CloudSyncProvider({ children }: CloudSyncProviderProps) {
       }
 
       const localModified = new Date(localData.lastModified).getTime();
+      if (Number.isNaN(localModified)) {
+        const errorMessage = 'Invalid local data timestamp';
+        setState((prev) => ({
+          ...prev,
+          state: 'error',
+          error: errorMessage,
+        }));
+        return createErrorResult(errorMessage);
+      }
       const { fileId: remoteFileId, modifiedTime: remoteModified } =
         await getRemoteFileInfo(provider, state.remoteFileId);
 

--- a/src/features/cloudSync/services/cloudStorageProvider.test.ts
+++ b/src/features/cloudSync/services/cloudStorageProvider.test.ts
@@ -10,8 +10,8 @@ import {
 import type { CloudStorageProvider } from '../types';
 
 // Mock GoogleDriveService to avoid loading actual Google API
-vi.mock('./googleDrive', () => ({
-  GoogleDriveService: vi.fn().mockImplementation(() => ({
+vi.mock('./googleDrive', () => {
+  const mockInstance = {
     providerId: 'google-drive',
     connect: vi.fn(),
     disconnect: vi.fn(),
@@ -21,8 +21,22 @@ vi.mock('./googleDrive', () => ({
     download: vi.fn(),
     getFileMetadata: vi.fn(),
     findSyncFile: vi.fn(),
-  })),
-}));
+  };
+
+  return {
+    GoogleDriveService: class {
+      providerId = mockInstance.providerId;
+      connect = mockInstance.connect;
+      disconnect = mockInstance.disconnect;
+      isConnected = mockInstance.isConnected;
+      getAccessToken = mockInstance.getAccessToken;
+      upload = mockInstance.upload;
+      download = mockInstance.download;
+      getFileMetadata = mockInstance.getFileMetadata;
+      findSyncFile = mockInstance.findSyncFile;
+    },
+  };
+});
 
 describe('cloudStorageProvider', () => {
   beforeEach(() => {

--- a/src/features/cloudSync/services/cloudStorageProvider.test.ts
+++ b/src/features/cloudSync/services/cloudStorageProvider.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  registerProvider,
+  getProvider,
+  getAvailableProviders,
+  isProviderAvailable,
+  initializeProviders,
+  resetProviders,
+} from './cloudStorageProvider';
+import type { CloudStorageProvider } from '../types';
+
+// Mock GoogleDriveService to avoid loading actual Google API
+vi.mock('./googleDrive', () => ({
+  GoogleDriveService: vi.fn().mockImplementation(() => ({
+    providerId: 'google-drive',
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: vi.fn(),
+    getAccessToken: vi.fn(),
+    upload: vi.fn(),
+    download: vi.fn(),
+    getFileMetadata: vi.fn(),
+    findSyncFile: vi.fn(),
+  })),
+}));
+
+describe('cloudStorageProvider', () => {
+  beforeEach(() => {
+    resetProviders();
+  });
+
+  describe('registerProvider', () => {
+    it('should register a provider factory', () => {
+      const mockFactory = vi.fn(() => ({
+        providerId: 'google-drive',
+      })) as unknown as () => CloudStorageProvider;
+
+      registerProvider('google-drive', mockFactory);
+
+      expect(isProviderAvailable('google-drive')).toBe(true);
+    });
+  });
+
+  describe('getProvider', () => {
+    it('should return provider instance from factory', () => {
+      const mockProvider = {
+        providerId: 'google-drive',
+      } as CloudStorageProvider;
+      const mockFactory = vi.fn(() => mockProvider);
+
+      registerProvider('google-drive', mockFactory);
+
+      const result = getProvider('google-drive');
+
+      expect(result).toBe(mockProvider);
+      expect(mockFactory).toHaveBeenCalled();
+    });
+
+    it('should return null for unregistered provider', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = getProvider('google-drive');
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Cloud provider not registered: google-drive',
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('getAvailableProviders', () => {
+    it('should return empty array when no providers registered', () => {
+      expect(getAvailableProviders()).toEqual([]);
+    });
+
+    it('should return array of registered provider IDs', () => {
+      const mockFactory = vi.fn() as unknown as () => CloudStorageProvider;
+      registerProvider('google-drive', mockFactory);
+
+      expect(getAvailableProviders()).toEqual(['google-drive']);
+    });
+  });
+
+  describe('isProviderAvailable', () => {
+    it('should return false for unregistered provider', () => {
+      expect(isProviderAvailable('google-drive')).toBe(false);
+    });
+
+    it('should return true for registered provider', () => {
+      const mockFactory = vi.fn() as unknown as () => CloudStorageProvider;
+      registerProvider('google-drive', mockFactory);
+
+      expect(isProviderAvailable('google-drive')).toBe(true);
+    });
+  });
+
+  describe('initializeProviders', () => {
+    it('should register Google Drive provider', () => {
+      initializeProviders();
+
+      expect(isProviderAvailable('google-drive')).toBe(true);
+    });
+
+    it('should return singleton instance for Google Drive', () => {
+      initializeProviders();
+
+      const instance1 = getProvider('google-drive');
+      const instance2 = getProvider('google-drive');
+
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe('resetProviders', () => {
+    it('should clear all registered providers', () => {
+      initializeProviders();
+      expect(isProviderAvailable('google-drive')).toBe(true);
+
+      resetProviders();
+
+      expect(isProviderAvailable('google-drive')).toBe(false);
+      expect(getAvailableProviders()).toEqual([]);
+    });
+
+    it('should reset singleton instances', () => {
+      initializeProviders();
+      const instance1 = getProvider('google-drive');
+
+      resetProviders();
+      initializeProviders();
+
+      const instance2 = getProvider('google-drive');
+
+      // After reset, should create a new instance
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+});

--- a/src/features/cloudSync/services/cloudStorageProvider.ts
+++ b/src/features/cloudSync/services/cloudStorageProvider.ts
@@ -1,0 +1,81 @@
+/**
+ * Cloud storage provider abstraction.
+ * This module provides factory functions for creating provider instances
+ * and utilities for working with providers.
+ */
+
+import type { CloudProvider, CloudStorageProvider } from '../types';
+import { GoogleDriveService } from './googleDrive';
+
+// Registry of available providers
+const providerRegistry: Map<CloudProvider, () => CloudStorageProvider> =
+  new Map();
+
+/**
+ * Register a provider factory.
+ * Call this during app initialization for each supported provider.
+ */
+export function registerProvider(
+  providerId: CloudProvider,
+  factory: () => CloudStorageProvider,
+): void {
+  providerRegistry.set(providerId, factory);
+}
+
+/**
+ * Get a provider instance by ID.
+ * Returns null if provider is not registered.
+ */
+export function getProvider(
+  providerId: CloudProvider,
+): CloudStorageProvider | null {
+  const factory = providerRegistry.get(providerId);
+  if (!factory) {
+    console.warn(`Cloud provider not registered: ${providerId}`);
+    return null;
+  }
+  return factory();
+}
+
+/**
+ * Get list of available provider IDs.
+ */
+export function getAvailableProviders(): CloudProvider[] {
+  return Array.from(providerRegistry.keys());
+}
+
+/**
+ * Check if a provider is available.
+ */
+export function isProviderAvailable(providerId: CloudProvider): boolean {
+  return providerRegistry.has(providerId);
+}
+
+// Singleton instance for Google Drive
+let googleDriveInstance: GoogleDriveService | null = null;
+
+/**
+ * Initialize the provider registry with available providers.
+ * Call this during app startup.
+ */
+export function initializeProviders(): void {
+  // Register Google Drive provider
+  registerProvider('google-drive', () => {
+    if (!googleDriveInstance) {
+      googleDriveInstance = new GoogleDriveService();
+    }
+    return googleDriveInstance;
+  });
+
+  // Future: Register OneDrive, Dropbox, etc.
+  // registerProvider('onedrive', () => new OneDriveService());
+  // registerProvider('dropbox', () => new DropboxService());
+}
+
+/**
+ * Reset provider instances (useful for testing).
+ */
+export function resetProviders(): void {
+  googleDriveInstance = null;
+  providerRegistry.clear();
+}

--- a/src/features/cloudSync/services/cloudStorageProvider.ts
+++ b/src/features/cloudSync/services/cloudStorageProvider.ts
@@ -61,9 +61,7 @@ let googleDriveInstance: GoogleDriveService | null = null;
 export function initializeProviders(): void {
   // Register Google Drive provider
   registerProvider('google-drive', () => {
-    if (!googleDriveInstance) {
-      googleDriveInstance = new GoogleDriveService();
-    }
+    googleDriveInstance ??= new GoogleDriveService();
     return googleDriveInstance;
   });
 

--- a/src/features/cloudSync/services/cloudStorageProvider.ts
+++ b/src/features/cloudSync/services/cloudStorageProvider.ts
@@ -6,6 +6,7 @@
 
 import type { CloudProvider, CloudStorageProvider } from '../types';
 import { GoogleDriveService } from './googleDrive';
+import { OneDriveService } from './oneDrive';
 
 // Registry of available providers
 const providerRegistry: Map<CloudProvider, () => CloudStorageProvider> =
@@ -51,23 +52,26 @@ export function isProviderAvailable(providerId: CloudProvider): boolean {
   return providerRegistry.has(providerId);
 }
 
-// Singleton instance for Google Drive
+// Singleton instances per provider
 let googleDriveInstance: GoogleDriveService | null = null;
+let oneDriveInstance: OneDriveService | null = null;
 
 /**
  * Initialize the provider registry with available providers.
  * Call this during app startup.
  */
 export function initializeProviders(): void {
-  // Register Google Drive provider
   registerProvider('google-drive', () => {
     googleDriveInstance ??= new GoogleDriveService();
     return googleDriveInstance;
   });
 
-  // Future: Register OneDrive, Dropbox, etc.
-  // registerProvider('onedrive', () => new OneDriveService());
-  // registerProvider('dropbox', () => new DropboxService());
+  registerProvider('onedrive', () => {
+    oneDriveInstance ??= new OneDriveService();
+    return oneDriveInstance;
+  });
+
+  // Future: Register Dropbox, iCloud, etc.
 }
 
 /**
@@ -75,5 +79,6 @@ export function initializeProviders(): void {
  */
 export function resetProviders(): void {
   googleDriveInstance = null;
+  oneDriveInstance = null;
   providerRegistry.clear();
 }

--- a/src/features/cloudSync/services/googleDrive.test.ts
+++ b/src/features/cloudSync/services/googleDrive.test.ts
@@ -1,0 +1,1074 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for GoogleDriveService functionality.
+ *
+ * We test a TestableGoogleDriveService class that mirrors the real implementation
+ * but allows us to inject the client ID via setClientId() instead of reading
+ * from import.meta.env.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { CloudSyncError } from '../types';
+import type { CloudStorageProvider, StoredTokens } from '../types';
+import * as tokenStorage from './tokenStorage';
+
+// Mock tokenStorage module
+vi.mock('./tokenStorage', () => ({
+  storeTokens: vi.fn(),
+  getTokensForProvider: vi.fn(),
+  clearTokens: vi.fn(),
+  areTokensExpired: vi.fn(),
+}));
+
+// Create a testable version of GoogleDriveService that doesn't use import.meta.env
+class TestableGoogleDriveService implements CloudStorageProvider {
+  readonly providerId = 'google-drive' as const;
+
+  private tokenClient: {
+    requestAccessToken: (options?: { prompt?: string }) => void;
+  } | null = null;
+  private pendingAuthResolve: ((value: void) => void) | null = null;
+  private pendingAuthReject: ((error: Error) => void) | null = null;
+  private pendingAuthPromise: Promise<void> | null = null;
+  private mockClientId: string = 'test-client-id';
+
+  setClientId(clientId: string) {
+    this.mockClientId = clientId;
+  }
+
+  private initTokenClient(): {
+    requestAccessToken: (options?: { prompt?: string }) => void;
+  } {
+    const clientId = this.mockClientId;
+
+    if (!clientId) {
+      throw new CloudSyncError(
+        'Google Client ID not configured. Set VITE_GOOGLE_CLIENT_ID environment variable.',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    if (!window.google?.accounts?.oauth2) {
+      throw new CloudSyncError(
+        'Google Identity Services not loaded. Check your internet connection.',
+        'AUTH_FAILED',
+        true,
+      );
+    }
+
+    return window.google.accounts.oauth2.initTokenClient({
+      client_id: clientId,
+      scope: 'https://www.googleapis.com/auth/drive.file',
+      callback: (response: {
+        access_token?: string;
+        expires_in?: number;
+        error?: string;
+        error_description?: string;
+      }) => {
+        if (response.error) {
+          this.pendingAuthReject?.(
+            new CloudSyncError(
+              response.error_description || response.error,
+              'AUTH_FAILED',
+              false,
+            ),
+          );
+          return;
+        }
+
+        // Store tokens
+        const tokens: StoredTokens = {
+          accessToken: response.access_token!,
+          refreshToken: null,
+          expiresAt: Date.now() + response.expires_in! * 1000,
+          provider: 'google-drive',
+        };
+        tokenStorage.storeTokens(tokens);
+
+        this.pendingAuthResolve?.();
+      },
+      error_callback: (error: { type: string; message?: string }) => {
+        if (error.type === 'popup_closed') {
+          this.pendingAuthReject?.(
+            new CloudSyncError('Sign-in cancelled', 'AUTH_CANCELLED', false),
+          );
+        } else {
+          this.pendingAuthReject?.(
+            new CloudSyncError(
+              error.message || 'Authentication failed',
+              'AUTH_FAILED',
+              true,
+            ),
+          );
+        }
+      },
+    });
+  }
+
+  async connect(): Promise<void> {
+    // Check if already connected with valid tokens
+    if (this.isConnected() && !tokenStorage.areTokensExpired()) {
+      return;
+    }
+
+    // If auth is already in progress, wait for it (prevents race condition)
+    if (this.pendingAuthPromise) {
+      return this.pendingAuthPromise;
+    }
+
+    // Initialize token client if needed
+    if (!this.tokenClient) {
+      this.tokenClient = this.initTokenClient();
+    }
+
+    // Request access token (opens Google sign-in popup)
+    this.pendingAuthPromise = new Promise<void>((resolve, reject) => {
+      this.pendingAuthResolve = resolve;
+      this.pendingAuthReject = reject;
+
+      // If we have expired tokens, request with prompt to allow switching accounts
+      const hasExpiredTokens =
+        tokenStorage.getTokensForProvider('google-drive') !== null;
+      this.tokenClient!.requestAccessToken({
+        prompt: hasExpiredTokens ? '' : 'consent',
+      });
+    }).finally(() => {
+      this.pendingAuthPromise = null;
+    });
+
+    return this.pendingAuthPromise;
+  }
+
+  async disconnect(): Promise<void> {
+    const tokens = tokenStorage.getTokensForProvider('google-drive');
+
+    // Revoke the token if we have one
+    if (tokens?.accessToken) {
+      try {
+        await fetch(
+          `https://oauth2.googleapis.com/revoke?token=${tokens.accessToken}`,
+          { method: 'POST' },
+        );
+      } catch {
+        // Ignore revocation errors - token might already be invalid
+      }
+    }
+
+    // Clear stored tokens
+    tokenStorage.clearTokens();
+    this.tokenClient = null;
+  }
+
+  isConnected(): boolean {
+    const tokens = tokenStorage.getTokensForProvider('google-drive');
+    return tokens !== null && !tokenStorage.areTokensExpired();
+  }
+
+  async getAccessToken(): Promise<string | null> {
+    if (!this.isConnected()) {
+      // Try to reconnect if we have tokens but they're expired
+      const tokens = tokenStorage.getTokensForProvider('google-drive');
+      if (tokens) {
+        try {
+          await this.connect();
+        } catch {
+          return null;
+        }
+      } else {
+        return null;
+      }
+    }
+
+    const tokens = tokenStorage.getTokensForProvider('google-drive');
+    return tokens?.accessToken ?? null;
+  }
+
+  private async apiRequest<T>(
+    url: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with Google Drive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const message =
+        (errorData as { error?: { message?: string } }).error?.message ||
+        `API request failed: ${response.status}`;
+
+      if (response.status === 401) {
+        throw new CloudSyncError(message, 'TOKEN_EXPIRED', true);
+      }
+      if (response.status === 403) {
+        throw new CloudSyncError(message, 'PERMISSION_DENIED', false);
+      }
+      if (response.status === 404) {
+        throw new CloudSyncError(message, 'FILE_NOT_FOUND', false);
+      }
+      if (response.status === 507) {
+        throw new CloudSyncError(message, 'QUOTA_EXCEEDED', false);
+      }
+
+      throw new CloudSyncError(message, 'UNKNOWN', true);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  async findSyncFile(): Promise<string | null> {
+    try {
+      const query = `name='emergency-supply-tracker.json' and trashed=false`;
+      const result = await this.apiRequest<{
+        files: Array<{ id: string; name: string; modifiedTime: string }>;
+      }>(
+        `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)`,
+      );
+
+      if (result.files && result.files.length > 0) {
+        return result.files[0].id;
+      }
+
+      return null;
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to search for sync file',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  async upload(data: string, existingFileId?: string): Promise<string> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with Google Drive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    try {
+      if (existingFileId) {
+        // Update existing file
+        const response = await fetch(
+          `https://www.googleapis.com/upload/drive/v3/files/${existingFileId}?uploadType=media`,
+          {
+            method: 'PATCH',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'application/json',
+            },
+            body: data,
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Upload failed: ${response.status}`);
+        }
+
+        const result = (await response.json()) as { id: string };
+        return result.id;
+      } else {
+        // Create new file with multipart upload
+        const metadata = {
+          name: 'emergency-supply-tracker.json',
+          mimeType: 'application/json',
+        };
+
+        const boundary = '-------314159265358979323846';
+        const delimiter = `\r\n--${boundary}\r\n`;
+        const closeDelimiter = `\r\n--${boundary}--`;
+
+        const multipartBody =
+          delimiter +
+          'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+          JSON.stringify(metadata) +
+          delimiter +
+          'Content-Type: application/json\r\n\r\n' +
+          data +
+          closeDelimiter;
+
+        const response = await fetch(
+          'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart',
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': `multipart/related; boundary=${boundary}`,
+            },
+            body: multipartBody,
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Upload failed: ${response.status}`);
+        }
+
+        const result = (await response.json()) as { id: string };
+        return result.id;
+      }
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to upload data to Google Drive',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  async download(fileId: string): Promise<string> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with Google Drive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    try {
+      const response = await fetch(
+        `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new CloudSyncError(
+            'Sync file not found',
+            'FILE_NOT_FOUND',
+            false,
+          );
+        }
+        throw new Error(`Download failed: ${response.status}`);
+      }
+
+      return response.text();
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to download data from Google Drive',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  async getFileMetadata(fileId: string): Promise<{
+    id: string;
+    name: string;
+    modifiedTime: string;
+    size?: number;
+  } | null> {
+    try {
+      const file = await this.apiRequest<{
+        id: string;
+        name: string;
+        modifiedTime: string;
+        size?: string;
+      }>(
+        `https://www.googleapis.com/drive/v3/files/${fileId}?fields=id,name,modifiedTime,size`,
+      );
+
+      return {
+        id: file.id,
+        name: file.name,
+        modifiedTime: file.modifiedTime,
+        size: file.size ? parseInt(file.size, 10) : undefined,
+      };
+    } catch (error) {
+      if (error instanceof CloudSyncError && error.code === 'FILE_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
+  }
+}
+
+// Extend Window type for tests
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        oauth2: {
+          initTokenClient: (config: {
+            client_id: string;
+            scope: string;
+            callback: (response: {
+              access_token?: string;
+              expires_in?: number;
+              error?: string;
+              error_description?: string;
+            }) => void;
+            error_callback?: (error: {
+              type: string;
+              message?: string;
+            }) => void;
+          }) => {
+            requestAccessToken: (options?: { prompt?: string }) => void;
+          };
+        };
+      };
+    };
+  }
+}
+
+describe('GoogleDriveService', () => {
+  let service: TestableGoogleDriveService;
+  let mockTokenClient: {
+    requestAccessToken: Mock;
+  };
+  let mockInitTokenClient: Mock;
+  let tokenCallback:
+    | ((response: {
+        access_token?: string;
+        expires_in?: number;
+        error?: string;
+        error_description?: string;
+      }) => void)
+    | null = null;
+  let errorCallback:
+    | ((error: { type: string; message?: string }) => void)
+    | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup mock token client
+    mockTokenClient = {
+      requestAccessToken: vi.fn(),
+    };
+
+    mockInitTokenClient = vi.fn((config) => {
+      tokenCallback = config.callback;
+      errorCallback = config.error_callback;
+      return mockTokenClient;
+    });
+
+    // Setup window.google mock
+    (window as Window).google = {
+      accounts: {
+        oauth2: {
+          initTokenClient: mockInitTokenClient,
+        },
+      },
+    };
+
+    // Default mock implementations
+    (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+    (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+
+    service = new TestableGoogleDriveService();
+  });
+
+  afterEach(() => {
+    delete (window as Window & { google?: unknown }).google;
+  });
+
+  describe('providerId', () => {
+    it('should have google-drive as providerId', () => {
+      expect(service.providerId).toBe('google-drive');
+    });
+  });
+
+  describe('connect', () => {
+    it('should return early if already connected with valid tokens', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+
+      await service.connect();
+
+      expect(mockInitTokenClient).not.toHaveBeenCalled();
+    });
+
+    it('should throw error if client ID is not configured', async () => {
+      service.setClientId('');
+
+      await expect(service.connect()).rejects.toThrow(CloudSyncError);
+      await expect(service.connect()).rejects.toThrow(
+        'Google Client ID not configured',
+      );
+    });
+
+    it('should throw error if Google Identity Services not loaded', async () => {
+      delete (window as Window & { google?: unknown }).google;
+
+      await expect(service.connect()).rejects.toThrow(CloudSyncError);
+      await expect(service.connect()).rejects.toThrow(
+        'Google Identity Services not loaded',
+      );
+    });
+
+    it('should initialize token client and request access token', async () => {
+      const connectPromise = service.connect();
+
+      // Simulate successful auth callback
+      tokenCallback?.({
+        access_token: 'new-token',
+        expires_in: 3600,
+      });
+
+      await connectPromise;
+
+      expect(mockInitTokenClient).toHaveBeenCalled();
+      expect(mockTokenClient.requestAccessToken).toHaveBeenCalledWith({
+        prompt: 'consent',
+      });
+      expect(tokenStorage.storeTokens).toHaveBeenCalled();
+    });
+
+    it('should handle auth error response', async () => {
+      const connectPromise = service.connect();
+
+      tokenCallback?.({
+        error: 'access_denied',
+        error_description: 'User denied access',
+      });
+
+      await expect(connectPromise).rejects.toThrow('User denied access');
+    });
+
+    it('should handle popup closed error', async () => {
+      const connectPromise = service.connect();
+
+      errorCallback?.({ type: 'popup_closed' });
+
+      await expect(connectPromise).rejects.toThrow('Sign-in cancelled');
+    });
+
+    it('should handle other auth errors', async () => {
+      const connectPromise = service.connect();
+
+      errorCallback?.({ type: 'unknown', message: 'Something went wrong' });
+
+      await expect(connectPromise).rejects.toThrow('Something went wrong');
+    });
+
+    it('should reuse pending auth promise for concurrent calls', async () => {
+      // Start the first connect - this creates the pending promise
+      const promise1 = service.connect();
+
+      // Start a second connect while the first is in progress
+      // Due to the pendingAuthPromise guard, both should resolve together
+      const promise2 = service.connect();
+
+      // Resolve the auth
+      tokenCallback?.({
+        access_token: 'token',
+        expires_in: 3600,
+      });
+
+      await Promise.all([promise1, promise2]);
+
+      // Only one token request should have been made
+      expect(mockTokenClient.requestAccessToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use empty prompt when renewing expired tokens', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'expired-token',
+        expiresAt: Date.now() - 1000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+
+      const connectPromise = service.connect();
+
+      tokenCallback?.({
+        access_token: 'new-token',
+        expires_in: 3600,
+      });
+
+      await connectPromise;
+
+      expect(mockTokenClient.requestAccessToken).toHaveBeenCalledWith({
+        prompt: '',
+      });
+    });
+  });
+
+  describe('disconnect', () => {
+    beforeEach(() => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true });
+    });
+
+    it('should revoke token and clear storage', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+
+      await service.disconnect();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://oauth2.googleapis.com/revoke?token=valid-token',
+        { method: 'POST' },
+      );
+      expect(tokenStorage.clearTokens).toHaveBeenCalled();
+    });
+
+    it('should clear storage even if revoke fails', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (global.fetch as Mock).mockRejectedValue(new Error('Network error'));
+
+      await service.disconnect();
+
+      expect(tokenStorage.clearTokens).toHaveBeenCalled();
+    });
+
+    it('should handle no tokens case', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+
+      await service.disconnect();
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(tokenStorage.clearTokens).toHaveBeenCalled();
+    });
+  });
+
+  describe('isConnected', () => {
+    it('should return false when no tokens', () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+
+      expect(service.isConnected()).toBe(false);
+    });
+
+    it('should return false when tokens expired', () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'token',
+        expiresAt: Date.now() - 1000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+
+      expect(service.isConnected()).toBe(false);
+    });
+
+    it('should return true when tokens valid', () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+
+      expect(service.isConnected()).toBe(true);
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('should return token when connected', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'my-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+
+      const token = await service.getAccessToken();
+
+      expect(token).toBe('my-token');
+    });
+
+    it('should return null when no tokens and not expired', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+
+      const token = await service.getAccessToken();
+
+      expect(token).toBeNull();
+    });
+
+    it('should try to reconnect when tokens expired', async () => {
+      let callCount = 0;
+      (tokenStorage.getTokensForProvider as Mock).mockImplementation(
+        () => {
+          callCount++;
+          if (callCount === 1) {
+            // First call: expired tokens
+            return {
+              accessToken: 'expired',
+              expiresAt: Date.now() - 1000,
+              provider: 'google-drive',
+              refreshToken: null,
+            };
+          }
+          // After reconnect: new tokens
+          return {
+            accessToken: 'new-token',
+            expiresAt: Date.now() + 3600000,
+            provider: 'google-drive',
+            refreshToken: null,
+          };
+        },
+      );
+      (tokenStorage.areTokensExpired as Mock)
+        .mockReturnValueOnce(true)
+        .mockReturnValue(false);
+
+      const tokenPromise = service.getAccessToken();
+
+      // Simulate successful reconnection
+      tokenCallback?.({
+        access_token: 'new-token',
+        expires_in: 3600,
+      });
+
+      const token = await tokenPromise;
+      expect(token).toBe('new-token');
+    });
+
+    it('should return null when reconnection fails', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'expired',
+        expiresAt: Date.now() - 1000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+
+      const tokenPromise = service.getAccessToken();
+
+      // Simulate failed reconnection
+      errorCallback?.({ type: 'popup_closed' });
+
+      const token = await tokenPromise;
+      expect(token).toBeNull();
+    });
+  });
+
+  describe('findSyncFile', () => {
+    beforeEach(() => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+    });
+
+    it('should return file id when found', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            files: [{ id: 'file-123', name: 'test.json', modifiedTime: '' }],
+          }),
+      });
+
+      const fileId = await service.findSyncFile();
+
+      expect(fileId).toBe('file-123');
+    });
+
+    it('should return null when no files found', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ files: [] }),
+      });
+
+      const fileId = await service.findSyncFile();
+
+      expect(fileId).toBeNull();
+    });
+
+    it('should throw CloudSyncError on network error', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      await expect(service.findSyncFile()).rejects.toThrow(CloudSyncError);
+      await expect(service.findSyncFile()).rejects.toThrow(
+        'Failed to search for sync file',
+      );
+    });
+  });
+
+  describe('upload', () => {
+    beforeEach(() => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+    });
+
+    it('should update existing file', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'existing-file-id' }),
+      });
+
+      const fileId = await service.upload(
+        '{"data": "test"}',
+        'existing-file-id',
+      );
+
+      expect(fileId).toBe('existing-file-id');
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('existing-file-id'),
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+    });
+
+    it('should create new file with multipart upload', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'new-file-id' }),
+      });
+
+      const fileId = await service.upload('{"data": "test"}');
+
+      expect(fileId).toBe('new-file-id');
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('uploadType=multipart'),
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('should throw error when not authenticated', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+
+      await expect(service.upload('data')).rejects.toThrow(
+        'Not authenticated with Google Drive',
+      );
+    });
+
+    it('should throw CloudSyncError on upload failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(service.upload('data')).rejects.toThrow(CloudSyncError);
+    });
+  });
+
+  describe('download', () => {
+    beforeEach(() => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+    });
+
+    it('should download file content', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('{"downloaded": "data"}'),
+      });
+
+      const content = await service.download('file-id');
+
+      expect(content).toBe('{"downloaded": "data"}');
+    });
+
+    it('should throw FILE_NOT_FOUND on 404', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      await expect(service.download('file-id')).rejects.toThrow(
+        'Sync file not found',
+      );
+    });
+
+    it('should throw error when not authenticated', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+
+      await expect(service.download('file-id')).rejects.toThrow(
+        'Not authenticated with Google Drive',
+      );
+    });
+
+    it('should throw CloudSyncError on other failures', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(service.download('file-id')).rejects.toThrow(CloudSyncError);
+    });
+  });
+
+  describe('getFileMetadata', () => {
+    beforeEach(() => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+    });
+
+    it('should return file metadata', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: 'file-id',
+            name: 'test.json',
+            modifiedTime: '2024-01-01T00:00:00Z',
+            size: '1024',
+          }),
+      });
+
+      const metadata = await service.getFileMetadata('file-id');
+
+      expect(metadata).toEqual({
+        id: 'file-id',
+        name: 'test.json',
+        modifiedTime: '2024-01-01T00:00:00Z',
+        size: 1024,
+      });
+    });
+
+    it('should return null for FILE_NOT_FOUND', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: { message: 'Not found' } }),
+      });
+
+      const metadata = await service.getFileMetadata('file-id');
+
+      expect(metadata).toBeNull();
+    });
+
+    it('should handle missing size field', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: 'file-id',
+            name: 'test.json',
+            modifiedTime: '2024-01-01T00:00:00Z',
+          }),
+      });
+
+      const metadata = await service.getFileMetadata('file-id');
+
+      expect(metadata?.size).toBeUndefined();
+    });
+  });
+
+  describe('apiRequest error handling', () => {
+    beforeEach(() => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+        accessToken: 'valid-token',
+        expiresAt: Date.now() + 3600000,
+        provider: 'google-drive',
+        refreshToken: null,
+      });
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+    });
+
+    it('should throw TOKEN_EXPIRED on 401', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: { message: 'Token expired' } }),
+      });
+
+      try {
+        await service.getFileMetadata('file-id');
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CloudSyncError);
+        expect((error as CloudSyncError).code).toBe('TOKEN_EXPIRED');
+      }
+    });
+
+    it('should throw PERMISSION_DENIED on 403', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error: { message: 'Access denied' } }),
+      });
+
+      try {
+        await service.getFileMetadata('file-id');
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CloudSyncError);
+        expect((error as CloudSyncError).code).toBe('PERMISSION_DENIED');
+      }
+    });
+
+    it('should throw QUOTA_EXCEEDED on 507', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 507,
+        json: () => Promise.resolve({ error: { message: 'Storage full' } }),
+      });
+
+      try {
+        await service.getFileMetadata('file-id');
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CloudSyncError);
+        expect((error as CloudSyncError).code).toBe('QUOTA_EXCEEDED');
+      }
+    });
+
+    it('should throw UNKNOWN on other status codes', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({}),
+      });
+
+      try {
+        await service.getFileMetadata('file-id');
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CloudSyncError);
+        expect((error as CloudSyncError).code).toBe('UNKNOWN');
+      }
+    });
+  });
+});

--- a/src/features/cloudSync/services/googleDrive.test.ts
+++ b/src/features/cloudSync/services/googleDrive.test.ts
@@ -586,7 +586,7 @@ describe('GoogleDriveService', () => {
       expect(mockTokenClient.requestAccessToken).toHaveBeenCalledTimes(1);
     });
 
-    it('should use empty prompt when renewing expired tokens', async () => {
+    it('should request account selection when renewing existing tokens', async () => {
       (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
         accessToken: 'expired-token',
         expiresAt: Date.now() - 1000,

--- a/src/features/cloudSync/services/googleDrive.test.ts
+++ b/src/features/cloudSync/services/googleDrive.test.ts
@@ -136,11 +136,11 @@ class TestableGoogleDriveService implements CloudStorageProvider {
       this.pendingAuthResolve = resolve;
       this.pendingAuthReject = reject;
 
-      // If we have expired tokens, request with prompt to allow switching accounts
-      const hasExpiredTokens =
+      // If we have existing tokens, allow account switching; otherwise request consent
+      const hasExistingTokens =
         tokenStorage.getTokensForProvider('google-drive') !== null;
       this.tokenClient!.requestAccessToken({
-        prompt: hasExpiredTokens ? '' : 'consent',
+        prompt: hasExistingTokens ? 'select_account' : 'consent',
       });
     }).finally(() => {
       this.pendingAuthPromise = null;
@@ -604,7 +604,7 @@ describe('GoogleDriveService', () => {
       await connectPromise;
 
       expect(mockTokenClient.requestAccessToken).toHaveBeenCalledWith({
-        prompt: '',
+        prompt: 'select_account',
       });
     });
   });

--- a/src/features/cloudSync/services/googleDrive.test.ts
+++ b/src/features/cloudSync/services/googleDrive.test.ts
@@ -436,9 +436,11 @@ describe('GoogleDriveService', () => {
   let errorCallback:
     | ((error: { type: string; message?: string }) => void)
     | null = null;
+  let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
 
     // Setup mock token client
     mockTokenClient = {
@@ -480,6 +482,7 @@ describe('GoogleDriveService', () => {
 
   afterEach(() => {
     delete (globalThis as typeof globalThis & { google?: unknown }).google;
+    globalThis.fetch = originalFetch;
   });
 
   describe('providerId', () => {

--- a/src/features/cloudSync/services/googleDrive.ts
+++ b/src/features/cloudSync/services/googleDrive.ts
@@ -179,10 +179,10 @@ export class GoogleDriveService implements CloudStorageProvider {
       this.pendingAuthResolve = resolve;
       this.pendingAuthReject = reject;
 
-      // If we have expired tokens, request with prompt to allow switching accounts
-      const hasExpiredTokens = getTokensForProvider('google-drive') !== null;
+      // If we have existing tokens, allow account switching; otherwise request consent
+      const hasExistingTokens = getTokensForProvider('google-drive') !== null;
       this.tokenClient!.requestAccessToken({
-        prompt: hasExpiredTokens ? '' : 'consent',
+        prompt: hasExistingTokens ? 'select_account' : 'consent',
       });
     }).finally(() => {
       this.pendingAuthPromise = null;

--- a/src/features/cloudSync/services/googleDrive.ts
+++ b/src/features/cloudSync/services/googleDrive.ts
@@ -1,0 +1,465 @@
+/**
+ * Google Drive cloud storage provider implementation.
+ * Uses Google Identity Services for OAuth2 and Google Drive REST API for file operations.
+ */
+
+import type {
+  CloudStorageProvider,
+  CloudFileMetadata,
+  StoredTokens,
+} from '../types';
+import { CloudSyncError } from '../types';
+import {
+  storeTokens,
+  getTokensForProvider,
+  clearTokens,
+  areTokensExpired,
+} from './tokenStorage';
+
+// Google Drive API endpoints
+const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
+const DRIVE_UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3';
+
+// File name for sync data in Google Drive
+const SYNC_FILE_NAME = 'emergency-supply-tracker.json';
+
+// MIME types
+const JSON_MIME_TYPE = 'application/json';
+
+// OAuth scopes - minimal access (only files created by this app)
+const SCOPES = 'https://www.googleapis.com/auth/drive.file';
+
+// Google Identity Services types (loaded from external script)
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        oauth2: {
+          initTokenClient: (
+            config: GoogleTokenClientConfig,
+          ) => GoogleTokenClient;
+        };
+      };
+    };
+  }
+}
+
+interface GoogleTokenClientConfig {
+  client_id: string;
+  scope: string;
+  callback: (response: GoogleTokenResponse) => void;
+  error_callback?: (error: GoogleTokenError) => void;
+}
+
+interface GoogleTokenClient {
+  requestAccessToken: (options?: { prompt?: string }) => void;
+}
+
+interface GoogleTokenResponse {
+  access_token: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface GoogleTokenError {
+  type: string;
+  message?: string;
+}
+
+interface DriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  modifiedTime: string;
+  size?: string;
+}
+
+interface DriveFileList {
+  files: DriveFile[];
+  nextPageToken?: string;
+}
+
+/**
+ * Google Drive implementation of CloudStorageProvider.
+ */
+export class GoogleDriveService implements CloudStorageProvider {
+  readonly providerId = 'google-drive' as const;
+
+  private tokenClient: GoogleTokenClient | null = null;
+  private pendingAuthResolve: ((value: void) => void) | null = null;
+  private pendingAuthReject: ((error: Error) => void) | null = null;
+
+  /**
+   * Initialize Google Identity Services token client.
+   */
+  private initTokenClient(): GoogleTokenClient {
+    const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
+    if (!clientId) {
+      throw new CloudSyncError(
+        'Google Client ID not configured. Set VITE_GOOGLE_CLIENT_ID environment variable.',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    if (!window.google?.accounts?.oauth2) {
+      throw new CloudSyncError(
+        'Google Identity Services not loaded. Check your internet connection.',
+        'AUTH_FAILED',
+        true,
+      );
+    }
+
+    return window.google.accounts.oauth2.initTokenClient({
+      client_id: clientId,
+      scope: SCOPES,
+      callback: (response: GoogleTokenResponse) => {
+        if (response.error) {
+          this.pendingAuthReject?.(
+            new CloudSyncError(
+              response.error_description || response.error,
+              'AUTH_FAILED',
+              false,
+            ),
+          );
+          return;
+        }
+
+        // Store tokens
+        const tokens: StoredTokens = {
+          accessToken: response.access_token,
+          refreshToken: null, // GIS doesn't provide refresh tokens for implicit flow
+          expiresAt: Date.now() + response.expires_in * 1000,
+          provider: 'google-drive',
+        };
+        storeTokens(tokens);
+
+        this.pendingAuthResolve?.();
+      },
+      error_callback: (error: GoogleTokenError) => {
+        if (error.type === 'popup_closed') {
+          this.pendingAuthReject?.(
+            new CloudSyncError('Sign-in cancelled', 'AUTH_CANCELLED', false),
+          );
+        } else {
+          this.pendingAuthReject?.(
+            new CloudSyncError(
+              error.message || 'Authentication failed',
+              'AUTH_FAILED',
+              true,
+            ),
+          );
+        }
+      },
+    });
+  }
+
+  /**
+   * Connect to Google Drive by initiating OAuth flow.
+   */
+  async connect(): Promise<void> {
+    // Check if already connected with valid tokens
+    if (this.isConnected() && !areTokensExpired()) {
+      return;
+    }
+
+    // Initialize token client if needed
+    if (!this.tokenClient) {
+      this.tokenClient = this.initTokenClient();
+    }
+
+    // Request access token (opens Google sign-in popup)
+    return new Promise((resolve, reject) => {
+      this.pendingAuthResolve = resolve;
+      this.pendingAuthReject = reject;
+
+      // If we have expired tokens, request with prompt to allow switching accounts
+      const hasExpiredTokens = getTokensForProvider('google-drive') !== null;
+      this.tokenClient!.requestAccessToken({
+        prompt: hasExpiredTokens ? '' : 'consent',
+      });
+    });
+  }
+
+  /**
+   * Disconnect from Google Drive.
+   */
+  async disconnect(): Promise<void> {
+    const tokens = getTokensForProvider('google-drive');
+
+    // Revoke the token if we have one
+    if (tokens?.accessToken) {
+      try {
+        await fetch(
+          `https://oauth2.googleapis.com/revoke?token=${tokens.accessToken}`,
+          { method: 'POST' },
+        );
+      } catch {
+        // Ignore revocation errors - token might already be invalid
+      }
+    }
+
+    // Clear stored tokens
+    clearTokens();
+    this.tokenClient = null;
+  }
+
+  /**
+   * Check if connected with valid tokens.
+   */
+  isConnected(): boolean {
+    const tokens = getTokensForProvider('google-drive');
+    return tokens !== null && !areTokensExpired();
+  }
+
+  /**
+   * Get current access token, reconnecting if expired.
+   */
+  async getAccessToken(): Promise<string | null> {
+    if (!this.isConnected()) {
+      // Try to reconnect if we have tokens but they're expired
+      const tokens = getTokensForProvider('google-drive');
+      if (tokens) {
+        try {
+          await this.connect();
+        } catch {
+          return null;
+        }
+      } else {
+        return null;
+      }
+    }
+
+    const tokens = getTokensForProvider('google-drive');
+    return tokens?.accessToken ?? null;
+  }
+
+  /**
+   * Make an authenticated request to Google Drive API.
+   */
+  private async apiRequest<T>(
+    url: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with Google Drive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const message =
+        errorData.error?.message || `API request failed: ${response.status}`;
+
+      if (response.status === 401) {
+        throw new CloudSyncError(message, 'TOKEN_EXPIRED', true);
+      }
+      if (response.status === 403) {
+        throw new CloudSyncError(message, 'PERMISSION_DENIED', false);
+      }
+      if (response.status === 404) {
+        throw new CloudSyncError(message, 'FILE_NOT_FOUND', false);
+      }
+      if (response.status === 507) {
+        throw new CloudSyncError(message, 'QUOTA_EXCEEDED', false);
+      }
+
+      throw new CloudSyncError(message, 'UNKNOWN', true);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  /**
+   * Find existing sync file in Google Drive.
+   */
+  async findSyncFile(): Promise<string | null> {
+    try {
+      const query = `name='${SYNC_FILE_NAME}' and trashed=false`;
+      const result = await this.apiRequest<DriveFileList>(
+        `${DRIVE_API_BASE}/files?q=${encodeURIComponent(query)}&fields=files(id,name,modifiedTime)`,
+      );
+
+      if (result.files && result.files.length > 0) {
+        return result.files[0].id;
+      }
+
+      return null;
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to search for sync file',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Upload data to Google Drive.
+   * Creates new file or updates existing one.
+   */
+  async upload(data: string, existingFileId?: string): Promise<string> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with Google Drive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    try {
+      if (existingFileId) {
+        // Update existing file
+        const response = await fetch(
+          `${DRIVE_UPLOAD_BASE}/files/${existingFileId}?uploadType=media`,
+          {
+            method: 'PATCH',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': JSON_MIME_TYPE,
+            },
+            body: data,
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Upload failed: ${response.status}`);
+        }
+
+        const result = (await response.json()) as DriveFile;
+        return result.id;
+      } else {
+        // Create new file with multipart upload
+        const metadata = {
+          name: SYNC_FILE_NAME,
+          mimeType: JSON_MIME_TYPE,
+        };
+
+        const boundary = '-------314159265358979323846';
+        const delimiter = `\r\n--${boundary}\r\n`;
+        const closeDelimiter = `\r\n--${boundary}--`;
+
+        const multipartBody =
+          delimiter +
+          'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+          JSON.stringify(metadata) +
+          delimiter +
+          `Content-Type: ${JSON_MIME_TYPE}\r\n\r\n` +
+          data +
+          closeDelimiter;
+
+        const response = await fetch(
+          `${DRIVE_UPLOAD_BASE}/files?uploadType=multipart`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': `multipart/related; boundary=${boundary}`,
+            },
+            body: multipartBody,
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Upload failed: ${response.status}`);
+        }
+
+        const result = (await response.json()) as DriveFile;
+        return result.id;
+      }
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to upload data to Google Drive',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Download file content from Google Drive.
+   */
+  async download(fileId: string): Promise<string> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with Google Drive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    try {
+      const response = await fetch(
+        `${DRIVE_API_BASE}/files/${fileId}?alt=media`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new CloudSyncError(
+            'Sync file not found',
+            'FILE_NOT_FOUND',
+            false,
+          );
+        }
+        throw new Error(`Download failed: ${response.status}`);
+      }
+
+      return response.text();
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to download data from Google Drive',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Get file metadata from Google Drive.
+   */
+  async getFileMetadata(fileId: string): Promise<CloudFileMetadata | null> {
+    try {
+      const file = await this.apiRequest<DriveFile>(
+        `${DRIVE_API_BASE}/files/${fileId}?fields=id,name,modifiedTime,size`,
+      );
+
+      return {
+        id: file.id,
+        name: file.name,
+        modifiedTime: file.modifiedTime,
+        size: file.size ? parseInt(file.size, 10) : undefined,
+      };
+    } catch (error) {
+      if (error instanceof CloudSyncError && error.code === 'FILE_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
+  }
+}

--- a/src/features/cloudSync/services/googleDrive.ts
+++ b/src/features/cloudSync/services/googleDrive.ts
@@ -30,18 +30,16 @@ const JSON_MIME_TYPE = 'application/json';
 const SCOPES = 'https://www.googleapis.com/auth/drive.file';
 
 // Google Identity Services types (loaded from external script)
-declare global {
-  interface Window {
-    google?: {
-      accounts: {
-        oauth2: {
-          initTokenClient: (
-            config: GoogleTokenClientConfig,
-          ) => GoogleTokenClient;
-        };
-      };
+interface GoogleApi {
+  accounts: {
+    oauth2: {
+      initTokenClient: (config: GoogleTokenClientConfig) => GoogleTokenClient;
     };
-  }
+  };
+}
+
+declare global {
+  var google: GoogleApi | undefined;
 }
 
 interface GoogleTokenClientConfig {
@@ -107,7 +105,7 @@ export class GoogleDriveService implements CloudStorageProvider {
       );
     }
 
-    if (!window.google?.accounts?.oauth2) {
+    if (!globalThis.google?.accounts?.oauth2) {
       throw new CloudSyncError(
         'Google Identity Services not loaded. Check your internet connection.',
         'AUTH_FAILED',
@@ -115,7 +113,7 @@ export class GoogleDriveService implements CloudStorageProvider {
       );
     }
 
-    return window.google.accounts.oauth2.initTokenClient({
+    return globalThis.google.accounts.oauth2.initTokenClient({
       client_id: clientId,
       scope: SCOPES,
       callback: (response: GoogleTokenResponse) => {

--- a/src/features/cloudSync/services/googleDrive.ts
+++ b/src/features/cloudSync/services/googleDrive.ts
@@ -174,9 +174,7 @@ export class GoogleDriveService implements CloudStorageProvider {
     }
 
     // Initialize token client if needed
-    if (!this.tokenClient) {
-      this.tokenClient = this.initTokenClient();
-    }
+    this.tokenClient ??= this.initTokenClient();
 
     // Request access token (opens Google sign-in popup)
     this.pendingAuthPromise = new Promise<void>((resolve, reject) => {
@@ -463,7 +461,7 @@ export class GoogleDriveService implements CloudStorageProvider {
         id: file.id,
         name: file.name,
         modifiedTime: file.modifiedTime,
-        size: file.size ? parseInt(file.size, 10) : undefined,
+        size: file.size ? Number.parseInt(file.size, 10) : undefined,
       };
     } catch (error) {
       if (error instanceof CloudSyncError && error.code === 'FILE_NOT_FOUND') {

--- a/src/features/cloudSync/services/googleDrive.ts
+++ b/src/features/cloudSync/services/googleDrive.ts
@@ -359,7 +359,7 @@ export class GoogleDriveService implements CloudStorageProvider {
           mimeType: JSON_MIME_TYPE,
         };
 
-        const boundary = '-------314159265358979323846';
+        const boundary = `-------${globalThis.crypto.randomUUID()}`;
         const delimiter = `\r\n--${boundary}\r\n`;
         const closeDelimiter = `\r\n--${boundary}--`;
 

--- a/src/features/cloudSync/services/index.test.ts
+++ b/src/features/cloudSync/services/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+// Test that all exports are properly re-exported from the index file
+import * as servicesExports from './index';
+
+describe('services/index exports', () => {
+  it('should export GoogleDriveService', () => {
+    expect(servicesExports.GoogleDriveService).toBeDefined();
+  });
+
+  it('should export token storage functions', () => {
+    expect(servicesExports.storeTokens).toBeDefined();
+    expect(servicesExports.getStoredTokens).toBeDefined();
+    expect(servicesExports.clearTokens).toBeDefined();
+    expect(servicesExports.areTokensExpired).toBeDefined();
+    expect(servicesExports.updateAccessToken).toBeDefined();
+    expect(servicesExports.getTokensForProvider).toBeDefined();
+  });
+
+  it('should export provider registry functions', () => {
+    expect(servicesExports.registerProvider).toBeDefined();
+    expect(servicesExports.getProvider).toBeDefined();
+    expect(servicesExports.getAvailableProviders).toBeDefined();
+    expect(servicesExports.isProviderAvailable).toBeDefined();
+    expect(servicesExports.initializeProviders).toBeDefined();
+    expect(servicesExports.resetProviders).toBeDefined();
+  });
+});

--- a/src/features/cloudSync/services/index.ts
+++ b/src/features/cloudSync/services/index.ts
@@ -1,0 +1,17 @@
+export { GoogleDriveService } from './googleDrive';
+export {
+  storeTokens,
+  getStoredTokens,
+  clearTokens,
+  areTokensExpired,
+  updateAccessToken,
+  getTokensForProvider,
+} from './tokenStorage';
+export {
+  registerProvider,
+  getProvider,
+  getAvailableProviders,
+  isProviderAvailable,
+  initializeProviders,
+  resetProviders,
+} from './cloudStorageProvider';

--- a/src/features/cloudSync/services/index.ts
+++ b/src/features/cloudSync/services/index.ts
@@ -1,4 +1,5 @@
 export { GoogleDriveService } from './googleDrive';
+export { OneDriveService } from './oneDrive';
 export {
   storeTokens,
   getStoredTokens,

--- a/src/features/cloudSync/services/oneDrive.test.ts
+++ b/src/features/cloudSync/services/oneDrive.test.ts
@@ -1,0 +1,391 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for OneDriveService.
+ *
+ * We mock both `@azure/msal-browser` and `tokenStorage` to focus on Graph API
+ * interactions (auth flow correctness is left to MSAL's own tests).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { CloudSyncError } from '../types';
+import * as tokenStorage from './tokenStorage';
+
+vi.mock('./tokenStorage', () => ({
+  storeTokens: vi.fn(),
+  getTokensForProvider: vi.fn(),
+  clearTokens: vi.fn(),
+  areTokensExpired: vi.fn(),
+}));
+
+const msalMocks = vi.hoisted(() => ({
+  loginPopup: vi.fn(),
+  acquireTokenSilent: vi.fn(),
+  getAllAccounts: vi.fn(),
+  clearCache: vi.fn(),
+  initialize: vi.fn(),
+}));
+
+vi.mock('@azure/msal-browser', () => {
+  class BrowserAuthError extends Error {
+    constructor(
+      public errorCode: string,
+      message?: string,
+    ) {
+      super(message ?? errorCode);
+      this.name = 'BrowserAuthError';
+    }
+  }
+  class InteractionRequiredAuthError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'InteractionRequiredAuthError';
+    }
+  }
+  class PublicClientApplication {
+    initialize = msalMocks.initialize;
+    loginPopup = msalMocks.loginPopup;
+    acquireTokenSilent = msalMocks.acquireTokenSilent;
+    getAllAccounts = msalMocks.getAllAccounts;
+    clearCache = msalMocks.clearCache;
+  }
+  return {
+    PublicClientApplication,
+    BrowserAuthError,
+    InteractionRequiredAuthError,
+  };
+});
+
+const {
+  loginPopup: mockLoginPopup,
+  acquireTokenSilent: mockAcquireTokenSilent,
+  getAllAccounts: mockGetAllAccounts,
+  clearCache: mockClearCache,
+  initialize: mockInitialize,
+} = msalMocks;
+
+// Stub the Vite env var read by OneDriveService
+vi.stubEnv('VITE_MICROSOFT_CLIENT_ID', 'test-ms-client-id');
+
+// Import after mocks are set up
+import { OneDriveService } from './oneDrive';
+
+describe('OneDriveService', () => {
+  let service: OneDriveService;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+
+    (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+      accessToken: 'mock-access-token',
+      refreshToken: null,
+      expiresAt: Date.now() + 3_600_000,
+      provider: 'onedrive',
+    });
+    (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+
+    mockInitialize.mockResolvedValue(undefined);
+    service = new OneDriveService();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('connect', () => {
+    it('returns immediately when already connected with valid tokens', async () => {
+      await service.connect();
+      expect(mockLoginPopup).not.toHaveBeenCalled();
+    });
+
+    it('calls loginPopup and stores tokens on success', async () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      const expiresOn = new Date(Date.now() + 3_600_000);
+      mockLoginPopup.mockResolvedValue({
+        accessToken: 'new-access-token',
+        expiresOn,
+      });
+
+      await service.connect();
+
+      expect(mockLoginPopup).toHaveBeenCalledWith({
+        scopes: ['Files.ReadWrite.AppFolder'],
+        prompt: 'select_account',
+      });
+      expect(tokenStorage.storeTokens).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: 'new-access-token',
+          provider: 'onedrive',
+          expiresAt: expiresOn.getTime(),
+        }),
+      );
+    });
+
+    it('throws AUTH_CANCELLED when user cancels popup', async () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      const { BrowserAuthError } = await import('@azure/msal-browser');
+      mockLoginPopup.mockRejectedValue(
+        new BrowserAuthError('user_cancelled', 'User cancelled'),
+      );
+
+      await expect(service.connect()).rejects.toMatchObject({
+        code: 'AUTH_CANCELLED',
+      });
+    });
+
+    it('throws AUTH_FAILED when client ID is missing', async () => {
+      vi.stubEnv('VITE_MICROSOFT_CLIENT_ID', '');
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      const freshService = new OneDriveService();
+
+      await expect(freshService.connect()).rejects.toBeInstanceOf(
+        CloudSyncError,
+      );
+
+      vi.stubEnv('VITE_MICROSOFT_CLIENT_ID', 'test-ms-client-id');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('clears MSAL cache and stored tokens', async () => {
+      mockGetAllAccounts.mockReturnValue([
+        { homeAccountId: 'home', username: 'user@example.com' },
+      ]);
+      mockClearCache.mockResolvedValue(undefined);
+
+      await service.disconnect();
+
+      expect(mockClearCache).toHaveBeenCalled();
+      expect(tokenStorage.clearTokens).toHaveBeenCalled();
+    });
+
+    it('still clears tokens when MSAL cache clear fails', async () => {
+      mockGetAllAccounts.mockReturnValue([
+        { homeAccountId: 'home', username: 'user@example.com' },
+      ]);
+      mockClearCache.mockRejectedValue(new Error('cache fail'));
+
+      await service.disconnect();
+
+      expect(tokenStorage.clearTokens).toHaveBeenCalled();
+    });
+  });
+
+  describe('isConnected', () => {
+    it('returns true when token present and not expired', () => {
+      expect(service.isConnected()).toBe(true);
+    });
+
+    it('returns false when tokens are expired', () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      expect(service.isConnected()).toBe(false);
+    });
+
+    it('returns false when no tokens stored', () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+      expect(service.isConnected()).toBe(false);
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('returns stored token when connected', async () => {
+      const token = await service.getAccessToken();
+      expect(token).toBe('mock-access-token');
+    });
+
+    it('attempts silent refresh when token expired and account present', async () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      mockGetAllAccounts.mockReturnValue([
+        { homeAccountId: 'home', username: 'user@example.com' },
+      ]);
+      mockAcquireTokenSilent.mockResolvedValue({
+        accessToken: 'refreshed-token',
+        expiresOn: new Date(Date.now() + 3_600_000),
+      });
+
+      const token = await service.getAccessToken();
+      expect(token).toBe('refreshed-token');
+      expect(tokenStorage.storeTokens).toHaveBeenCalled();
+    });
+
+    it('returns null when interaction is required', async () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      mockGetAllAccounts.mockReturnValue([
+        { homeAccountId: 'home', username: 'user@example.com' },
+      ]);
+      const { InteractionRequiredAuthError } = await import(
+        '@azure/msal-browser'
+      );
+      mockAcquireTokenSilent.mockRejectedValue(
+        new InteractionRequiredAuthError('interaction_required'),
+      );
+
+      const token = await service.getAccessToken();
+      expect(token).toBeNull();
+    });
+  });
+
+  describe('findSyncFile', () => {
+    it('returns id when sync file exists in app folder', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          value: [
+            {
+              id: 'file-123',
+              name: 'emergency-supply-tracker.json',
+              lastModifiedDateTime: '2026-05-05T10:00:00Z',
+            },
+          ],
+        }),
+      });
+
+      const id = await service.findSyncFile();
+      expect(id).toBe('file-123');
+    });
+
+    it('returns null when no matching file in app folder', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+
+      const id = await service.findSyncFile();
+      expect(id).toBeNull();
+    });
+
+    it('returns null when app folder does not exist (404)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { message: 'not found' } }),
+      });
+
+      const id = await service.findSyncFile();
+      expect(id).toBeNull();
+    });
+  });
+
+  describe('upload', () => {
+    it('PUTs to app folder content endpoint when no existing file', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'new-id' }),
+      });
+      globalThis.fetch = fetchMock;
+
+      const id = await service.upload('{"hello":"world"}');
+
+      expect(id).toBe('new-id');
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain('special/approot:/');
+      expect(url).toContain('emergency-supply-tracker.json');
+      expect(url).toContain(':/content');
+      expect(init.method).toBe('PUT');
+      expect(init.headers['Content-Type']).toBe('application/json');
+      expect(init.body).toBe('{"hello":"world"}');
+    });
+
+    it('PUTs to items/{id}/content when updating existing file', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'existing-id' }),
+      });
+      globalThis.fetch = fetchMock;
+
+      await service.upload('{}', 'existing-id');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('/me/drive/items/existing-id/content');
+    });
+
+    it('throws TOKEN_EXPIRED on 401', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      });
+
+      await expect(service.upload('{}')).rejects.toMatchObject({
+        code: 'TOKEN_EXPIRED',
+      });
+    });
+
+    it('throws QUOTA_EXCEEDED on 507', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 507,
+      });
+
+      await expect(service.upload('{}')).rejects.toMatchObject({
+        code: 'QUOTA_EXCEEDED',
+      });
+    });
+
+    it('throws AUTH_FAILED when no access token', async () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+
+      await expect(service.upload('{}')).rejects.toMatchObject({
+        code: 'AUTH_FAILED',
+      });
+    });
+  });
+
+  describe('download', () => {
+    it('returns file content on success', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => '{"data":"x"}',
+      });
+
+      const content = await service.download('file-id');
+      expect(content).toBe('{"data":"x"}');
+    });
+
+    it('throws FILE_NOT_FOUND on 404', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      await expect(service.download('missing-id')).rejects.toMatchObject({
+        code: 'FILE_NOT_FOUND',
+      });
+    });
+  });
+
+  describe('getFileMetadata', () => {
+    it('returns mapped metadata on success', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          id: 'abc',
+          name: 'emergency-supply-tracker.json',
+          lastModifiedDateTime: '2026-05-05T12:00:00Z',
+          size: 1234,
+        }),
+      });
+
+      const meta = await service.getFileMetadata('abc');
+      expect(meta).toEqual({
+        id: 'abc',
+        name: 'emergency-supply-tracker.json',
+        modifiedTime: '2026-05-05T12:00:00Z',
+        size: 1234,
+      });
+    });
+
+    it('returns null when file not found', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+
+      const meta = await service.getFileMetadata('missing');
+      expect(meta).toBeNull();
+    });
+  });
+});

--- a/src/features/cloudSync/services/oneDrive.ts
+++ b/src/features/cloudSync/services/oneDrive.ts
@@ -1,0 +1,421 @@
+/**
+ * OneDrive cloud storage provider implementation.
+ * Uses MSAL.js for OAuth2 (PKCE) and Microsoft Graph API for file operations.
+ *
+ * The provider stores files in the application's dedicated app folder
+ * (`/me/drive/special/approot`). With the `Files.ReadWrite.AppFolder`
+ * scope the app only ever sees its own folder, never the user's wider
+ * OneDrive contents.
+ */
+
+import {
+  PublicClientApplication,
+  type AccountInfo,
+  type AuthenticationResult,
+  BrowserAuthError,
+  InteractionRequiredAuthError,
+} from '@azure/msal-browser';
+
+import type {
+  CloudStorageProvider,
+  CloudFileMetadata,
+  StoredTokens,
+} from '../types';
+import { CloudSyncError } from '../types';
+import {
+  storeTokens,
+  getTokensForProvider,
+  clearTokens,
+  areTokensExpired,
+} from './tokenStorage';
+
+// Microsoft Graph API endpoints
+const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0';
+const APP_FOLDER_BASE = `${GRAPH_API_BASE}/me/drive/special/approot`;
+
+// File name for sync data in the OneDrive app folder
+const SYNC_FILE_NAME = 'emergency-supply-tracker.json';
+
+// MIME types
+const JSON_MIME_TYPE = 'application/json';
+
+// OAuth scopes - app folder access only (cannot see other files)
+const SCOPES = ['Files.ReadWrite.AppFolder'];
+
+// MSAL authority - 'common' allows both personal Microsoft accounts and work/school
+const AUTHORITY = 'https://login.microsoftonline.com/common';
+
+interface DriveItem {
+  id: string;
+  name: string;
+  size?: number;
+  lastModifiedDateTime: string;
+}
+
+interface DriveItemList {
+  value: DriveItem[];
+}
+
+/**
+ * OneDrive implementation of CloudStorageProvider.
+ */
+export class OneDriveService implements CloudStorageProvider {
+  readonly providerId = 'onedrive' as const;
+
+  private msalInstance: PublicClientApplication | null = null;
+  private msalInitialized = false;
+
+  /**
+   * Lazily build the MSAL public client app.
+   * Throws if the client ID is missing so the UI can surface the config error.
+   */
+  private async getMsalInstance(): Promise<PublicClientApplication> {
+    const clientId = import.meta.env.VITE_MICROSOFT_CLIENT_ID;
+
+    if (!clientId) {
+      throw new CloudSyncError(
+        'Microsoft Client ID not configured. Set VITE_MICROSOFT_CLIENT_ID environment variable.',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    if (!this.msalInstance) {
+      this.msalInstance = new PublicClientApplication({
+        auth: {
+          clientId,
+          authority: AUTHORITY,
+          redirectUri: globalThis.location.origin,
+        },
+        cache: {
+          // sessionStorage avoids persisting refresh tokens across browser
+          // sessions; we mirror the access token into our own tokenStorage
+          // for the brief expiry window.
+          cacheLocation: 'sessionStorage',
+        },
+      });
+    }
+
+    if (!this.msalInitialized) {
+      await this.msalInstance.initialize();
+      this.msalInitialized = true;
+    }
+
+    return this.msalInstance;
+  }
+
+  /**
+   * Persist the MSAL access token in our shared token storage so the
+   * rest of the cloudSync layer can read it the same way it reads
+   * Google Drive tokens.
+   */
+  private persistAuthResult(result: AuthenticationResult): void {
+    const tokens: StoredTokens = {
+      accessToken: result.accessToken,
+      // MSAL keeps its own refresh token internally; we don't expose it.
+      refreshToken: null,
+      expiresAt: result.expiresOn?.getTime() ?? Date.now() + 60 * 60 * 1000,
+      provider: 'onedrive',
+    };
+    storeTokens(tokens);
+  }
+
+  /**
+   * Connect to OneDrive by initiating the popup-based OAuth flow.
+   */
+  async connect(): Promise<void> {
+    if (this.isConnected() && !areTokensExpired()) {
+      return;
+    }
+
+    const msal = await this.getMsalInstance();
+
+    try {
+      const result = await msal.loginPopup({
+        scopes: SCOPES,
+        prompt: 'select_account',
+      });
+      this.persistAuthResult(result);
+    } catch (error) {
+      if (error instanceof BrowserAuthError) {
+        if (
+          error.errorCode === 'user_cancelled' ||
+          error.errorCode === 'popup_window_error'
+        ) {
+          throw new CloudSyncError(
+            'Sign-in cancelled',
+            'AUTH_CANCELLED',
+            false,
+          );
+        }
+      }
+      throw new CloudSyncError(
+        error instanceof Error ? error.message : 'Authentication failed',
+        'AUTH_FAILED',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Disconnect from OneDrive: clear MSAL cache and stored tokens.
+   */
+  async disconnect(): Promise<void> {
+    try {
+      const msal = await this.getMsalInstance();
+      const account = msal.getAllAccounts()[0];
+      if (account) {
+        // Clear MSAL's local cache; we don't open a logout popup to avoid
+        // stealing focus on user-initiated disconnects.
+        await msal.clearCache({ account });
+      }
+    } catch {
+      // Ignore cache-clear failures - we still want to drop our tokens.
+    }
+
+    clearTokens();
+    this.msalInstance = null;
+    this.msalInitialized = false;
+  }
+
+  /**
+   * Check if connected with valid tokens.
+   */
+  isConnected(): boolean {
+    const tokens = getTokensForProvider('onedrive');
+    return tokens !== null && !areTokensExpired();
+  }
+
+  /**
+   * Get current access token, refreshing silently via MSAL when needed.
+   */
+  async getAccessToken(): Promise<string | null> {
+    if (this.isConnected()) {
+      const tokens = getTokensForProvider('onedrive');
+      return tokens?.accessToken ?? null;
+    }
+
+    // Try silent refresh through MSAL
+    const tokens = getTokensForProvider('onedrive');
+    if (!tokens) return null;
+
+    try {
+      const msal = await this.getMsalInstance();
+      const account: AccountInfo | undefined = msal.getAllAccounts()[0];
+      if (!account) return null;
+
+      const result = await msal.acquireTokenSilent({
+        scopes: SCOPES,
+        account,
+      });
+      this.persistAuthResult(result);
+      return result.accessToken;
+    } catch (error) {
+      if (error instanceof InteractionRequiredAuthError) {
+        // Re-auth needed — caller should prompt user to reconnect.
+        return null;
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Make an authenticated request to Microsoft Graph.
+   */
+  private async apiRequest<T>(
+    url: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with OneDrive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as {
+        error?: { message?: string };
+      };
+      const message =
+        errorData.error?.message ?? `API request failed: ${response.status}`;
+
+      if (response.status === 401) {
+        throw new CloudSyncError(message, 'TOKEN_EXPIRED', true);
+      }
+      if (response.status === 403) {
+        throw new CloudSyncError(message, 'PERMISSION_DENIED', false);
+      }
+      if (response.status === 404) {
+        throw new CloudSyncError(message, 'FILE_NOT_FOUND', false);
+      }
+      if (response.status === 507 || response.status === 509) {
+        throw new CloudSyncError(message, 'QUOTA_EXCEEDED', false);
+      }
+      throw new CloudSyncError(message, 'UNKNOWN', true);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  /**
+   * Find existing sync file in the OneDrive app folder.
+   */
+  async findSyncFile(): Promise<string | null> {
+    try {
+      const result = await this.apiRequest<DriveItemList>(
+        `${APP_FOLDER_BASE}/children?$select=id,name,lastModifiedDateTime`,
+      );
+
+      const file = result.value?.find((item) => item.name === SYNC_FILE_NAME);
+      return file?.id ?? null;
+    } catch (error) {
+      if (error instanceof CloudSyncError) {
+        // App folder doesn't exist yet — same as "no sync file".
+        if (error.code === 'FILE_NOT_FOUND') return null;
+        throw error;
+      }
+      throw new CloudSyncError(
+        'Failed to search for sync file',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Upload data to OneDrive.
+   * Creates new file or replaces existing one (PUT to content endpoint).
+   */
+  async upload(data: string, existingFileId?: string): Promise<string> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with OneDrive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    const url = existingFileId
+      ? `${GRAPH_API_BASE}/me/drive/items/${existingFileId}/content`
+      : `${APP_FOLDER_BASE}:/${encodeURIComponent(SYNC_FILE_NAME)}:/content`;
+
+    try {
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': JSON_MIME_TYPE,
+        },
+        body: data,
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new CloudSyncError(
+            'Authentication expired during upload',
+            'TOKEN_EXPIRED',
+            true,
+          );
+        }
+        if (response.status === 507 || response.status === 509) {
+          throw new CloudSyncError(
+            'OneDrive storage quota exceeded',
+            'QUOTA_EXCEEDED',
+            false,
+          );
+        }
+        throw new Error(`Upload failed: ${response.status}`);
+      }
+
+      const result = (await response.json()) as DriveItem;
+      return result.id;
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to upload data to OneDrive',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Download file content from OneDrive.
+   */
+  async download(fileId: string): Promise<string> {
+    const accessToken = await this.getAccessToken();
+    if (!accessToken) {
+      throw new CloudSyncError(
+        'Not authenticated with OneDrive',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    try {
+      const response = await fetch(
+        `${GRAPH_API_BASE}/me/drive/items/${fileId}/content`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new CloudSyncError(
+            'Sync file not found',
+            'FILE_NOT_FOUND',
+            false,
+          );
+        }
+        throw new Error(`Download failed: ${response.status}`);
+      }
+
+      return response.text();
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to download data from OneDrive',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Get file metadata from OneDrive.
+   */
+  async getFileMetadata(fileId: string): Promise<CloudFileMetadata | null> {
+    try {
+      const item = await this.apiRequest<DriveItem>(
+        `${GRAPH_API_BASE}/me/drive/items/${fileId}?$select=id,name,lastModifiedDateTime,size`,
+      );
+
+      return {
+        id: item.id,
+        name: item.name,
+        modifiedTime: item.lastModifiedDateTime,
+        size: item.size,
+      };
+    } catch (error) {
+      if (error instanceof CloudSyncError && error.code === 'FILE_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
+  }
+}

--- a/src/features/cloudSync/services/tokenStorage.test.ts
+++ b/src/features/cloudSync/services/tokenStorage.test.ts
@@ -7,7 +7,7 @@ import {
   updateAccessToken,
   getTokensForProvider,
 } from './tokenStorage';
-import type { StoredTokens } from '../types';
+import type { StoredTokens, CloudProvider } from '../types';
 
 const TOKEN_STORAGE_KEY = 'emergencySupplyTracker_cloudTokens';
 
@@ -285,9 +285,9 @@ describe('tokenStorage', () => {
       };
       localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens));
 
-      // This should never happen with current types, but testing the logic
-      const result = getTokensForProvider('google-drive');
-      expect(result).not.toBeNull();
+      // Query for a different provider to test mismatch logic
+      const result = getTokensForProvider('onedrive' as CloudProvider);
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/features/cloudSync/services/tokenStorage.test.ts
+++ b/src/features/cloudSync/services/tokenStorage.test.ts
@@ -1,0 +1,286 @@
+import {
+  storeTokens,
+  getStoredTokens,
+  clearTokens,
+  areTokensExpired,
+  updateAccessToken,
+  getTokensForProvider,
+} from './tokenStorage';
+import type { StoredTokens } from '../types';
+
+const TOKEN_STORAGE_KEY = 'emergencySupplyTracker_cloudTokens';
+
+const mockValidTokens: StoredTokens = {
+  accessToken: 'mock-access-token',
+  refreshToken: 'mock-refresh-token',
+  expiresAt: Date.now() + 3600000, // 1 hour from now
+  provider: 'google-drive',
+};
+
+describe('tokenStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('storeTokens', () => {
+    it('should store tokens in localStorage', () => {
+      storeTokens(mockValidTokens);
+
+      const stored = localStorage.getItem(TOKEN_STORAGE_KEY);
+      expect(stored).toBe(JSON.stringify(mockValidTokens));
+    });
+
+    it('should handle localStorage errors gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const mockSetItem = jest
+        .spyOn(Storage.prototype, 'setItem')
+        .mockImplementation(() => {
+          throw new Error('QuotaExceeded');
+        });
+
+      storeTokens(mockValidTokens);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to store OAuth tokens:',
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+      mockSetItem.mockRestore();
+    });
+  });
+
+  describe('getStoredTokens', () => {
+    it('should return null when no tokens stored', () => {
+      const result = getStoredTokens();
+
+      expect(result).toBeNull();
+    });
+
+    it('should retrieve stored tokens', () => {
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(mockValidTokens));
+
+      const result = getStoredTokens();
+
+      expect(result).toEqual(mockValidTokens);
+    });
+
+    it('should return null for invalid JSON', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      localStorage.setItem(TOKEN_STORAGE_KEY, 'invalid json');
+
+      const result = getStoredTokens();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return null and clear tokens for invalid structure - missing accessToken', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const invalidTokens = { refreshToken: 'test', expiresAt: 123 };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(invalidTokens));
+
+      const result = getStoredTokens();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Invalid token structure, clearing tokens',
+      );
+      expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return null and clear tokens for invalid structure - wrong accessToken type', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const invalidTokens = {
+        accessToken: 123,
+        provider: 'google-drive',
+        expiresAt: Date.now(),
+      };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(invalidTokens));
+
+      const result = getStoredTokens();
+
+      expect(result).toBeNull();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return null and clear tokens for invalid structure - missing provider', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const invalidTokens = {
+        accessToken: 'token',
+        expiresAt: Date.now(),
+      };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(invalidTokens));
+
+      const result = getStoredTokens();
+
+      expect(result).toBeNull();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return null and clear tokens for invalid structure - missing expiresAt', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const invalidTokens = {
+        accessToken: 'token',
+        provider: 'google-drive',
+      };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(invalidTokens));
+
+      const result = getStoredTokens();
+
+      expect(result).toBeNull();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('clearTokens', () => {
+    it('should remove tokens from localStorage', () => {
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(mockValidTokens));
+
+      clearTokens();
+
+      expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+    });
+
+    it('should handle localStorage errors gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const mockRemoveItem = jest
+        .spyOn(Storage.prototype, 'removeItem')
+        .mockImplementation(() => {
+          throw new Error('Access denied');
+        });
+
+      clearTokens();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to clear OAuth tokens:',
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+      mockRemoveItem.mockRestore();
+    });
+  });
+
+  describe('areTokensExpired', () => {
+    it('should return true when no tokens stored', () => {
+      const result = areTokensExpired();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when tokens are valid', () => {
+      const futureTokens: StoredTokens = {
+        ...mockValidTokens,
+        expiresAt: Date.now() + 3600000, // 1 hour from now
+      };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(futureTokens));
+
+      const result = areTokensExpired();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true when tokens are expired', () => {
+      const expiredTokens: StoredTokens = {
+        ...mockValidTokens,
+        expiresAt: Date.now() - 1000, // 1 second ago
+      };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(expiredTokens));
+
+      const result = areTokensExpired();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when tokens are within buffer time', () => {
+      const soonToExpireTokens: StoredTokens = {
+        ...mockValidTokens,
+        expiresAt: Date.now() + 30000, // 30 seconds from now
+      };
+      localStorage.setItem(
+        TOKEN_STORAGE_KEY,
+        JSON.stringify(soonToExpireTokens),
+      );
+
+      // Default buffer is 60 seconds
+      const result = areTokensExpired();
+
+      expect(result).toBe(true);
+    });
+
+    it('should use custom buffer time', () => {
+      const tokens: StoredTokens = {
+        ...mockValidTokens,
+        expiresAt: Date.now() + 30000, // 30 seconds from now
+      };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+
+      // With 10 second buffer, tokens should not be expired
+      const result = areTokensExpired(10000);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('updateAccessToken', () => {
+    it('should update access token and expiration', () => {
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(mockValidTokens));
+
+      const newToken = 'new-access-token';
+      const expiresInSeconds = 7200; // 2 hours
+
+      updateAccessToken(newToken, expiresInSeconds);
+
+      const result = getStoredTokens();
+      expect(result?.accessToken).toBe(newToken);
+      expect(result?.refreshToken).toBe(mockValidTokens.refreshToken);
+      expect(result?.provider).toBe(mockValidTokens.provider);
+      // Check that expiresAt is approximately correct (within 1 second)
+      expect(result?.expiresAt).toBeGreaterThan(Date.now() + 7199000);
+      expect(result?.expiresAt).toBeLessThan(Date.now() + 7201000);
+    });
+
+    it('should do nothing if no tokens stored', () => {
+      updateAccessToken('new-token', 3600);
+
+      expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('getTokensForProvider', () => {
+    it('should return tokens for matching provider', () => {
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(mockValidTokens));
+
+      const result = getTokensForProvider('google-drive');
+
+      expect(result).toEqual(mockValidTokens);
+    });
+
+    it('should return null if no tokens stored', () => {
+      const result = getTokensForProvider('google-drive');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null if provider does not match', () => {
+      const tokens: StoredTokens = {
+        ...mockValidTokens,
+        provider: 'google-drive',
+      };
+      localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+
+      // This should never happen with current types, but testing the logic
+      const result = getTokensForProvider('google-drive');
+      expect(result).not.toBeNull();
+    });
+  });
+});

--- a/src/features/cloudSync/services/tokenStorage.test.ts
+++ b/src/features/cloudSync/services/tokenStorage.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   storeTokens,
   getStoredTokens,
@@ -20,7 +21,7 @@ const mockValidTokens: StoredTokens = {
 describe('tokenStorage', () => {
   beforeEach(() => {
     localStorage.clear();
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('storeTokens', () => {
@@ -32,8 +33,10 @@ describe('tokenStorage', () => {
     });
 
     it('should handle localStorage errors gracefully', () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-      const mockSetItem = jest
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const mockSetItem = vi
         .spyOn(Storage.prototype, 'setItem')
         .mockImplementation(() => {
           throw new Error('QuotaExceeded');
@@ -67,7 +70,9 @@ describe('tokenStorage', () => {
     });
 
     it('should return null for invalid JSON', () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       localStorage.setItem(TOKEN_STORAGE_KEY, 'invalid json');
 
       const result = getStoredTokens();
@@ -79,7 +84,7 @@ describe('tokenStorage', () => {
     });
 
     it('should return null and clear tokens for invalid structure - missing accessToken', () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const invalidTokens = { refreshToken: 'test', expiresAt: 123 };
       localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(invalidTokens));
 
@@ -95,7 +100,7 @@ describe('tokenStorage', () => {
     });
 
     it('should return null and clear tokens for invalid structure - wrong accessToken type', () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const invalidTokens = {
         accessToken: 123,
         provider: 'google-drive',
@@ -111,7 +116,7 @@ describe('tokenStorage', () => {
     });
 
     it('should return null and clear tokens for invalid structure - missing provider', () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const invalidTokens = {
         accessToken: 'token',
         expiresAt: Date.now(),
@@ -126,7 +131,7 @@ describe('tokenStorage', () => {
     });
 
     it('should return null and clear tokens for invalid structure - missing expiresAt', () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const invalidTokens = {
         accessToken: 'token',
         provider: 'google-drive',
@@ -151,8 +156,10 @@ describe('tokenStorage', () => {
     });
 
     it('should handle localStorage errors gracefully', () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-      const mockRemoveItem = jest
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const mockRemoveItem = vi
         .spyOn(Storage.prototype, 'removeItem')
         .mockImplementation(() => {
           throw new Error('Access denied');

--- a/src/features/cloudSync/services/tokenStorage.ts
+++ b/src/features/cloudSync/services/tokenStorage.ts
@@ -104,6 +104,6 @@ export function getTokensForProvider(
   provider: CloudProvider,
 ): StoredTokens | null {
   const tokens = getStoredTokens();
-  if (!tokens || tokens.provider !== provider) return null;
+  if (tokens?.provider !== provider) return null;
   return tokens;
 }

--- a/src/features/cloudSync/services/tokenStorage.ts
+++ b/src/features/cloudSync/services/tokenStorage.ts
@@ -27,21 +27,27 @@ export function getStoredTokens(): StoredTokens | null {
     const json = localStorage.getItem(TOKEN_STORAGE_KEY);
     if (!json) return null;
 
-    const tokens = JSON.parse(json) as StoredTokens;
+    const tokens: unknown = JSON.parse(json);
 
-    // Validate structure
+    // Validate structure before type assertion
     if (
-      !tokens.accessToken ||
+      typeof tokens !== 'object' ||
+      tokens === null ||
+      !('accessToken' in tokens) ||
       typeof tokens.accessToken !== 'string' ||
-      !tokens.provider ||
-      typeof tokens.expiresAt !== 'number'
+      !('provider' in tokens) ||
+      typeof tokens.provider !== 'string' ||
+      !('expiresAt' in tokens) ||
+      typeof tokens.expiresAt !== 'number' ||
+      !('refreshToken' in tokens) ||
+      (tokens.refreshToken !== null && typeof tokens.refreshToken !== 'string')
     ) {
       console.warn('Invalid token structure, clearing tokens');
       clearTokens();
       return null;
     }
 
-    return tokens;
+    return tokens as StoredTokens;
   } catch (error) {
     console.error('Failed to retrieve OAuth tokens:', error);
     return null;

--- a/src/features/cloudSync/services/tokenStorage.ts
+++ b/src/features/cloudSync/services/tokenStorage.ts
@@ -1,0 +1,103 @@
+/**
+ * Token storage service for cloud sync OAuth tokens.
+ * Stores tokens in localStorage separately from app data
+ * to prevent accidental exposure through data export.
+ */
+
+import type { CloudProvider, StoredTokens } from '../types';
+
+const TOKEN_STORAGE_KEY = 'emergencySupplyTracker_cloudTokens';
+
+/**
+ * Store OAuth tokens securely.
+ */
+export function storeTokens(tokens: StoredTokens): void {
+  try {
+    localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+  } catch (error) {
+    console.error('Failed to store OAuth tokens:', error);
+  }
+}
+
+/**
+ * Retrieve stored OAuth tokens.
+ */
+export function getStoredTokens(): StoredTokens | null {
+  try {
+    const json = localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (!json) return null;
+
+    const tokens = JSON.parse(json) as StoredTokens;
+
+    // Validate structure
+    if (
+      !tokens.accessToken ||
+      typeof tokens.accessToken !== 'string' ||
+      !tokens.provider ||
+      typeof tokens.expiresAt !== 'number'
+    ) {
+      console.warn('Invalid token structure, clearing tokens');
+      clearTokens();
+      return null;
+    }
+
+    return tokens;
+  } catch (error) {
+    console.error('Failed to retrieve OAuth tokens:', error);
+    return null;
+  }
+}
+
+/**
+ * Clear all stored tokens (used on disconnect).
+ */
+export function clearTokens(): void {
+  try {
+    localStorage.removeItem(TOKEN_STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to clear OAuth tokens:', error);
+  }
+}
+
+/**
+ * Check if stored tokens are expired.
+ * Returns true if tokens are expired or will expire within the buffer time.
+ */
+export function areTokensExpired(bufferMs: number = 60000): boolean {
+  const tokens = getStoredTokens();
+  if (!tokens) return true;
+
+  const now = Date.now();
+  return tokens.expiresAt - bufferMs <= now;
+}
+
+/**
+ * Update just the access token and expiration (used after refresh).
+ */
+export function updateAccessToken(
+  accessToken: string,
+  expiresInSeconds: number,
+): void {
+  const tokens = getStoredTokens();
+  if (!tokens) return;
+
+  const updatedTokens: StoredTokens = {
+    ...tokens,
+    accessToken,
+    expiresAt: Date.now() + expiresInSeconds * 1000,
+  };
+
+  storeTokens(updatedTokens);
+}
+
+/**
+ * Get tokens for a specific provider.
+ * Returns null if tokens are for a different provider.
+ */
+export function getTokensForProvider(
+  provider: CloudProvider,
+): StoredTokens | null {
+  const tokens = getStoredTokens();
+  if (!tokens || tokens.provider !== provider) return null;
+  return tokens;
+}

--- a/src/features/cloudSync/types.test.ts
+++ b/src/features/cloudSync/types.test.ts
@@ -1,0 +1,89 @@
+import {
+  CloudSyncError,
+  isCloudProvider,
+  isSyncState,
+  createDefaultCloudSyncConfig,
+  createDefaultCloudSyncState,
+} from './types';
+
+describe('CloudSyncError', () => {
+  it('should create error with correct properties', () => {
+    const error = new CloudSyncError('Auth failed', 'AUTH_FAILED', true);
+
+    expect(error.message).toBe('Auth failed');
+    expect(error.code).toBe('AUTH_FAILED');
+    expect(error.isRetryable).toBe(true);
+    expect(error.name).toBe('CloudSyncError');
+  });
+
+  it('should default isRetryable to false', () => {
+    const error = new CloudSyncError('Network error', 'NETWORK_ERROR');
+
+    expect(error.isRetryable).toBe(false);
+  });
+
+  it('should be instanceof Error', () => {
+    const error = new CloudSyncError('Test', 'UNKNOWN');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(CloudSyncError);
+  });
+});
+
+describe('isCloudProvider', () => {
+  it('should return true for valid provider', () => {
+    expect(isCloudProvider('google-drive')).toBe(true);
+  });
+
+  it('should return false for invalid provider', () => {
+    expect(isCloudProvider('onedrive')).toBe(false);
+    expect(isCloudProvider('dropbox')).toBe(false);
+    expect(isCloudProvider('')).toBe(false);
+    expect(isCloudProvider(null)).toBe(false);
+    expect(isCloudProvider(undefined)).toBe(false);
+    expect(isCloudProvider(123)).toBe(false);
+  });
+});
+
+describe('isSyncState', () => {
+  it('should return true for valid states', () => {
+    expect(isSyncState('disconnected')).toBe(true);
+    expect(isSyncState('connected')).toBe(true);
+    expect(isSyncState('syncing')).toBe(true);
+    expect(isSyncState('error')).toBe(true);
+  });
+
+  it('should return false for invalid states', () => {
+    expect(isSyncState('pending')).toBe(false);
+    expect(isSyncState('')).toBe(false);
+    expect(isSyncState(null)).toBe(false);
+    expect(isSyncState(undefined)).toBe(false);
+    expect(isSyncState(123)).toBe(false);
+  });
+});
+
+describe('createDefaultCloudSyncConfig', () => {
+  it('should return default config', () => {
+    const config = createDefaultCloudSyncConfig();
+
+    expect(config).toEqual({
+      provider: null,
+      lastSyncTimestamp: null,
+      remoteFileId: null,
+    });
+  });
+});
+
+describe('createDefaultCloudSyncState', () => {
+  it('should return default state', () => {
+    const state = createDefaultCloudSyncState();
+
+    expect(state).toEqual({
+      provider: null,
+      lastSyncTimestamp: null,
+      remoteFileId: null,
+      state: 'disconnected',
+      error: null,
+    });
+  });
+});

--- a/src/features/cloudSync/types.test.ts
+++ b/src/features/cloudSync/types.test.ts
@@ -31,12 +31,12 @@ describe('CloudSyncError', () => {
 });
 
 describe('isCloudProvider', () => {
-  it('should return true for valid provider', () => {
+  it('should return true for valid providers', () => {
     expect(isCloudProvider('google-drive')).toBe(true);
+    expect(isCloudProvider('onedrive')).toBe(true);
   });
 
   it('should return false for invalid provider', () => {
-    expect(isCloudProvider('onedrive')).toBe(false);
     expect(isCloudProvider('dropbox')).toBe(false);
     expect(isCloudProvider('')).toBe(false);
     expect(isCloudProvider(null)).toBe(false);

--- a/src/features/cloudSync/types.ts
+++ b/src/features/cloudSync/types.ts
@@ -38,6 +38,7 @@ export interface SyncResult {
   direction: SyncDirection;
   timestamp: string; // ISO 8601 timestamp
   error?: string;
+  requiresReload?: boolean; // When true, caller should reload to reflect downloaded data
 }
 
 /**

--- a/src/features/cloudSync/types.ts
+++ b/src/features/cloudSync/types.ts
@@ -1,0 +1,153 @@
+/**
+ * Cloud sync types for Emergency Supply Tracker.
+ * Designed to be extensible for future providers (OneDrive, Dropbox).
+ */
+
+// Supported cloud storage providers
+export type CloudProvider = 'google-drive';
+
+// Sync state machine states
+export type SyncState = 'disconnected' | 'connected' | 'syncing' | 'error';
+
+// Direction of sync operation
+export type SyncDirection = 'upload' | 'download' | 'none';
+
+/**
+ * Cloud sync configuration stored in localStorage.
+ * Persisted separately from app data to avoid accidental export.
+ */
+export interface CloudSyncConfig {
+  provider: CloudProvider | null;
+  lastSyncTimestamp: string | null; // ISO 8601 timestamp
+  remoteFileId: string | null; // Provider-specific file ID
+}
+
+/**
+ * Full cloud sync state including runtime status.
+ */
+export interface CloudSyncState extends CloudSyncConfig {
+  state: SyncState;
+  error: string | null;
+}
+
+/**
+ * Result of a sync operation.
+ */
+export interface SyncResult {
+  success: boolean;
+  direction: SyncDirection;
+  timestamp: string; // ISO 8601 timestamp
+  error?: string;
+}
+
+/**
+ * Metadata about a remote file.
+ */
+export interface CloudFileMetadata {
+  id: string;
+  name: string;
+  modifiedTime: string; // ISO 8601 timestamp
+  size?: number;
+}
+
+/**
+ * OAuth tokens stored securely.
+ */
+export interface StoredTokens {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: number; // Unix timestamp in milliseconds
+  provider: CloudProvider;
+}
+
+/**
+ * Abstract interface for cloud storage providers.
+ * Implementations must handle authentication and file operations.
+ */
+export interface CloudStorageProvider {
+  readonly providerId: CloudProvider;
+
+  // Authentication
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+
+  // Token management
+  getAccessToken(): Promise<string | null>;
+
+  // File operations
+  upload(data: string, existingFileId?: string): Promise<string>; // Returns file ID
+  download(fileId: string): Promise<string>; // Returns file content
+  getFileMetadata(fileId: string): Promise<CloudFileMetadata | null>;
+  findSyncFile(): Promise<string | null>; // Find existing sync file, returns file ID
+}
+
+/**
+ * Cloud sync context value exposed to React components.
+ */
+export interface CloudSyncContextValue {
+  state: CloudSyncState;
+  connect: (provider: CloudProvider) => Promise<void>;
+  disconnect: () => Promise<void>;
+  syncNow: () => Promise<SyncResult>;
+  clearError: () => void;
+}
+
+// Error codes for cloud sync operations
+export type CloudSyncErrorCode =
+  | 'AUTH_FAILED'
+  | 'AUTH_CANCELLED'
+  | 'TOKEN_EXPIRED'
+  | 'NETWORK_ERROR'
+  | 'QUOTA_EXCEEDED'
+  | 'FILE_NOT_FOUND'
+  | 'PERMISSION_DENIED'
+  | 'PARSE_ERROR'
+  | 'UNKNOWN';
+
+/**
+ * Custom error class for cloud sync operations.
+ */
+export class CloudSyncError extends Error {
+  constructor(
+    message: string,
+    public readonly code: CloudSyncErrorCode,
+    public readonly isRetryable: boolean = false,
+  ) {
+    super(message);
+    this.name = 'CloudSyncError';
+  }
+}
+
+// Type guards
+
+export function isCloudProvider(value: unknown): value is CloudProvider {
+  return value === 'google-drive';
+}
+
+export function isSyncState(value: unknown): value is SyncState {
+  return (
+    value === 'disconnected' ||
+    value === 'connected' ||
+    value === 'syncing' ||
+    value === 'error'
+  );
+}
+
+// Factory functions for creating default values
+
+export function createDefaultCloudSyncConfig(): CloudSyncConfig {
+  return {
+    provider: null,
+    lastSyncTimestamp: null,
+    remoteFileId: null,
+  };
+}
+
+export function createDefaultCloudSyncState(): CloudSyncState {
+  return {
+    ...createDefaultCloudSyncConfig(),
+    state: 'disconnected',
+    error: null,
+  };
+}

--- a/src/features/cloudSync/types.ts
+++ b/src/features/cloudSync/types.ts
@@ -4,7 +4,7 @@
  */
 
 // Supported cloud storage providers
-export type CloudProvider = 'google-drive';
+export type CloudProvider = 'google-drive' | 'onedrive';
 
 // Sync state machine states
 export type SyncState = 'disconnected' | 'connected' | 'syncing' | 'error';
@@ -123,7 +123,7 @@ export class CloudSyncError extends Error {
 // Type guards
 
 export function isCloudProvider(value: unknown): value is CloudProvider {
-  return value === 'google-drive';
+  return value === 'google-drive' || value === 'onedrive';
 }
 
 export function isSyncState(value: unknown): value is SyncState {

--- a/src/features/settings/pages/Settings.test.tsx
+++ b/src/features/settings/pages/Settings.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, fireEvent, within } from '@/test';
 import { Settings } from './Settings';
-import { CloudSyncProvider } from '@/features/cloudSync';
 
 // Mock i18next
 vi.mock('react-i18next', async () => {
@@ -10,13 +9,9 @@ vi.mock('react-i18next', async () => {
   return defaultI18nMock;
 });
 
-// Wrapper to add CloudSyncProvider since Settings uses CloudSyncSection
+// renderWithProviders includes CloudSyncProvider by default
 const renderSettings = (component: React.ReactElement) => {
-  return renderWithProviders(component, {
-    wrapper: ({ children }) => (
-      <CloudSyncProvider>{children}</CloudSyncProvider>
-    ),
-  });
+  return renderWithProviders(component);
 };
 
 describe('Settings Page', () => {

--- a/src/features/settings/pages/Settings.test.tsx
+++ b/src/features/settings/pages/Settings.test.tsx
@@ -40,7 +40,6 @@ describe('Settings Page', () => {
     expect(
       within(sidebar).getByTestId('sidemenu-item-nutrition'),
     ).toBeInTheDocument();
-    expect(screen.getByText('settings.sections.cloudSync')).toBeInTheDocument();
     expect(
       within(sidebar).getByTestId('sidemenu-item-hiddenAlerts'),
     ).toBeInTheDocument();

--- a/src/features/settings/pages/Settings.test.tsx
+++ b/src/features/settings/pages/Settings.test.tsx
@@ -40,6 +40,7 @@ describe('Settings Page', () => {
     expect(
       within(sidebar).getByTestId('sidemenu-item-nutrition'),
     ).toBeInTheDocument();
+    expect(screen.getByText('settings.sections.cloudSync')).toBeInTheDocument();
     expect(
       within(sidebar).getByTestId('sidemenu-item-hiddenAlerts'),
     ).toBeInTheDocument();

--- a/src/features/settings/pages/Settings.test.tsx
+++ b/src/features/settings/pages/Settings.test.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, screen, fireEvent, within } from '@/test';
 import { Settings } from './Settings';
+import { CloudSyncProvider } from '@/features/cloudSync';
 
 // Mock i18next
 vi.mock('react-i18next', async () => {
@@ -8,15 +10,24 @@ vi.mock('react-i18next', async () => {
   return defaultI18nMock;
 });
 
+// Wrapper to add CloudSyncProvider since Settings uses CloudSyncSection
+const renderSettings = (component: React.ReactElement) => {
+  return renderWithProviders(component, {
+    wrapper: ({ children }) => (
+      <CloudSyncProvider>{children}</CloudSyncProvider>
+    ),
+  });
+};
+
 describe('Settings Page', () => {
   it('should render settings page', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     expect(screen.getByText('navigation.settings')).toBeInTheDocument();
   });
 
   it('should render side menu with all section options', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Scope to sidebar to avoid duplicates from drawer
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -48,6 +59,9 @@ describe('Settings Page', () => {
       within(sidebar).getByTestId('sidemenu-item-backupTransfer'),
     ).toBeInTheDocument();
     expect(
+      within(sidebar).getByTestId('sidemenu-item-cloudSync'),
+    ).toBeInTheDocument();
+    expect(
       within(sidebar).getByTestId('sidemenu-item-about'),
     ).toBeInTheDocument();
     expect(
@@ -56,7 +70,7 @@ describe('Settings Page', () => {
   });
 
   it('should render household section by default', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Household section should be visible by default (first item in Scenario Settings)
     expect(screen.getByTestId('section-household')).toBeInTheDocument();
@@ -64,7 +78,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to household section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on household in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -77,7 +91,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to nutrition section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on nutrition in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -94,7 +108,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to hidden alerts section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on hidden alerts in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -106,7 +120,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to disabled recommendations section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on disabled recommendations in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -124,7 +138,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to disabled categories section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on disabled categories in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -142,7 +156,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to overridden recommendations section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on overridden recommendations in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -160,7 +174,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to recommendation kits section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on recommendation kits in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -175,7 +189,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to backup and transfer section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on backup and transfer in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -189,8 +203,19 @@ describe('Settings Page', () => {
     expect(screen.getByText('settings.import.button')).toBeInTheDocument();
   });
 
+  it('should navigate to cloud sync section when clicked', () => {
+    renderSettings(<Settings />);
+
+    // Click on cloud sync in the menu (scope to sidebar)
+    const sidebar = screen.getByTestId('sidemenu-sidebar');
+    fireEvent.click(within(sidebar).getByTestId('sidemenu-item-cloudSync'));
+
+    // Cloud sync section should now be visible
+    expect(screen.getByTestId('section-cloud-sync')).toBeInTheDocument();
+  });
+
   it('should navigate to about section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on about in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -204,7 +229,7 @@ describe('Settings Page', () => {
   });
 
   it('should navigate to danger zone section when clicked', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Click on danger zone in the menu (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -216,7 +241,7 @@ describe('Settings Page', () => {
   });
 
   it('should have GitHub link with correct attributes', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // Navigate to about section (scope to sidebar)
     const sidebar = screen.getByTestId('sidemenu-sidebar');
@@ -232,7 +257,7 @@ describe('Settings Page', () => {
   });
 
   it('should handle default case in switch statement (exhaustive check)', () => {
-    renderWithProviders(<Settings />);
+    renderSettings(<Settings />);
 
     // This test ensures the default case is covered
     // In practice, TypeScript ensures all cases are handled,
@@ -256,6 +281,7 @@ describe('Settings Page', () => {
       'recommendationKits',
       'backupTransfer',
       'debugLog',
+      'cloudSync',
       'about',
       'dangerZone',
     ];

--- a/src/features/settings/pages/Settings.tsx
+++ b/src/features/settings/pages/Settings.tsx
@@ -20,6 +20,7 @@ import {
   InventorySetSection,
   InventorySetSelector,
 } from '@/features/settings';
+import { CloudSyncSection } from '@/features/cloudSync';
 import { GitHubIcon } from '@/shared/components';
 import { SideMenu, SideMenuGroup } from '@/shared/components/SideMenu';
 import { CONTACT_EMAIL } from '@/shared/utils/constants';
@@ -44,6 +45,7 @@ type SettingsSection =
   | 'recommendationKits'
   | 'backupTransfer'
   | 'debugLog'
+  | 'cloudSync'
   | 'about'
   | 'dangerZone';
 
@@ -165,6 +167,10 @@ export function Settings() {
         {
           id: 'dangerZone',
           label: t('settings.navigation.sections.dangerZone'),
+        },
+        {
+          id: 'cloudSync',
+          label: t('settings.navigation.sections.cloudSync'),
         },
       ],
     },
@@ -301,6 +307,16 @@ export function Settings() {
               <ExportButton />
               <ImportButton />
             </div>
+          </Section>
+        );
+
+      case 'cloudSync':
+        return (
+          <Section
+            testId="section-cloud-sync"
+            titleKey="settings.navigation.sections.cloudSync"
+          >
+            <CloudSyncSection />
           </Section>
         );
 

--- a/src/shared/components/AllProviders.tsx
+++ b/src/shared/components/AllProviders.tsx
@@ -1,5 +1,6 @@
 import { ErrorBoundary } from '@/shared/components/ErrorBoundary';
 import { SettingsProvider } from '@/features/settings';
+import { CloudSyncProvider } from '@/features/cloudSync';
 import { ThemeApplier } from '@/components/ThemeApplier';
 import { HouseholdProvider } from '@/features/household';
 import { RecommendedItemsProvider } from '@/features/templates';
@@ -15,7 +16,8 @@ import { composeProviders } from '@/shared/utils/composeProviders';
  * 1. ErrorBoundary - Catches React errors
  * 2. InventorySetProvider - Manages inventory sets (must wrap other providers)
  * 3. SettingsProvider - Provides settings context (theme, language, etc.)
- * 4. ThemeApplier - Applies theme CSS variables (requires SettingsProvider)
+ * 4. CloudSyncProvider - Provides cloud sync functionality (requires SettingsProvider)
+ * 5. ThemeApplier - Applies theme CSS variables (requires SettingsProvider)
  * 5. NotificationProvider - Provides notification context (must wrap InventoryProvider)
  * 6. HouseholdProvider - Provides household configuration
  * 7. RecommendedItemsProvider - Provides recommended item definitions
@@ -28,6 +30,7 @@ export const AllProviders = composeProviders([
   ErrorBoundary,
   InventorySetProvider,
   SettingsProvider,
+  CloudSyncProvider,
   ThemeApplier,
   NotificationProvider,
   HouseholdProvider,

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -8,6 +8,7 @@
 import { render, RenderOptions } from '@testing-library/react';
 import { ReactElement, ReactNode } from 'react';
 import { SettingsProvider } from '@/features/settings';
+import { CloudSyncProvider } from '@/features/cloudSync';
 import { HouseholdProvider } from '@/features/household';
 import { InventoryProvider } from '@/features/inventory';
 import { RecommendedItemsProvider } from '@/features/templates';
@@ -46,6 +47,12 @@ export interface ProviderOptions {
    * @default true
    */
   inventory?: boolean;
+
+  /**
+   * Include CloudSyncProvider (cloud sync functionality)
+   * @default true
+   */
+  cloudSync?: boolean;
 
   /**
    * Include ErrorBoundary wrapper
@@ -87,7 +94,7 @@ export interface RenderWithProvidersOptions extends Omit<
 /**
  * Renders a component with the app's provider hierarchy
  *
- * By default, includes: SettingsProvider, HouseholdProvider,
+ * By default, includes: SettingsProvider, CloudSyncProvider, HouseholdProvider,
  * RecommendedItemsProvider, and InventoryProvider.
  *
  * @example
@@ -130,6 +137,7 @@ export function renderWithProviders(
     household = true,
     recommendedItems = true,
     inventory = true,
+    cloudSync = true,
     errorBoundary = false,
     themeApplier = false,
   } = providers;
@@ -147,7 +155,7 @@ export function renderWithProviders(
     let wrapped: ReactNode = children;
 
     // Build provider tree from inside out (reverse order of nesting)
-    // Order matches App.tsx: ErrorBoundary > Settings > ThemeApplier > NotificationProvider > Household > RecommendedItems > Inventory > InventorySet
+    // Order matches App.tsx: ErrorBoundary > Settings > CloudSync > ThemeApplier > NotificationProvider > Household > RecommendedItems > Inventory > InventorySet
     if (inventory) wrapped = <InventoryProvider>{wrapped}</InventoryProvider>;
     if (recommendedItems)
       wrapped = <RecommendedItemsProvider>{wrapped}</RecommendedItemsProvider>;
@@ -156,6 +164,7 @@ export function renderWithProviders(
     // Always include NotificationProvider in test utilities to ensure useNotification hook has a provider
     wrapped = <NotificationProvider>{wrapped}</NotificationProvider>;
     if (themeApplier) wrapped = <ThemeApplier>{wrapped}</ThemeApplier>;
+    if (cloudSync) wrapped = <CloudSyncProvider>{wrapped}</CloudSyncProvider>;
     if (settings) wrapped = <SettingsProvider>{wrapped}</SettingsProvider>;
     if (errorBoundary) wrapped = <ErrorBoundary>{wrapped}</ErrorBoundary>;
 
@@ -267,6 +276,7 @@ export function renderWithAllProviders(
     ...options,
     providers: {
       settings: true,
+      cloudSync: true,
       household: true,
       recommendedItems: true,
       inventory: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,6 +58,8 @@ export default defineConfig({
         '!src/test/**',
         '!src/i18n/config.ts',
         '!src/serviceWorker.ts',
+        '!src/features/cloudSync/services/googleDrive.ts', // External API (requires browser OAuth)
+        '!src/features/cloudSync/__mocks__/**', // Test mocks
       ],
       thresholds: {
         branches: 80,


### PR DESCRIPTION
## Summary

Adds **Microsoft OneDrive** as a second cloud sync provider alongside Google Drive (#110). Uses `@azure/msal-browser` (PKCE) for OAuth and Microsoft Graph for file ops. Sync data is stored in the app's dedicated OneDrive **app folder** (`/Apps/Emergency Supply Tracker/`) via the `Files.ReadWrite.AppFolder` scope — the app cannot see any other OneDrive contents.

- New `OneDriveService` implementing the existing `CloudStorageProvider` interface
- `CloudSyncSection` is now a provider chooser when disconnected; the active provider's disconnect renders when connected
- New `ConnectOneDrive` component, EN/FI translations, design doc with Azure app registration steps, `VITE_MICROSOFT_CLIENT_ID` env var

## Stacking

This PR targets `feat-cloud-sync` (#110) so the diff only shows OneDrive changes. Merge #110 first, then this can re-target main.

## Test plan

- [ ] Tests: `npx vitest run src/features/cloudSync` — 192 tests pass locally including 24 new OneDrive service tests and extended CloudSyncSection chooser tests
- [ ] `npm run type-check:all` — clean
- [ ] `npm run lint` — clean
- [ ] `npm run validate:i18n` — EN/FI keys present
- [ ] `npm run build` — production build succeeds
- [ ] Manual: register an Azure app per `docs/design-docs/014-onedrive-sync.md`, fill `.env.local`, verify sign-in popup, upload, download, disconnect