### PR TITLE
ci: update workflows to Node 24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,10 +10,8 @@
       "installZsh": false,
       "upgradePackages": false
     },
-    // CI still runs Node 20 (to be updated separately). Dev container is
-    // pinned to 24 (current Node LTS) instead, since Claude Code requires
-    // engines.node >=22 and floating on "latest" would also track
-    // non-LTS/odd-numbered releases.
+    // Pinned to 24 (current Node LTS, matches CI) rather than "latest",
+    // which would also track non-LTS/odd-numbered releases.
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24"
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run type-check:all
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run test:coverage
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Install Playwright Browsers
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Install Playwright Browsers
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Install Playwright Browsers
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Run visual regression tests
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - name: Generate version
         run: echo "VITE_APP_VERSION=$(date +'%Y.%m.%d')-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Install Playwright Browsers

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci


### PR DESCRIPTION
## Summary
- Bump `node-version` from 20 to 24 (current Node LTS) across all GitHub Actions workflows
- Aligns CI with the dev container, which was already pinned to Node 24

## Changes
- `.github/workflows/ci.yml` — all 7 jobs (lint, type-check, test, storybook, e2e, a11y, build)
- `.github/workflows/deploy.yml` — build and smoke-test jobs
- `.github/workflows/deploy-pr-preview.yml`
- `.github/workflows/mutation-testing.yml`
- `.devcontainer/devcontainer.json` — updated a comment that referenced CI still running Node 20

## Test plan
- [x] All tests pass (`npm run test` — 3430 passed)
- [x] TypeScript type-check passes (`npm run type-check:all`)
- [x] Production build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime environment to Node.js 24, the current LTS release.
  * Updated automated testing, validation, preview, deployment, and smoke-test processes to use Node.js 24.
  * Clarified documentation around the pinned Node.js LTS version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->