### PR TITLE
feat: add Apple iCloud cloud sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,19 @@ VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 #    (User.Read is included automatically for sign-in)
 # 5. Copy the Application (client) ID below
 VITE_MICROSOFT_CLIENT_ID=your-microsoft-client-id
+
+# Apple iCloud (CloudKit) configuration for iCloud sync
+# Requires an active Apple Developer Program membership ($99/year).
+# 1. Sign in to https://developer.apple.com/ and open CloudKit Console:
+#    https://icloud.developer.apple.com/dashboard
+# 2. Create a container, e.g. iCloud.fi.72tuntia.app
+#    (the prefix `iCloud.` is required by Apple)
+# 3. In Schema -> Record Types, create `EmergencySupplyData` with one
+#    field: `data` (String, indexed: queryable not required)
+# 4. In API Tokens, create a new web token; allow your origins:
+#    http://localhost:5173 for dev, plus staging/production URLs
+# 5. Copy the container ID and API token below. Use 'development' while
+#    iterating on the schema and 'production' once deployed.
+VITE_ICLOUD_CONTAINER_ID=iCloud.your.bundle.id
+VITE_ICLOUD_API_TOKEN=your-cloudkit-web-api-token
+VITE_ICLOUD_ENVIRONMENT=production

--- a/docs/design-docs/015-icloud-sync.md
+++ b/docs/design-docs/015-icloud-sync.md
@@ -1,0 +1,93 @@
+# iCloud Sync
+
+Adds Apple iCloud as the third cloud sync provider, alongside Google Drive and Microsoft OneDrive. Users sign in with their Apple ID; sync data is stored as a single record in the user's _private_ CloudKit database. The app cannot read any other iCloud data.
+
+## Architecture
+
+iCloud plugs into the existing `CloudStorageProvider` abstraction:
+
+```
+src/features/cloudSync/
+├── services/
+│   ├── googleDrive.ts         # existing
+│   ├── oneDrive.ts            # existing
+│   ├── iCloud.ts              # NEW — CloudKit JS + private DB
+│   ├── tokenStorage.ts        # shared
+│   └── cloudStorageProvider.ts  # registers all three providers
+├── components/
+│   ├── ConnectGoogleDrive.tsx
+│   ├── ConnectOneDrive.tsx
+│   ├── ConnectICloud.tsx      # NEW — mirror component
+│   └── CloudSyncSection.tsx   # provider chooser shows all three
+└── types.ts                   # CloudProvider = 'google-drive' | 'onedrive' | 'icloud'
+```
+
+Only one provider is active at a time. Switching providers means disconnect → reconnect.
+
+## CloudKit data model
+
+CloudKit is record-based, not file-based. We model the sync payload as one record:
+
+| Field        | Type                       | Purpose                                                                 |
+| ------------ | -------------------------- | ----------------------------------------------------------------------- |
+| `recordType` | `EmergencySupplyData`      | Schema name                                                             |
+| `recordName` | `sync-data` (fixed)        | Stable identifier so the record is unique per user                      |
+| `data`       | `String`                   | Serialized JSON payload (the same blob other providers store as a file) |
+| `modified`   | (auto-managed by CloudKit) | Used as `modifiedTime` for last-write-wins comparison                   |
+
+The same shape (id / modifiedTime / size) is exposed via `CloudFileMetadata`, so the rest of the cloudSync layer treats this provider identically to the others.
+
+## CloudKit JS
+
+CloudKit JS is loaded **dynamically from Apple's CDN** (`https://cdn.apple-cloudkit.com/ck/2/cloudkit.js`) — there is no npm package. `iCloud.ts` injects a `<script>` tag once and caches the load promise. After the script loads, we call:
+
+- `CloudKit.configure({ containers: [...] })` — once per session
+- `container.setUpAuth()` — resolves the existing identity, or `null` if the user must click _Sign in with Apple_
+- `container.privateCloudDatabase.fetchRecords(['sync-data'])` — read
+- `container.privateCloudDatabase.saveRecords([record])` — create / replace
+
+Auth state lives inside CloudKit JS's session cookies. We mirror the user's `userRecordName` into our shared `tokenStorage` so the rest of the layer can call `isConnected()` uniformly. The mirrored "token" is a marker, not a credential — actual auth is enforced by Apple on every API call.
+
+Errors from CloudKit JS carry a `ckErrorCode` field that we map to our `CloudSyncErrorCode` union: `AUTHENTICATION_REQUIRED` → `TOKEN_EXPIRED`, `RECORD_NOT_FOUND`/`NOT_FOUND` → null/`FILE_NOT_FOUND`, `QUOTA_EXCEEDED` → `QUOTA_EXCEEDED`.
+
+## Setup: Apple Developer + CloudKit Console
+
+iCloud sync is **not free** — it requires an active Apple Developer Program membership ($99/year).
+
+1. **Apple Developer Program**: enroll at <https://developer.apple.com/programs/>. Wait for approval (a few hours to a day).
+2. **CloudKit container**: open the [CloudKit Console](https://icloud.developer.apple.com/dashboard) and create a container. The identifier must start with `iCloud.`, e.g. `iCloud.fi.72tuntia.app`.
+3. **Schema**: in **Schema → Record Types**, add `EmergencySupplyData` with one custom field:
+   - `data` — type _String_, queryable not required.
+4. **Web API token**: in **API Tokens**, click _New Token_ → _Web Services_. Add allowed origins for every domain that will use iCloud sync:
+   - `http://localhost:5173` (dev)
+   - `https://72tuntia.fi` (prod)
+   - any staging hosts
+     Copy the generated token.
+5. **Environment**: CloudKit has separate _development_ and _production_ environments. Use `development` while iterating on the schema; promote it via the dashboard before going to `production`.
+6. **`.env.local`**:
+   ```
+   VITE_ICLOUD_CONTAINER_ID=iCloud.fi.72tuntia.app
+   VITE_ICLOUD_API_TOKEN=<the web API token>
+   VITE_ICLOUD_ENVIRONMENT=production
+   ```
+7. **Sign in with Apple** is configured automatically when the container is created — no separate Apple ID app registration is needed for the JS web flow.
+
+## What we don't do
+
+- **No multi-device push notifications.** CloudKit supports record subscriptions and push, but we currently do manual sync only. A subscription that triggers `syncNow()` when another device updates the record is a natural follow-up.
+- **No conflict resolution beyond last-write-wins.** CloudKit gives us `recordChangeTag` for optimistic concurrency, but `performSync` already uses timestamp-based last-write-wins to stay consistent across providers. We accept the same trade-off here.
+- **No iOS/macOS-app integration.** This is a web-only path. A native companion app could share the same CloudKit container (same `containerIdentifier`) and the records would be visible from both — but that is out of scope.
+
+## Testing
+
+`iCloud.test.ts` mocks `tokenStorage` and injects a fake `globalThis.CloudKit`, exercising:
+
+- Connect (existing identity, fallback to `auth.signIn`, missing env vars)
+- Disconnect (sign-out success, sign-out failure still clears tokens)
+- `isConnected` across token states
+- `findSyncFile` (record present, empty result, RECORD_NOT_FOUND)
+- `upload` (saves record, AUTHENTICATION_REQUIRED → `TOKEN_EXPIRED`, QUOTA_EXCEEDED)
+- `download` (returns `data` field, missing record → `FILE_NOT_FOUND`, wrong field type → `PARSE_ERROR`)
+- `getFileMetadata` (mapped CloudKit fields, missing record returns `null`)
+
+The provider chooser UI is covered by extended `CloudSyncSection` tests verifying that all three connect components render when disconnected and that the correct provider's disconnect appears when connected.

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -813,7 +813,8 @@
     },
     "providers": {
       "google-drive": "Google Drive",
-      "onedrive": "OneDrive"
+      "onedrive": "OneDrive",
+      "icloud": "iCloud"
     },
     "section": {
       "connectTitle": "Connect to Cloud",
@@ -841,6 +842,12 @@
       "connecting": "Connecting...",
       "connected": "Connected to OneDrive",
       "description": "Sign in with your Microsoft account to sync data to your OneDrive."
+    },
+    "icloud": {
+      "connect": "Connect iCloud",
+      "connecting": "Connecting...",
+      "connected": "Connected to iCloud",
+      "description": "Sign in with your Apple ID to sync data to your iCloud."
     },
     "disconnect": {
       "button": "Disconnect",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -813,7 +813,8 @@
     },
     "providers": {
       "google-drive": "Google Drive",
-      "onedrive": "OneDrive"
+      "onedrive": "OneDrive",
+      "icloud": "iCloud"
     },
     "section": {
       "connectTitle": "Yhdistä pilveen",
@@ -841,6 +842,12 @@
       "connecting": "Yhdistetään...",
       "connected": "Yhdistetty OneDriveen",
       "description": "Kirjaudu sisään Microsoft-tililläsi synkronoidaksesi tiedot OneDriveen."
+    },
+    "icloud": {
+      "connect": "Yhdistä iCloud",
+      "connecting": "Yhdistetään...",
+      "connected": "Yhdistetty iCloudiin",
+      "description": "Kirjaudu sisään Apple ID:lläsi synkronoidaksesi tiedot iCloudiin."
     },
     "disconnect": {
       "button": "Katkaise yhteys",

--- a/src/features/cloudSync/__mocks__/services/cloudStorageProvider.ts
+++ b/src/features/cloudSync/__mocks__/services/cloudStorageProvider.ts
@@ -5,6 +5,7 @@
 import type { CloudProvider, CloudStorageProvider } from '../../types';
 import { GoogleDriveService } from './googleDrive';
 import { OneDriveService } from './oneDrive';
+import { ICloudService } from './iCloud';
 
 const providerRegistry: Map<CloudProvider, () => CloudStorageProvider> =
   new Map();
@@ -37,6 +38,7 @@ export function isProviderAvailable(providerId: CloudProvider): boolean {
 export function initializeProviders(): void {
   registerProvider('google-drive', () => new GoogleDriveService());
   registerProvider('onedrive', () => new OneDriveService());
+  registerProvider('icloud', () => new ICloudService());
 }
 
 export function resetProviders(): void {

--- a/src/features/cloudSync/__mocks__/services/iCloud.ts
+++ b/src/features/cloudSync/__mocks__/services/iCloud.ts
@@ -1,0 +1,41 @@
+/**
+ * Mock iCloud service for tests.
+ */
+
+import type { CloudStorageProvider, CloudFileMetadata } from '../../types';
+
+export class ICloudService implements CloudStorageProvider {
+  readonly providerId = 'icloud' as const;
+
+  async connect(): Promise<void> {
+    // No-op for mock
+  }
+
+  async disconnect(): Promise<void> {
+    // No-op for mock
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+
+  async getAccessToken(): Promise<string | null> {
+    return null;
+  }
+
+  async upload(_data: string, _existingFileId?: string): Promise<string> {
+    return 'mock-icloud-record-name';
+  }
+
+  async download(_fileId: string): Promise<string> {
+    return '{}';
+  }
+
+  async getFileMetadata(_fileId: string): Promise<CloudFileMetadata | null> {
+    return null;
+  }
+
+  async findSyncFile(): Promise<string | null> {
+    return null;
+  }
+}

--- a/src/features/cloudSync/__mocks__/services/index.ts
+++ b/src/features/cloudSync/__mocks__/services/index.ts
@@ -1,5 +1,6 @@
 export { GoogleDriveService } from './googleDrive';
 export { OneDriveService } from './oneDrive';
+export { ICloudService } from './iCloud';
 export {
   storeTokens,
   getStoredTokens,

--- a/src/features/cloudSync/components/CloudSyncSection.test.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.test.tsx
@@ -29,6 +29,10 @@ vi.mock('./ConnectOneDrive', () => ({
   ConnectOneDrive: () => <div data-testid="connect-onedrive">Connect</div>,
 }));
 
+vi.mock('./ConnectICloud', () => ({
+  ConnectICloud: () => <div data-testid="connect-icloud">Connect</div>,
+}));
+
 const defaultState: CloudSyncState = {
   provider: null,
   lastSyncTimestamp: null,
@@ -85,6 +89,12 @@ describe('CloudSyncSection', () => {
       renderWithContext(createMockContext({ state: 'disconnected' }));
 
       expect(screen.getByTestId('connect-onedrive')).toBeInTheDocument();
+    });
+
+    it('should show ConnectICloud component', () => {
+      renderWithContext(createMockContext({ state: 'disconnected' }));
+
+      expect(screen.getByTestId('connect-icloud')).toBeInTheDocument();
     });
 
     it('should render both providers in a chooser group', () => {
@@ -160,6 +170,19 @@ describe('CloudSyncSection', () => {
       expect(
         screen.queryByTestId('connect-google-drive'),
       ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('connect-icloud')).not.toBeInTheDocument();
+    });
+
+    it('should render iCloud disconnect when provider is icloud', () => {
+      renderWithContext(
+        createMockContext({ state: 'connected', provider: 'icloud' }),
+      );
+
+      expect(screen.getByTestId('connect-icloud')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('connect-google-drive'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('connect-onedrive')).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/cloudSync/components/CloudSyncSection.tsx
+++ b/src/features/cloudSync/components/CloudSyncSection.tsx
@@ -3,6 +3,7 @@ import { CloudSyncStatus } from './CloudSyncStatus';
 import { CloudSyncButton } from './CloudSyncButton';
 import { ConnectGoogleDrive } from './ConnectGoogleDrive';
 import { ConnectOneDrive } from './ConnectOneDrive';
+import { ConnectICloud } from './ConnectICloud';
 import { useCloudSync } from '../hooks';
 import styles from './CloudSyncSection.module.css';
 
@@ -25,6 +26,7 @@ export function CloudSyncSection() {
 
   const renderActiveProviderControls = () => {
     if (state.provider === 'onedrive') return <ConnectOneDrive />;
+    if (state.provider === 'icloud') return <ConnectICloud />;
     return <ConnectGoogleDrive />;
   };
 
@@ -50,6 +52,7 @@ export function CloudSyncSection() {
             >
               <ConnectGoogleDrive />
               <ConnectOneDrive />
+              <ConnectICloud />
             </div>
           )}
         </div>

--- a/src/features/cloudSync/components/ConnectICloud.module.css
+++ b/src/features/cloudSync/components/ConnectICloud.module.css
@@ -1,0 +1,36 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.iCloudButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.connectedInfo {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
+}
+
+.providerIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.connectedText {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}

--- a/src/features/cloudSync/components/ConnectICloud.tsx
+++ b/src/features/cloudSync/components/ConnectICloud.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/shared/components/Button';
+import { useCloudSync } from '../hooks';
+import styles from './ConnectICloud.module.css';
+
+/**
+ * Component to connect/disconnect from Apple iCloud.
+ * Mirrors ConnectGoogleDrive / ConnectOneDrive — shows the connect button
+ * when disconnected, the disconnect option when connected.
+ */
+export function ConnectICloud() {
+  const { t } = useTranslation();
+  const { state, connect, disconnect } = useCloudSync();
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const isConnected =
+    state.provider === 'icloud' &&
+    (state.state === 'connected' ||
+      state.state === 'syncing' ||
+      state.state === 'error');
+
+  const handleConnect = async () => {
+    setIsConnecting(true);
+    try {
+      await connect('icloud');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    const confirmed = globalThis.confirm(t('cloudSync.disconnect.confirm'));
+    if (!confirmed) return;
+
+    setIsDisconnecting(true);
+    try {
+      await disconnect();
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  if (isConnected) {
+    return (
+      <div className={styles.container} data-testid="connect-icloud">
+        <div className={styles.connectedInfo}>
+          <span className={styles.providerIcon}>
+            <ICloudIcon />
+          </span>
+          <span className={styles.connectedText}>
+            {t('cloudSync.icloud.connected')}
+          </span>
+        </div>
+        <Button
+          variant="secondary"
+          onClick={handleDisconnect}
+          disabled={isDisconnecting || state.state === 'syncing'}
+          data-testid="cloud-sync-disconnect-button"
+        >
+          {isDisconnecting
+            ? t('cloudSync.disconnect.disconnecting')
+            : t('cloudSync.disconnect.button')}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container} data-testid="connect-icloud">
+      <Button
+        variant="secondary"
+        onClick={handleConnect}
+        disabled={isConnecting}
+        className={styles.iCloudButton}
+        data-testid="cloud-sync-connect-icloud-button"
+      >
+        <ICloudIcon />
+        <span>
+          {isConnecting
+            ? t('cloudSync.icloud.connecting')
+            : t('cloudSync.icloud.connect')}
+        </span>
+      </Button>
+      <p className={styles.description}>{t('cloudSync.icloud.description')}</p>
+    </div>
+  );
+}
+
+/**
+ * iCloud icon SVG (cloud emblem in iCloud blue).
+ */
+function ICloudIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M17.5 18H6.5C4 18 2 16 2 13.5C2 11.2 3.7 9.3 6 9C6.5 6.2 9 4 12 4C14.7 4 17 5.8 17.7 8.3C20 8.6 22 10.6 22 13C22 15.8 19.8 18 17.5 18Z"
+        fill="#3693F3"
+      />
+    </svg>
+  );
+}

--- a/src/features/cloudSync/components/index.ts
+++ b/src/features/cloudSync/components/index.ts
@@ -3,3 +3,4 @@ export { CloudSyncStatus } from './CloudSyncStatus';
 export { CloudSyncButton } from './CloudSyncButton';
 export { ConnectGoogleDrive } from './ConnectGoogleDrive';
 export { ConnectOneDrive } from './ConnectOneDrive';
+export { ConnectICloud } from './ConnectICloud';

--- a/src/features/cloudSync/services/cloudStorageProvider.ts
+++ b/src/features/cloudSync/services/cloudStorageProvider.ts
@@ -7,6 +7,7 @@
 import type { CloudProvider, CloudStorageProvider } from '../types';
 import { GoogleDriveService } from './googleDrive';
 import { OneDriveService } from './oneDrive';
+import { ICloudService } from './iCloud';
 
 // Registry of available providers
 const providerRegistry: Map<CloudProvider, () => CloudStorageProvider> =
@@ -55,6 +56,7 @@ export function isProviderAvailable(providerId: CloudProvider): boolean {
 // Singleton instances per provider
 let googleDriveInstance: GoogleDriveService | null = null;
 let oneDriveInstance: OneDriveService | null = null;
+let iCloudInstance: ICloudService | null = null;
 
 /**
  * Initialize the provider registry with available providers.
@@ -71,7 +73,12 @@ export function initializeProviders(): void {
     return oneDriveInstance;
   });
 
-  // Future: Register Dropbox, iCloud, etc.
+  registerProvider('icloud', () => {
+    iCloudInstance ??= new ICloudService();
+    return iCloudInstance;
+  });
+
+  // Future: Register Dropbox, etc.
 }
 
 /**
@@ -80,5 +87,6 @@ export function initializeProviders(): void {
 export function resetProviders(): void {
   googleDriveInstance = null;
   oneDriveInstance = null;
+  iCloudInstance = null;
   providerRegistry.clear();
 }

--- a/src/features/cloudSync/services/iCloud.test.ts
+++ b/src/features/cloudSync/services/iCloud.test.ts
@@ -1,0 +1,342 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for ICloudService.
+ *
+ * We bypass the CloudKit JS dynamic-script load by injecting a fake
+ * `globalThis.CloudKit` before each test. tokenStorage is mocked the same
+ * way as the other providers' tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { CloudSyncError } from '../types';
+import * as tokenStorage from './tokenStorage';
+
+vi.mock('./tokenStorage', () => ({
+  storeTokens: vi.fn(),
+  getTokensForProvider: vi.fn(),
+  clearTokens: vi.fn(),
+  areTokensExpired: vi.fn(),
+}));
+
+vi.stubEnv('VITE_ICLOUD_CONTAINER_ID', 'iCloud.test.container');
+vi.stubEnv('VITE_ICLOUD_API_TOKEN', 'test-api-token');
+vi.stubEnv('VITE_ICLOUD_ENVIRONMENT', 'development');
+
+import { ICloudService } from './iCloud';
+
+interface FakeContainer {
+  privateCloudDatabase: {
+    fetchRecords: Mock;
+    saveRecords: Mock;
+    performQuery: Mock;
+  };
+  fetchUserIdentity: Mock;
+  setUpAuth: Mock;
+}
+
+function installFakeCloudKit(): {
+  container: FakeContainer;
+  configure: Mock;
+  signIn: Mock;
+  signOut: Mock;
+} {
+  const container: FakeContainer = {
+    privateCloudDatabase: {
+      fetchRecords: vi.fn(),
+      saveRecords: vi.fn(),
+      performQuery: vi.fn(),
+    },
+    fetchUserIdentity: vi.fn(),
+    setUpAuth: vi.fn(),
+  };
+
+  const configure = vi.fn();
+  const signIn = vi.fn();
+  const signOut = vi.fn();
+
+  (
+    globalThis as typeof globalThis & {
+      CloudKit?: unknown;
+    }
+  ).CloudKit = {
+    configure,
+    getDefaultContainer: () => container,
+    auth: { signIn, signOut },
+  } as unknown as typeof globalThis.CloudKit;
+
+  return { container, configure, signIn, signOut };
+}
+
+describe('ICloudService', () => {
+  let service: ICloudService;
+  let fake: ReturnType<typeof installFakeCloudKit>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fake = installFakeCloudKit();
+
+    (tokenStorage.getTokensForProvider as Mock).mockReturnValue({
+      accessToken: 'user-record-name-123',
+      refreshToken: null,
+      expiresAt: Date.now() + 365 * 24 * 60 * 60 * 1000,
+      provider: 'icloud',
+    });
+    (tokenStorage.areTokensExpired as Mock).mockReturnValue(false);
+
+    service = new ICloudService();
+  });
+
+  afterEach(() => {
+    delete (globalThis as typeof globalThis & { CloudKit?: unknown }).CloudKit;
+  });
+
+  describe('connect', () => {
+    it('returns immediately when already connected with valid tokens', async () => {
+      await service.connect();
+      expect(fake.configure).not.toHaveBeenCalled();
+    });
+
+    it('configures CloudKit and persists identity from setUpAuth', async () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      fake.container.setUpAuth.mockResolvedValue({
+        userRecordName: 'user-abc',
+      });
+
+      await service.connect();
+
+      expect(fake.configure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          containers: expect.arrayContaining([
+            expect.objectContaining({
+              containerIdentifier: 'iCloud.test.container',
+            }),
+          ]),
+        }),
+      );
+      expect(tokenStorage.storeTokens).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: 'user-abc',
+          provider: 'icloud',
+        }),
+      );
+    });
+
+    it('falls back to auth.signIn when setUpAuth returns null', async () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      fake.container.setUpAuth.mockResolvedValue(null);
+      fake.signIn.mockResolvedValue({ userRecordName: 'user-xyz' });
+
+      await service.connect();
+
+      expect(fake.signIn).toHaveBeenCalled();
+      expect(tokenStorage.storeTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: 'user-xyz' }),
+      );
+    });
+
+    it('throws AUTH_FAILED when env vars are missing', async () => {
+      vi.stubEnv('VITE_ICLOUD_CONTAINER_ID', '');
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      const freshService = new ICloudService();
+
+      await expect(freshService.connect()).rejects.toBeInstanceOf(
+        CloudSyncError,
+      );
+
+      vi.stubEnv('VITE_ICLOUD_CONTAINER_ID', 'iCloud.test.container');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('calls auth.signOut and clears tokens', async () => {
+      fake.signOut.mockResolvedValue(undefined);
+      await service.disconnect();
+      expect(fake.signOut).toHaveBeenCalled();
+      expect(tokenStorage.clearTokens).toHaveBeenCalled();
+    });
+
+    it('still clears tokens when signOut fails', async () => {
+      fake.signOut.mockRejectedValue(new Error('signout fail'));
+      await service.disconnect();
+      expect(tokenStorage.clearTokens).toHaveBeenCalled();
+    });
+  });
+
+  describe('isConnected', () => {
+    it('returns true when token present and not expired', () => {
+      expect(service.isConnected()).toBe(true);
+    });
+
+    it('returns false when tokens are expired', () => {
+      (tokenStorage.areTokensExpired as Mock).mockReturnValue(true);
+      expect(service.isConnected()).toBe(false);
+    });
+
+    it('returns false when no tokens stored', () => {
+      (tokenStorage.getTokensForProvider as Mock).mockReturnValue(null);
+      expect(service.isConnected()).toBe(false);
+    });
+  });
+
+  describe('findSyncFile', () => {
+    it('returns recordName when sync record exists', async () => {
+      fake.container.privateCloudDatabase.fetchRecords.mockResolvedValue({
+        records: [
+          {
+            recordName: 'sync-data',
+            recordType: 'EmergencySupplyData',
+            fields: { data: { value: '{}' } },
+          },
+        ],
+      });
+
+      const id = await service.findSyncFile();
+      expect(id).toBe('sync-data');
+    });
+
+    it('returns null when no record exists', async () => {
+      fake.container.privateCloudDatabase.fetchRecords.mockResolvedValue({
+        records: [],
+      });
+
+      const id = await service.findSyncFile();
+      expect(id).toBeNull();
+    });
+
+    it('returns null when CloudKit reports RECORD_NOT_FOUND', async () => {
+      const err = Object.assign(new Error('not found'), {
+        ckErrorCode: 'RECORD_NOT_FOUND',
+      });
+      fake.container.privateCloudDatabase.fetchRecords.mockRejectedValue(err);
+
+      const id = await service.findSyncFile();
+      expect(id).toBeNull();
+    });
+  });
+
+  describe('upload', () => {
+    it('saves record with data field and returns the recordName', async () => {
+      fake.container.privateCloudDatabase.saveRecords.mockResolvedValue({
+        records: [
+          {
+            recordName: 'sync-data',
+            recordType: 'EmergencySupplyData',
+            fields: { data: { value: '{"x":1}' } },
+            recordChangeTag: 'tag-1',
+          },
+        ],
+      });
+
+      const id = await service.upload('{"x":1}');
+
+      expect(id).toBe('sync-data');
+      const [records] =
+        fake.container.privateCloudDatabase.saveRecords.mock.calls[0];
+      expect(records[0]).toMatchObject({
+        recordName: 'sync-data',
+        recordType: 'EmergencySupplyData',
+        fields: { data: { value: '{"x":1}' } },
+      });
+    });
+
+    it('maps AUTHENTICATION_REQUIRED to TOKEN_EXPIRED', async () => {
+      const err = Object.assign(new Error('auth req'), {
+        ckErrorCode: 'AUTHENTICATION_REQUIRED',
+      });
+      fake.container.privateCloudDatabase.saveRecords.mockRejectedValue(err);
+
+      await expect(service.upload('{}')).rejects.toMatchObject({
+        code: 'TOKEN_EXPIRED',
+      });
+    });
+
+    it('maps QUOTA_EXCEEDED', async () => {
+      const err = Object.assign(new Error('quota'), {
+        ckErrorCode: 'QUOTA_EXCEEDED',
+      });
+      fake.container.privateCloudDatabase.saveRecords.mockRejectedValue(err);
+
+      await expect(service.upload('{}')).rejects.toMatchObject({
+        code: 'QUOTA_EXCEEDED',
+      });
+    });
+  });
+
+  describe('download', () => {
+    it('returns the data field from the fetched record', async () => {
+      fake.container.privateCloudDatabase.fetchRecords.mockResolvedValue({
+        records: [
+          {
+            recordName: 'sync-data',
+            recordType: 'EmergencySupplyData',
+            fields: { data: { value: '{"hello":"world"}' } },
+          },
+        ],
+      });
+
+      const content = await service.download('sync-data');
+      expect(content).toBe('{"hello":"world"}');
+    });
+
+    it('throws FILE_NOT_FOUND when record is missing', async () => {
+      fake.container.privateCloudDatabase.fetchRecords.mockResolvedValue({
+        records: [],
+      });
+
+      await expect(service.download('sync-data')).rejects.toMatchObject({
+        code: 'FILE_NOT_FOUND',
+      });
+    });
+
+    it('throws PARSE_ERROR when data field has wrong type', async () => {
+      fake.container.privateCloudDatabase.fetchRecords.mockResolvedValue({
+        records: [
+          {
+            recordName: 'sync-data',
+            recordType: 'EmergencySupplyData',
+            fields: { data: { value: 42 } },
+          },
+        ],
+      });
+
+      await expect(service.download('sync-data')).rejects.toMatchObject({
+        code: 'PARSE_ERROR',
+      });
+    });
+  });
+
+  describe('getFileMetadata', () => {
+    it('returns metadata mapped from CloudKit record', async () => {
+      const ts = Date.UTC(2026, 4, 5, 10, 0, 0);
+      fake.container.privateCloudDatabase.fetchRecords.mockResolvedValue({
+        records: [
+          {
+            recordName: 'sync-data',
+            recordType: 'EmergencySupplyData',
+            modified: { timestamp: ts },
+            fields: { data: { value: '{"x":1}' } },
+          },
+        ],
+      });
+
+      const meta = await service.getFileMetadata('sync-data');
+      expect(meta).toEqual({
+        id: 'sync-data',
+        name: 'sync-data',
+        modifiedTime: new Date(ts).toISOString(),
+        size: 7,
+      });
+    });
+
+    it('returns null when record not found', async () => {
+      fake.container.privateCloudDatabase.fetchRecords.mockResolvedValue({
+        records: [],
+      });
+
+      const meta = await service.getFileMetadata('sync-data');
+      expect(meta).toBeNull();
+    });
+  });
+});

--- a/src/features/cloudSync/services/iCloud.ts
+++ b/src/features/cloudSync/services/iCloud.ts
@@ -1,0 +1,430 @@
+/**
+ * iCloud cloud storage provider implementation.
+ *
+ * Uses Apple's CloudKit JS SDK (loaded dynamically from Apple's CDN) to read
+ * and write a single record in the user's *private* CloudKit database.
+ *
+ * Why a record, not a Drive file?
+ *   CloudKit's data model is record-based, not file-based. We model the sync
+ *   payload as one record of type `EmergencySupplyData` with:
+ *     - recordName  : a fixed name `"sync-data"` so the record is unique.
+ *     - data        : a String field holding the serialized JSON payload.
+ *     - modified    : auto-managed by CloudKit (`record.modified.timestamp`).
+ *   The same shape (id / modifiedTime / size) is exposed via
+ *   {@link CloudFileMetadata} so the rest of the cloudSync layer treats this
+ *   provider identically to Google Drive and OneDrive.
+ */
+
+import type {
+  CloudStorageProvider,
+  CloudFileMetadata,
+  StoredTokens,
+} from '../types';
+import { CloudSyncError } from '../types';
+import {
+  storeTokens,
+  getTokensForProvider,
+  clearTokens,
+  areTokensExpired,
+} from './tokenStorage';
+
+// CloudKit JS is loaded from Apple's CDN at runtime.
+const CLOUDKIT_JS_URL = 'https://cdn.apple-cloudkit.com/ck/2/cloudkit.js';
+
+// Static record name for the single sync record per user.
+const SYNC_RECORD_NAME = 'sync-data';
+const SYNC_RECORD_TYPE = 'EmergencySupplyData';
+
+// CloudKit web auth tokens are valid for ~1 year by default. We track expiry
+// only so the rest of the layer can treat tokens uniformly; CloudKit itself
+// re-validates on every API call.
+const DEFAULT_TOKEN_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+
+// CloudKit JS minimal type surface. The real SDK exposes far more, but we
+// only need these symbols. Declared as `unknown` shapes wrapped in helpers
+// so the rest of the file stays type-safe without depending on @types
+// declarations that Apple does not publish.
+
+interface CKRecordField {
+  value: string | number | boolean | null;
+}
+
+interface CKRecord {
+  recordName: string;
+  recordType: string;
+  recordChangeTag?: string;
+  modified?: { timestamp: number };
+  fields: Record<string, CKRecordField>;
+}
+
+interface CKQueryResponse {
+  records: CKRecord[];
+}
+
+interface CKDatabase {
+  fetchRecords(recordNames: string[]): Promise<{ records: CKRecord[] }>;
+  saveRecords(records: CKRecord[]): Promise<{ records: CKRecord[] }>;
+  performQuery(query: { recordType: string }): Promise<CKQueryResponse>;
+}
+
+interface CKUserIdentity {
+  userRecordName: string;
+}
+
+interface CKAuth {
+  signIn?: () => Promise<CKUserIdentity>;
+  signOut?: () => Promise<void>;
+}
+
+interface CKContainer {
+  privateCloudDatabase: CKDatabase;
+  fetchUserIdentity(): Promise<CKUserIdentity | null>;
+  setUpAuth(): Promise<CKUserIdentity | null>;
+}
+
+interface CKConfig {
+  containers: Array<{
+    containerIdentifier: string;
+    apiTokenAuth: { apiToken: string; persist?: boolean };
+    environment: 'development' | 'production';
+  }>;
+}
+
+interface CKApi {
+  configure(config: CKConfig): void;
+  getDefaultContainer(): CKContainer;
+}
+
+declare global {
+  var CloudKit: CKApi | undefined;
+}
+
+let cloudKitScriptPromise: Promise<void> | null = null;
+
+/**
+ * Load CloudKit JS once (idempotent across calls).
+ */
+function loadCloudKitJs(): Promise<void> {
+  if (globalThis.CloudKit) return Promise.resolve();
+  if (cloudKitScriptPromise) return cloudKitScriptPromise;
+
+  cloudKitScriptPromise = new Promise<void>((resolve, reject) => {
+    const script = globalThis.document?.createElement('script');
+    if (!script) {
+      reject(
+        new CloudSyncError(
+          'CloudKit JS requires a browser environment',
+          'AUTH_FAILED',
+          false,
+        ),
+      );
+      return;
+    }
+    script.src = CLOUDKIT_JS_URL;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      cloudKitScriptPromise = null;
+      reject(
+        new CloudSyncError(
+          'Failed to load CloudKit JS. Check your internet connection.',
+          'NETWORK_ERROR',
+          true,
+        ),
+      );
+    };
+    globalThis.document!.head.appendChild(script);
+  });
+
+  return cloudKitScriptPromise;
+}
+
+/**
+ * iCloud (CloudKit) implementation of CloudStorageProvider.
+ */
+export class ICloudService implements CloudStorageProvider {
+  readonly providerId = 'icloud' as const;
+
+  private container: CKContainer | null = null;
+
+  /**
+   * Initialise CloudKit JS (load script + configure container).
+   * Throws when env vars are missing so the UI surfaces the misconfiguration.
+   */
+  private async getContainer(): Promise<CKContainer> {
+    const containerId = import.meta.env.VITE_ICLOUD_CONTAINER_ID;
+    const apiToken = import.meta.env.VITE_ICLOUD_API_TOKEN;
+    const environment =
+      (import.meta.env.VITE_ICLOUD_ENVIRONMENT as
+        | 'development'
+        | 'production'
+        | undefined) ?? 'production';
+
+    if (!containerId || !apiToken) {
+      throw new CloudSyncError(
+        'iCloud is not configured. Set VITE_ICLOUD_CONTAINER_ID and VITE_ICLOUD_API_TOKEN.',
+        'AUTH_FAILED',
+        false,
+      );
+    }
+
+    if (this.container) return this.container;
+
+    await loadCloudKitJs();
+
+    if (!globalThis.CloudKit) {
+      throw new CloudSyncError(
+        'CloudKit JS unavailable after script load',
+        'AUTH_FAILED',
+        true,
+      );
+    }
+
+    globalThis.CloudKit.configure({
+      containers: [
+        {
+          containerIdentifier: containerId,
+          apiTokenAuth: { apiToken, persist: true },
+          environment,
+        },
+      ],
+    });
+
+    this.container = globalThis.CloudKit.getDefaultContainer();
+    return this.container;
+  }
+
+  /**
+   * Persist the CloudKit user identity as our shared "token" so the rest of
+   * the cloudSync layer can read it uniformly. The real auth state lives in
+   * CloudKit's own session cookies; we store the user record name as a
+   * marker that we are connected.
+   */
+  private persistIdentity(identity: CKUserIdentity): void {
+    const tokens: StoredTokens = {
+      // CloudKit doesn't expose its session token to JS; use the user's
+      // record name as a stable marker that we have an authenticated session.
+      accessToken: identity.userRecordName,
+      refreshToken: null,
+      expiresAt: Date.now() + DEFAULT_TOKEN_TTL_MS,
+      provider: 'icloud',
+    };
+    storeTokens(tokens);
+  }
+
+  /**
+   * Connect to iCloud — opens Apple's Sign in with Apple flow.
+   */
+  async connect(): Promise<void> {
+    if (this.isConnected() && !areTokensExpired()) {
+      return;
+    }
+
+    try {
+      const container = await this.getContainer();
+      // setUpAuth resolves with the existing identity if already signed in,
+      // or null if the user needs to click the SIWA button injected by
+      // CloudKit JS. For programmatic connect, we then call signIn()
+      // when available to trigger the flow.
+      let identity = await container.setUpAuth();
+      if (!identity) {
+        // Some CloudKit JS versions expose `auth.signIn`; fall through to
+        // poll setUpAuth if not.
+        const ck = globalThis.CloudKit as CKApi & { auth?: CKAuth };
+        if (ck.auth?.signIn) {
+          identity = await ck.auth.signIn();
+        } else {
+          throw new CloudSyncError(
+            'iCloud sign-in requires user interaction. Click the Sign in with Apple button.',
+            'AUTH_FAILED',
+            false,
+          );
+        }
+      }
+      this.persistIdentity(identity);
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        error instanceof Error ? error.message : 'iCloud authentication failed',
+        'AUTH_FAILED',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Disconnect from iCloud.
+   */
+  async disconnect(): Promise<void> {
+    try {
+      const ck = globalThis.CloudKit as (CKApi & { auth?: CKAuth }) | undefined;
+      if (ck?.auth?.signOut) {
+        await ck.auth.signOut();
+      }
+    } catch {
+      // Ignore — we still clear local tokens below.
+    }
+
+    clearTokens();
+    this.container = null;
+  }
+
+  /**
+   * Check if connected with valid tokens.
+   */
+  isConnected(): boolean {
+    const tokens = getTokensForProvider('icloud');
+    return tokens !== null && !areTokensExpired();
+  }
+
+  /**
+   * CloudKit doesn't issue access tokens consumable from JS — auth is via
+   * session cookies inside the CloudKit JS instance. We expose the cached
+   * userRecordName so callers can detect "connected" status uniformly.
+   */
+  async getAccessToken(): Promise<string | null> {
+    const tokens = getTokensForProvider('icloud');
+    return tokens?.accessToken ?? null;
+  }
+
+  /**
+   * Find existing sync record. Returns the recordName as the file ID.
+   */
+  async findSyncFile(): Promise<string | null> {
+    try {
+      const container = await this.getContainer();
+      const result = await container.privateCloudDatabase.fetchRecords([
+        SYNC_RECORD_NAME,
+      ]);
+      const record = result.records[0];
+      if (!record) return null;
+      return record.recordName;
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      // CloudKit returns a "record not found" error when the record doesn't
+      // exist yet — treat as "not found" rather than an error.
+      const code = (error as { ckErrorCode?: string }).ckErrorCode;
+      if (code === 'RECORD_NOT_FOUND' || code === 'NOT_FOUND') return null;
+      throw new CloudSyncError(
+        'Failed to query iCloud for sync record',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Upload data by saving the record (creates or updates).
+   * Always uses the fixed `SYNC_RECORD_NAME`; the `existingFileId` argument
+   * is accepted for interface compatibility but not used.
+   */
+  async upload(data: string, _existingFileId?: string): Promise<string> {
+    try {
+      const container = await this.getContainer();
+      const record: CKRecord = {
+        recordName: SYNC_RECORD_NAME,
+        recordType: SYNC_RECORD_TYPE,
+        fields: {
+          data: { value: data },
+        },
+      };
+      const result = await container.privateCloudDatabase.saveRecords([record]);
+      const saved = result.records[0];
+      return saved?.recordName ?? SYNC_RECORD_NAME;
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      const code = (error as { ckErrorCode?: string }).ckErrorCode;
+      if (
+        code === 'AUTHENTICATION_REQUIRED' ||
+        code === 'AUTHENTICATION_FAILED'
+      ) {
+        throw new CloudSyncError(
+          'iCloud authentication expired',
+          'TOKEN_EXPIRED',
+          true,
+        );
+      }
+      if (code === 'QUOTA_EXCEEDED') {
+        throw new CloudSyncError(
+          'iCloud storage quota exceeded',
+          'QUOTA_EXCEEDED',
+          false,
+        );
+      }
+      throw new CloudSyncError(
+        'Failed to save sync record to iCloud',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Download record content.
+   */
+  async download(_fileId: string): Promise<string> {
+    try {
+      const container = await this.getContainer();
+      const result = await container.privateCloudDatabase.fetchRecords([
+        SYNC_RECORD_NAME,
+      ]);
+      const record = result.records[0];
+      if (!record) {
+        throw new CloudSyncError(
+          'Sync record not found in iCloud',
+          'FILE_NOT_FOUND',
+          false,
+        );
+      }
+      const value = record.fields.data?.value;
+      if (typeof value !== 'string') {
+        throw new CloudSyncError(
+          'iCloud sync record is malformed',
+          'PARSE_ERROR',
+          false,
+        );
+      }
+      return value;
+    } catch (error) {
+      if (error instanceof CloudSyncError) throw error;
+      throw new CloudSyncError(
+        'Failed to download data from iCloud',
+        'NETWORK_ERROR',
+        true,
+      );
+    }
+  }
+
+  /**
+   * Get record metadata.
+   */
+  async getFileMetadata(_fileId: string): Promise<CloudFileMetadata | null> {
+    try {
+      const container = await this.getContainer();
+      const result = await container.privateCloudDatabase.fetchRecords([
+        SYNC_RECORD_NAME,
+      ]);
+      const record = result.records[0];
+      if (!record) return null;
+
+      const dataValue = record.fields.data?.value;
+      const size = typeof dataValue === 'string' ? dataValue.length : undefined;
+
+      return {
+        id: record.recordName,
+        name: SYNC_RECORD_NAME,
+        modifiedTime: record.modified?.timestamp
+          ? new Date(record.modified.timestamp).toISOString()
+          : new Date().toISOString(),
+        size,
+      };
+    } catch (error) {
+      if (error instanceof CloudSyncError && error.code === 'FILE_NOT_FOUND') {
+        return null;
+      }
+      const code = (error as { ckErrorCode?: string }).ckErrorCode;
+      if (code === 'RECORD_NOT_FOUND' || code === 'NOT_FOUND') return null;
+      throw error;
+    }
+  }
+}

--- a/src/features/cloudSync/services/index.ts
+++ b/src/features/cloudSync/services/index.ts
@@ -1,5 +1,6 @@
 export { GoogleDriveService } from './googleDrive';
 export { OneDriveService } from './oneDrive';
+export { ICloudService } from './iCloud';
 export {
   storeTokens,
   getStoredTokens,

--- a/src/features/cloudSync/types.test.ts
+++ b/src/features/cloudSync/types.test.ts
@@ -34,6 +34,7 @@ describe('isCloudProvider', () => {
   it('should return true for valid providers', () => {
     expect(isCloudProvider('google-drive')).toBe(true);
     expect(isCloudProvider('onedrive')).toBe(true);
+    expect(isCloudProvider('icloud')).toBe(true);
   });
 
   it('should return false for invalid provider', () => {

--- a/src/features/cloudSync/types.ts
+++ b/src/features/cloudSync/types.ts
@@ -4,7 +4,7 @@
  */
 
 // Supported cloud storage providers
-export type CloudProvider = 'google-drive' | 'onedrive';
+export type CloudProvider = 'google-drive' | 'onedrive' | 'icloud';
 
 // Sync state machine states
 export type SyncState = 'disconnected' | 'connected' | 'syncing' | 'error';
@@ -123,7 +123,7 @@ export class CloudSyncError extends Error {
 // Type guards
 
 export function isCloudProvider(value: unknown): value is CloudProvider {
-  return value === 'google-drive' || value === 'onedrive';
+  return value === 'google-drive' || value === 'onedrive' || value === 'icloud';
 }
 
 export function isSyncState(value: unknown): value is SyncState {


### PR DESCRIPTION
## Summary

Adds **Apple iCloud** as a third cloud sync provider, stacked on top of OneDrive (#275). Uses CloudKit JS (loaded dynamically from Apple's CDN — no npm dep) and Sign in with Apple. Sync data lives as a single record (`recordType: EmergencySupplyData`, `recordName: sync-data`) in the user's *private* CloudKit database, so the app cannot read any other iCloud data.

- New `ICloudService` implementing `CloudStorageProvider` via CloudKit JS
- Provider chooser now shows Google Drive / OneDrive / iCloud
- New `ConnectICloud` component, EN/FI translations, design doc with Apple Developer + CloudKit Console setup, `VITE_ICLOUD_CONTAINER_ID` / `VITE_ICLOUD_API_TOKEN` / `VITE_ICLOUD_ENVIRONMENT` env vars

> [!NOTE]
> iCloud sync requires an active Apple Developer Program membership (\$99/year) to register a CloudKit container — see `docs/design-docs/015-icloud-sync.md`.

## Stacking

Targets `feat-onedrive-sync` (#275). Merge #110 → #275 → this in order. After #275 merges, this can re-target main.

## Test plan

- [ ] Tests: `npx vitest run src/features/cloudSync` — 214 tests pass locally including 20 new iCloud service tests and extended CloudSyncSection chooser tests
- [ ] `npm run type-check:all` — clean
- [ ] `npm run lint` — clean
- [ ] `npm run validate:i18n` — EN/FI keys present
- [ ] `npm run build` — production build succeeds
- [ ] Manual: create CloudKit container per design doc, fill `.env.local`, verify Sign in with Apple, upload, download, disconnect