### PR TITLE
chore: add CodeRabbit CLI to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -97,6 +97,10 @@
     // are allowed; force-pushes, pushes to main, and history rewrites are not.
     // main is branch-protected on GitHub as the backstop.
     "GH_EST_TOKEN": "${localEnv:GH_EST_TOKEN}",
+    // Lets post-create.sh authenticate the CodeRabbit CLI non-interactively.
+    // The CLI itself isn't part of the base image or a devcontainer feature,
+    // so post-create.sh installs it from the official install script.
+    "CODERABBIT_API_KEY": "${localEnv:CODERABBIT_API_KEY}",
     // Never hang waiting on an interactive credential prompt.
     "GIT_TERMINAL_PROMPT": "0",
     // Disable automatic gc for every git command in the container, without

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -25,6 +25,27 @@ if ! command -v gh >/dev/null 2>&1; then
   sudo apt-get update -qq && sudo apt-get install -y -qq gh
 fi
 
+echo "==> CodeRabbit CLI"
+# Not a devcontainer feature; the official installer drops the binary (and its
+# `cr` alias) into ~/.local/bin, which the base image already puts on PATH.
+if ! command -v coderabbit >/dev/null 2>&1; then
+  # CI=1 skips the installer's interactive "sign in now?" prompt (there's no
+  # TTY in a non-interactive postCreateCommand); auth is handled explicitly
+  # below instead, via the forwarded API key.
+  CI=1 curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+fi
+if [[ -n "${CODERABBIT_API_KEY:-}" ]]; then
+  if coderabbit auth login --api-key "$CODERABBIT_API_KEY" >/dev/null 2>&1; then
+    echo "    authenticated via CODERABBIT_API_KEY"
+  else
+    echo "FAIL: CODERABBIT_API_KEY is set but the CodeRabbit CLI rejected it." >&2
+    echo "      Generate a fresh key at https://app.coderabbit.ai and re-export it." >&2
+    exit 1
+  fi
+else
+  echo "    CODERABBIT_API_KEY not set: 'coderabbit review' will prompt to sign in"
+fi
+
 echo "==> Playwright browsers"
 # The base image ships browsers at $PLAYWRIGHT_BROWSERS_PATH (/ms-playwright).
 # It is a named volume, so make it writable in case a browser is added later.

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -32,7 +32,7 @@ if ! command -v coderabbit >/dev/null 2>&1; then
   # CI=1 skips the installer's interactive "sign in now?" prompt (there's no
   # TTY in a non-interactive postCreateCommand); auth is handled explicitly
   # below instead, via the forwarded API key.
-  CI=1 curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+  CI=1 curl --proto '=https' --tlsv1.2 -fsSL https://cli.coderabbit.ai/install.sh | sh
 fi
 if [[ -n "${CODERABBIT_API_KEY:-}" ]]; then
   if coderabbit auth login --api-key "$CODERABBIT_API_KEY" >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ container (`gh` keeps its own credentials in the OS keychain, which the containe
 ```bash
 export GH_EST_TOKEN=$(gh auth token)
 export CLAUDE_CODE_OAUTH_TOKEN=...   # optional: reuse your host Claude Code login
+export CODERABBIT_API_KEY=...        # optional: authenticate the CodeRabbit CLI (`coderabbit review`)
 ```
 
 `GH_EST_TOKEN` is named for this repo (Emergency Supply Tracker) rather than the generic
@@ -161,6 +162,14 @@ Scope it to only this repo, not a broad host credential. Prefer a fine-grained
 repository with **Contents: Read and write** (git push/fetch), **Issues: Read and write**, and
 **Pull requests: Read and write** (`gh issue create`, `gh pr create`/`edit`) — rather than `gh auth
 token`, which inherits your host `gh` login's full scope across every repo you can access.
+
+`CODERABBIT_API_KEY` authenticates the [CodeRabbit CLI](https://www.coderabbit.ai/cli) (`coderabbit
+review` / `cr review`) — this is separate from the `coderabbitai[bot]` GitHub reviewer `/pr-fix`
+already reads comments from, and isn't installed by any devcontainer feature. `post-create.sh`
+installs it from the official installer and, if the key is set, runs `coderabbit auth login
+--api-key` non-interactively — a browser-based `coderabbit auth login` won't work inside the
+container. Generate a key at [app.coderabbit.ai](https://app.coderabbit.ai) (Settings → API Keys).
+If unset, the CLI installs but stays signed out until you run `coderabbit auth login` yourself.
 
 Because the container is isolated and destructive git operations are blocked, you can also skip
 Claude Code's permission prompts by adding this to `.claude/settings.local.json` (gitignored, so it


### PR DESCRIPTION
## Summary
- Wires up the CodeRabbit CLI (`coderabbit`/`cr`, separate from the `coderabbitai[bot]` GitHub reviewer `/pr-fix` already uses) inside the dev container, following the same pattern already used for `GH_EST_TOKEN`/`CLAUDE_CODE_OAUTH_TOKEN`.

## Changes
- `.devcontainer/devcontainer.json`: forward `CODERABBIT_API_KEY` from the host env into the container.
- `.devcontainer/post-create.sh`: install the CLI via the official installer (idempotent) and, when the key is set, run `coderabbit auth login --api-key` non-interactively — browser-based `coderabbit auth login` doesn't work inside the container. Fails loudly if a key is set but rejected.
- `README.md`: document `CODERABBIT_API_KEY` alongside the existing forwarded tokens, with a pointer to generate a key at app.coderabbit.ai.

## Test plan
- [x] Verified the install script, idempotency check, and both the invalid-key and unset-key code paths directly in a running dev container
- [x] Pre-commit/pre-push hooks passed (format, type-check, lint, tests, build, i18n validation)