### PR TITLE
feat: add a static landing page for first-time visitors

### DIFF
--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -245,7 +245,11 @@ Sample recommendation files are available in `public/samples/`:
 A static marketing page at `/landing.html`, separate from the React app bundle.
 
 - Shown only to visitors with no `emergencySupplyTracker` localStorage key (i.e. they have never loaded the app before). Anyone with that key — including a visitor mid-onboarding who never finished — is redirected straight to `/`.
-- All CTAs ("Get started", "Open app") link to `/`, where the app decides between onboarding and the dashboard as usual.
+- It is also the site's front door: an inline gate at the top of `index.html` redirects `/` to `/landing.html` for those same first-time visitors. The decision reads `localStorage`, so it has to run in the browser — no hosting rewrite (Vercel or GitHub Pages) can make it. The two guards are mirror images and never both fire for one visitor.
+- All CTAs ("Get started", "Open app") link to `/?app=1`. The `app=1` bypass is required: a first-time visitor clicking through still has no storage key, so without it the root gate would bounce them back and the redirects would loop. The app then decides between onboarding and the dashboard as usual.
+- The root gate also stands down for an installed PWA (`display-mode: standalone`), so a launched app never opens the marketing page, and when `localStorage` is unavailable (privacy mode), where it falls through to the app.
+- `?lang=en` / `?lang=fi` on `/` is carried through to the landing page, so shared language-specific links keep working.
+- E2E specs starting from a clean profile use the `APP_URL` constant in `e2e/fixtures.ts` (`/?app=1`) rather than `/`, since a fresh Playwright profile looks exactly like a first-time visitor.
 - Fully translated (English/Finnish) via a small inline i18n dictionary; language priority matches the app (`?lang=` param → stored `settings.language` → `en`), plus a manual EN/FI toggle in the nav.
 - Linked from the in-app Help/Guide page's support section.
 

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -244,12 +244,12 @@ Sample recommendation files are available in `public/samples/`:
 
 A static marketing page at `/landing.html`, separate from the React app bundle.
 
-- Shown only to visitors with no `emergencySupplyTracker` localStorage key (i.e. they have never loaded the app before). Anyone with that key — including a visitor mid-onboarding who never finished — is redirected straight to `/`.
+- Shown only to visitors with no `emergencySupplyTracker` localStorage key (i.e. they have never loaded the app before). Anyone with that key — including a visitor mid-onboarding who never finished — is redirected straight to `/`. `?preview=1` bypasses this redirect, for links back to the pitch from inside the app itself (e.g. the Guide screen), where the visitor always has the key set.
 - It is also the site's front door: an inline gate at the top of `index.html` redirects `/` to `/landing.html` for those same first-time visitors. The decision reads `localStorage`, so it has to run in the browser — no hosting rewrite (Vercel or GitHub Pages) can make it. The two guards are mirror images and never both fire for one visitor.
 - All CTAs ("Get started", "Open app") link to `/?app=1`. The `app=1` bypass is required: a first-time visitor clicking through still has no storage key, so without it the root gate would bounce them back and the redirects would loop. The app then decides between onboarding and the dashboard as usual.
-- The root gate also stands down for an installed PWA (`display-mode: standalone`), so a launched app never opens the marketing page, and when `localStorage` is unavailable (privacy mode), where it falls through to the app.
+- The root gate also stands down for an installed PWA (`display-mode: standalone`, or `navigator.standalone` on iOS Safari, which doesn't always reflect standalone launches in `display-mode`), so a launched app never opens the marketing page, and when `localStorage` is unavailable (privacy mode), where it falls through to the app.
 - `?lang=en` / `?lang=fi` on `/` is carried through to the landing page, so shared language-specific links keep working.
-- E2E specs starting from a clean profile use the `APP_URL` constant in `e2e/fixtures.ts` (`/?app=1`) rather than `/`, since a fresh Playwright profile looks exactly like a first-time visitor.
+- E2E specs starting from a clean profile use the `APP_URL` constant in `e2e/fixtures.ts` (`/?app=1`) rather than `/`, since a fresh Playwright profile looks exactly like a first-time visitor. The smoke suites (`smoke-quick-setup.spec.ts`, `smoke-manual-entry.spec.ts`) use their own local `getBaseURL()` helper instead, which applies the same `?app=1` bypass on top of `PLAYWRIGHT_BASE_URL` so they can also run against a deployed site.
 - Fully translated (English/Finnish) via a small inline i18n dictionary; language priority matches the app (`?lang=` param → stored `settings.language` → `en`), plus a manual EN/FI toggle in the nav.
 - Linked from the in-app Help/Guide page's support section.
 

--- a/docs/FUNCTIONAL_SPEC.md
+++ b/docs/FUNCTIONAL_SPEC.md
@@ -240,6 +240,15 @@ Sample recommendation files are available in `public/samples/`:
 
 ### 5. User Workflows
 
+#### Landing Page
+
+A static marketing page at `/landing.html`, separate from the React app bundle.
+
+- Shown only to visitors with no `emergencySupplyTracker` localStorage key (i.e. they have never loaded the app before). Anyone with that key — including a visitor mid-onboarding who never finished — is redirected straight to `/`.
+- All CTAs ("Get started", "Open app") link to `/`, where the app decides between onboarding and the dashboard as usual.
+- Fully translated (English/Finnish) via a small inline i18n dictionary; language priority matches the app (`?lang=` param → stored `settings.language` → `en`), plus a manual EN/FI toggle in the nav.
+- Linked from the in-app Help/Guide page's support section.
+
 #### First-Time Onboarding (4 Steps)
 
 **Step 1: Welcome**

--- a/e2e/backup-reminder.spec.ts
+++ b/e2e/backup-reminder.spec.ts
@@ -4,6 +4,7 @@ import {
   setAppStorage,
   navigateToSettingsSection,
   toLocalDateString,
+  APP_URL,
 } from './fixtures';
 import {
   createMockAppData,
@@ -66,7 +67,7 @@ test.describe('Backup Reminder', () => {
       settings: v2Settings,
     });
 
-    await page.goto('/');
+    await page.goto(APP_URL);
     await setAppStorage(page, appData);
     await page.reload({ waitUntil: 'domcontentloaded' });
 
@@ -90,7 +91,7 @@ test.describe('Backup Reminder', () => {
       settings: v2Settings,
     });
 
-    await page.goto('/');
+    await page.goto(APP_URL);
     await setAppStorage(page, appData);
     await page.reload({ waitUntil: 'domcontentloaded' });
 
@@ -129,7 +130,7 @@ test.describe('Backup Reminder', () => {
       settings: v2Settings,
     });
 
-    await page.goto('/');
+    await page.goto(APP_URL);
     await setAppStorage(page, appData);
     await page.reload({ waitUntil: 'domcontentloaded' });
 
@@ -155,7 +156,7 @@ test.describe('Backup Reminder', () => {
       settings: v2Settings,
     });
 
-    await page.goto('/');
+    await page.goto(APP_URL);
     await setAppStorage(page, appData);
     await page.reload({ waitUntil: 'domcontentloaded' });
 
@@ -201,7 +202,7 @@ test.describe('Backup Reminder', () => {
       settings: v2Settings,
     });
 
-    await page.goto('/');
+    await page.goto(APP_URL);
     await setAppStorage(page, appData);
     await page.reload({ waitUntil: 'domcontentloaded' });
 

--- a/e2e/custom-categories.spec.ts
+++ b/e2e/custom-categories.spec.ts
@@ -3,6 +3,7 @@ import {
   expect,
   setAppStorage,
   navigateToSettingsSection,
+  APP_URL,
 } from './fixtures';
 import {
   createMockAppData,
@@ -36,7 +37,7 @@ async function seed(
     items?: ReturnType<typeof createMockInventoryItem>[];
   } = {},
 ) {
-  await page.goto('/');
+  await page.goto(APP_URL);
   await setAppStorage(
     page,
     createMockAppData({

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -11,6 +11,16 @@ import {
 } from '../src/shared/utils/storage/localStorage';
 import type { AppData } from '../src/shared/types';
 
+/**
+ * The app's own URL, with the root gate's bypass applied.
+ *
+ * `/` shows the static landing page to anyone with no stored data (see the
+ * gate script in index.html), and a spec starting from a clean profile looks
+ * exactly like that first-time visitor. `?app=1` is the same bypass the
+ * landing page's CTAs use, so specs exercise the app rather than the pitch.
+ */
+export const APP_URL = '/?app=1';
+
 /** Set localStorage to RootStorage built from AppData (for E2E fixtures). */
 export async function setAppStorage(
   page: Page,
@@ -180,7 +190,7 @@ export const test = base.extend<{
 }>({
   setupApp: async ({ page }, use) => {
     const setup = async () => {
-      await page.goto('/');
+      await page.goto(APP_URL);
       // Close any modals that might be open
       await closeAnyOpenModals(page);
       await setAppStorage(page, defaultAppData);

--- a/e2e/hidden-alerts.spec.ts
+++ b/e2e/hidden-alerts.spec.ts
@@ -4,6 +4,7 @@ import {
   setAppStorage,
   navigateToSettingsSection,
   toLocalDateString,
+  APP_URL,
 } from './fixtures';
 import {
   createMockAppData,
@@ -44,7 +45,7 @@ async function seed(
   page: import('@playwright/test').Page,
   items: ReturnType<typeof createMockInventoryItem>[],
 ) {
-  await page.goto('/');
+  await page.goto(APP_URL);
   await setAppStorage(page, createMockAppData({ settings: v2Settings, items }));
   await page.reload({ waitUntil: 'domcontentloaded' });
 }

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -123,6 +123,10 @@ test.describe('Landing page', () => {
     ).toBeVisible();
     await expect(page).toHaveTitle(/Tiedä, että olet valmis/);
 
+    // Mocked UI copy (app preview, feature previews, alerts) is translated too.
+    await expect(page.getByText('YLEISKATSAUS', { exact: true })).toBeVisible();
+    await expect(page.getByText('OVERVIEW', { exact: true })).not.toBeVisible();
+
     // Toggling back to English restores the original copy.
     await page.getByRole('link', { name: 'EN', exact: true }).click();
     await expect(page).toHaveURL(/\?lang=en$/);

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -187,4 +187,21 @@ test.describe('Landing page as the site root', () => {
       page.getByRole('heading', { name: /oikeasti valmis/ }),
     ).toBeVisible();
   });
+
+  test('does not bounce an installed iOS PWA to the landing page, even with no stored data', async ({
+    page,
+  }) => {
+    // iOS Safari doesn't reliably reflect a standalone launch in the
+    // `display-mode: standalone` media query, so the root gate also checks
+    // `navigator.standalone`. A cleared/lost storage key must not send an
+    // installed home-screen app to the marketing page.
+    await page.addInitScript(() => {
+      Object.defineProperty(window.navigator, 'standalone', {
+        value: true,
+        configurable: true,
+      });
+    });
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/$/);
+  });
 });

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from './fixtures';
+import { STORAGE_KEY } from '../src/shared/utils/storage/localStorage';
+
+test.describe('Landing page', () => {
+  test('shows the pitch to a visitor with no stored data', async ({ page }) => {
+    await page.goto('/landing.html');
+    await expect(
+      page.getByRole('heading', { name: /actually ready/ }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/landing\.html$/);
+  });
+
+  test('CTAs open the app', async ({ page }) => {
+    await page.goto('/landing.html');
+    await page.getByRole('link', { name: 'Start tracking →' }).click();
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('shows "get started" CTAs, not "open app", for a first-time visitor', async ({
+    page,
+  }) => {
+    await page.goto('/landing.html');
+    await expect(
+      page.getByRole('link', { name: 'Start tracking →' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Get started →' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Open the app' }).first(),
+    ).toBeHidden();
+  });
+
+  test('shows "open app" CTAs, not "get started", for a returning visitor previewing the page', async ({
+    page,
+    setupApp,
+  }) => {
+    await setupApp();
+    await page.goto('/landing.html?preview=1');
+    await expect(
+      page.getByRole('link', { name: 'Open the app' }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'Start tracking →' }),
+    ).toBeHidden();
+    await expect(
+      page.getByRole('link', { name: 'Get started →' }),
+    ).toBeHidden();
+  });
+
+  test('redirects a returning visitor straight to the app', async ({
+    page,
+    setupApp,
+  }) => {
+    // setupApp seeds localStorage with a completed household, i.e. this
+    // browser has "used the app before".
+    await setupApp();
+    await page.goto('/landing.html');
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('?preview=1 lets a returning visitor see the pitch without redirecting', async ({
+    page,
+    setupApp,
+  }) => {
+    // The in-app Guide screen links back here for visitors who already have
+    // a household set up, so the redirect above must not eat that link.
+    await setupApp();
+    await page.goto('/landing.html?preview=1');
+    await expect(
+      page.getByRole('heading', { name: /actually ready/ }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/landing\.html\?preview=1$/);
+  });
+
+  test('redirects a visitor who has loaded the app before, even without completing onboarding', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    // Loading the app once, even mid-onboarding, writes the storage key.
+    await expect
+      .poll(async () =>
+        page.evaluate((key) => localStorage.getItem(key), STORAGE_KEY),
+      )
+      .not.toBeNull();
+
+    await page.goto('/landing.html');
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('a fresh visitor with cleared storage sees the landing page instead of the app root', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    // A never-visited browser has no storage key at all yet.
+    await page.goto('/landing.html');
+    await expect(
+      page.getByRole('heading', { name: /actually ready/ }),
+    ).toBeVisible();
+  });
+
+  test('offers a Finnish translation via the language toggle', async ({
+    page,
+  }) => {
+    await page.goto('/landing.html');
+    await page.getByRole('link', { name: 'FI', exact: true }).click();
+    await expect(page).toHaveURL(/\?lang=fi$/);
+    await expect(
+      page.getByRole('heading', { name: /oikeasti valmis/ }),
+    ).toBeVisible();
+    await expect(page).toHaveTitle(/Tiedä, että olet valmis/);
+
+    // Toggling back to English restores the original copy.
+    await page.getByRole('link', { name: 'EN', exact: true }).click();
+    await expect(page).toHaveURL(/\?lang=en$/);
+    await expect(
+      page.getByRole('heading', { name: /actually ready/ }),
+    ).toBeVisible();
+  });
+
+  test('honors ?lang=fi directly, matching the app’s own URL-param priority', async ({
+    page,
+  }) => {
+    await page.goto('/landing.html?lang=fi');
+    await expect(
+      page.getByRole('heading', { name: /oikeasti valmis/ }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, APP_URL } from './fixtures';
 import { STORAGE_KEY } from '../src/shared/utils/storage/localStorage';
 
 test.describe('Landing page', () => {
@@ -13,7 +13,7 @@ test.describe('Landing page', () => {
   test('CTAs open the app', async ({ page }) => {
     await page.goto('/landing.html');
     await page.getByRole('link', { name: 'Start tracking →' }).click();
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/\/\?app=1$/);
   });
 
   test('shows "get started" CTAs, not "open app", for a first-time visitor', async ({
@@ -76,7 +76,7 @@ test.describe('Landing page', () => {
   test('redirects a visitor who has loaded the app before, even without completing onboarding', async ({
     page,
   }) => {
-    await page.goto('/');
+    await page.goto(APP_URL);
     await page.evaluate(() => localStorage.clear());
     await page.reload({ waitUntil: 'domcontentloaded' });
     // Loading the app once, even mid-onboarding, writes the storage key.
@@ -93,8 +93,18 @@ test.describe('Landing page', () => {
   test('a fresh visitor with cleared storage sees the landing page instead of the app root', async ({
     page,
   }) => {
-    await page.goto('/');
+    // Load the app once so it writes its key, then wipe storage from the
+    // landing page instead of the app. The landing page never writes the key
+    // itself, so the clear cannot race an app effect putting it straight back.
+    await page.goto(APP_URL);
+    await expect
+      .poll(async () =>
+        page.evaluate((key) => localStorage.getItem(key), STORAGE_KEY),
+      )
+      .not.toBeNull();
+    await page.goto('/landing.html?preview=1');
     await page.evaluate(() => localStorage.clear());
+
     // A never-visited browser has no storage key at all yet.
     await page.goto('/landing.html');
     await expect(
@@ -125,6 +135,50 @@ test.describe('Landing page', () => {
     page,
   }) => {
     await page.goto('/landing.html?lang=fi');
+    await expect(
+      page.getByRole('heading', { name: /oikeasti valmis/ }),
+    ).toBeVisible();
+  });
+});
+
+test.describe('Landing page as the site root', () => {
+  test('sends a first-time visitor at / to the landing page', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/landing\.html$/);
+    await expect(
+      page.getByRole('heading', { name: /actually ready/ }),
+    ).toBeVisible();
+  });
+
+  test('leaves a returning visitor at / on the app', async ({
+    page,
+    setupApp,
+  }) => {
+    await setupApp();
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByTestId('v2-nav-home')).toBeVisible();
+  });
+
+  test('does not bounce a first-time visitor who clicked through from the pitch', async ({
+    page,
+  }) => {
+    await page.goto('/landing.html');
+    await page.getByRole('link', { name: 'Start tracking →' }).click();
+
+    // The visitor still has no stored data at this point, so without the
+    // ?app=1 bypass the root gate would send them straight back and the two
+    // redirects would loop forever. They land in onboarding, not the
+    // dashboard, since this is still their first visit.
+    await expect(page).toHaveURL(/\/\?app=1$/);
+    await expect(page.getByText(/STEP 01 \/ 06/)).toBeVisible();
+  });
+
+  test('carries ?lang=fi through to the landing page', async ({ page }) => {
+    await page.goto('/?lang=fi');
+    await expect(page).toHaveURL(/\/landing\.html\?lang=fi$/);
     await expect(
       page.getByRole('heading', { name: /oikeasti valmis/ }),
     ).toBeVisible();

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, APP_URL } from './fixtures';
 import type { RootStorage } from '../src/shared/types';
 
 /**
@@ -17,7 +17,7 @@ import type { RootStorage } from '../src/shared/types';
  */
 
 const clearAndReload = async (page: import('@playwright/test').Page) => {
-  await page.goto('/');
+  await page.goto(APP_URL);
   await page.evaluate(() => localStorage.clear());
   await page.reload({ waitUntil: 'domcontentloaded' });
 };

--- a/e2e/pets.spec.ts
+++ b/e2e/pets.spec.ts
@@ -5,6 +5,7 @@ import {
   navigateToSettingsSection,
   selectInventoryCategory,
   waitForStoredData,
+  APP_URL,
 } from './fixtures';
 import {
   createMockAppData,
@@ -70,7 +71,7 @@ test.describe('Pet Support', () => {
       pets: number,
       items: ReturnType<typeof createMockInventoryItem>[] = [],
     ) => {
-      await page.goto('/');
+      await page.goto(APP_URL);
       await setAppStorage(
         page,
         createMockAppData({
@@ -116,7 +117,7 @@ test.describe('Pet Support', () => {
     test('should allow setting pets count during onboarding', async ({
       page,
     }) => {
-      await page.goto('/');
+      await page.goto(APP_URL);
       await page.evaluate(() => localStorage.clear());
       await page.reload({ waitUntil: 'domcontentloaded' });
 

--- a/e2e/shopping-list-export.spec.ts
+++ b/e2e/shopping-list-export.spec.ts
@@ -3,6 +3,7 @@ import {
   expect,
   setAppStorage,
   navigateToSettingsSection,
+  APP_URL,
 } from './fixtures';
 import {
   createMockAppData,
@@ -35,7 +36,7 @@ async function seed(
   page: import('@playwright/test').Page,
   items: ReturnType<typeof createMockInventoryItem>[],
 ) {
-  await page.goto('/');
+  await page.goto(APP_URL);
   await setAppStorage(page, createMockAppData({ settings: v2Settings, items }));
   await page.reload({ waitUntil: 'domcontentloaded' });
 }

--- a/e2e/smoke-manual-entry.spec.ts
+++ b/e2e/smoke-manual-entry.spec.ts
@@ -11,8 +11,16 @@ import { STORAGE_KEY } from '../src/shared/utils/storage/localStorage';
 import type { RootStorage } from '../src/shared/types';
 
 // Get base URL - use environment variable for deployed sites
-const getBaseURL = () =>
-  process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173';
+const getBaseURL = () => {
+  const base = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173';
+  // `/` shows the static landing page to visitors with no stored data, which
+  // is exactly what a smoke test's clean profile looks like. These specs
+  // exercise onboarding, so they take the same ?app=1 bypass the landing
+  // page's own CTAs use. See the root gate script in index.html.
+  const url = new URL(base);
+  url.searchParams.set('app', '1');
+  return url.toString();
+};
 
 // Timeout constants to avoid magic numbers
 const TIMEOUTS = {

--- a/e2e/smoke-quick-setup.spec.ts
+++ b/e2e/smoke-quick-setup.spec.ts
@@ -11,8 +11,16 @@ import { STORAGE_KEY } from '../src/shared/utils/storage/localStorage';
 import type { RootStorage } from '../src/shared/types';
 
 // Get base URL - use environment variable for deployed sites
-const getBaseURL = () =>
-  process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173';
+const getBaseURL = () => {
+  const base = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173';
+  // `/` shows the static landing page to visitors with no stored data, which
+  // is exactly what a smoke test's clean profile looks like. These specs
+  // exercise onboarding, so they take the same ?app=1 bypass the landing
+  // page's own CTAs use. See the root gate script in index.html.
+  const url = new URL(base);
+  url.searchParams.set('app', '1');
+  return url.toString();
+};
 
 // Timeout constants to avoid magic numbers
 const TIMEOUTS = {

--- a/e2e/v2-actions.spec.ts
+++ b/e2e/v2-actions.spec.ts
@@ -5,6 +5,7 @@ import {
   toLocalDateString,
   startAddCustomItem,
   waitForStoredData,
+  APP_URL,
 } from './fixtures';
 import {
   createMockAppData,
@@ -72,7 +73,7 @@ async function boot(page: Page, viewport: 'desktop' | 'mobile' = 'desktop') {
       ? { width: 1440, height: 960 }
       : { width: 390, height: 844 },
   );
-  await page.goto('/');
+  await page.goto(APP_URL);
   await setAppStorage(
     page,
     createMockAppData({ settings, items: [...items], customCategories: [] }),

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -5,6 +5,7 @@ import {
   defaultAppData,
   selectInventoryCategory,
   navigateToSettingsSection,
+  APP_URL,
 } from './fixtures';
 import { createMockAppData } from '../src/shared/utils/test/factories';
 import {
@@ -130,7 +131,7 @@ async function loadWith(
   page: import('@playwright/test').Page,
   appData: ReturnType<typeof createMockAppData>,
 ) {
-  await page.goto('/');
+  await page.goto(APP_URL);
   await setAppStorage(page, appData);
   await page.reload({ waitUntil: 'domcontentloaded' });
   await disableAnimations(page);
@@ -208,7 +209,7 @@ test.describe('Visual Regression - Settings', () => {
 
 test.describe('Visual Regression - Onboarding', () => {
   test('welcome screen', async ({ page }) => {
-    await page.goto('/');
+    await page.goto(APP_URL);
     await page.evaluate(() => localStorage.clear());
     await page.reload({ waitUntil: 'domcontentloaded' });
     await disableAnimations(page);

--- a/index.html
+++ b/index.html
@@ -3,6 +3,54 @@
   <head>
     <meta charset="UTF-8" />
 
+    <!--
+      Root gate: send first-time visitors to the static landing page.
+
+      The pitch is the front door of the site, but only for people who have
+      never loaded the app. Anyone with stored data gets the app directly, so
+      this has to run in the browser — no CDN or hosting rewrite can read
+      localStorage. It sits first in <head> so it fires before the app bundle,
+      the fonts, or the metadata script below do any work.
+
+      landing.html has the mirror-image guard: it redirects to / when the key
+      *is* present. The two never both fire for the same visitor, and ?app=1
+      keeps the landing page's own CTAs from bouncing back here.
+    -->
+    <script>
+      (function () {
+        try {
+          var params = new URLSearchParams(globalThis.location.search);
+
+          // The landing page's CTAs carry ?app=1. Without it a first-time
+          // visitor clicking "Get started" would be sent back to the pitch,
+          // since they still have no stored data at that moment.
+          if (params.get('app') === '1') return;
+
+          // An installed PWA launches at start_url. Opening a marketing page
+          // there is never right, even if storage was cleared.
+          if (
+            globalThis.matchMedia &&
+            globalThis.matchMedia('(display-mode: standalone)').matches
+          ) {
+            return;
+          }
+
+          // Same key as STORAGE_KEY in src/shared/utils/storage/localStorage.ts.
+          if (!localStorage.getItem('emergencySupplyTracker')) {
+            var lang = params.get('lang');
+            var target =
+              lang === 'en' || lang === 'fi'
+                ? '/landing.html?lang=' + lang
+                : '/landing.html';
+            globalThis.location.replace(target);
+          }
+        } catch (error) {
+          // localStorage unavailable (privacy mode, embedded webview) — the
+          // app is the safer thing to show, so fall through to it.
+        }
+      })();
+    </script>
+
     <!-- Primary Meta Tags -->
     <title>Emergency Supply Tracker - Preparedness Planning</title>
     <meta

--- a/index.html
+++ b/index.html
@@ -27,11 +27,15 @@
           if (params.get('app') === '1') return;
 
           // An installed PWA launches at start_url. Opening a marketing page
-          // there is never right, even if storage was cleared.
-          if (
-            globalThis.matchMedia &&
-            globalThis.matchMedia('(display-mode: standalone)').matches
-          ) {
+          // there is never right, even if storage was cleared. iOS Safari
+          // doesn't reliably reflect standalone launches in `display-mode`,
+          // so `navigator.standalone` is checked too.
+          var isStandalone =
+            (globalThis.matchMedia &&
+              globalThis.matchMedia('(display-mode: standalone)').matches) ||
+            (globalThis.navigator &&
+              globalThis.navigator.standalone === true);
+          if (isStandalone) {
             return;
           }
 

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
         } catch (error) {
           // localStorage unavailable (privacy mode, embedded webview) — the
           // app is the safer thing to show, so fall through to it.
+          console.warn('Root gate: localStorage unavailable.', error);
         }
       })();
     </script>

--- a/public/landing.html
+++ b/public/landing.html
@@ -15,8 +15,9 @@
       if (!isPreview && localStorage.getItem('emergencySupplyTracker')) {
         location.replace('/');
       }
-    } catch (e) {
-      /* localStorage unavailable (privacy mode, etc.) — just show the page */
+    } catch (error) {
+      // localStorage unavailable (privacy mode, etc.) — just show the page.
+      console.warn('Redirect guard: localStorage unavailable.', error);
     }
   })();
 </script>
@@ -233,8 +234,7 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
   </div>
 </header>
 
-<a id="top"></a>
-<section class="hero">
+<section id="top" class="hero">
   <div class="wrap hero-grid">
     <div>
       <span class="kicker" data-i18n="hero.kicker">Household preparedness, tracked</span>
@@ -265,17 +265,17 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
             <div class="rail-ico" style="margin-top:auto">⚙</div>
           </div>
           <div class="app-main">
-            <div class="app-top"><div class="t">OVERVIEW</div><div class="u">household.local</div></div>
+            <div class="app-top"><div class="t" data-i18n="mock.app.overview">OVERVIEW</div><div class="u" data-i18n="mock.app.user">household.local</div></div>
             <div class="stat-row">
-              <div class="stat"><div class="lab">READINESS</div><div class="val acc">74%</div><div class="gauge"><i style="width:74%"></i></div></div>
-              <div class="stat"><div class="lab">DAYS COVERED</div><div class="val ok">11</div></div>
-              <div class="stat"><div class="lab">NEEDS ACTION</div><div class="val warn">6</div></div>
+              <div class="stat"><div class="lab" data-i18n="mock.app.readiness">READINESS</div><div class="val acc">74%</div><div class="gauge"><i style="width:74%"></i></div></div>
+              <div class="stat"><div class="lab" data-i18n="mock.app.daysCovered">DAYS COVERED</div><div class="val ok">11</div></div>
+              <div class="stat"><div class="lab" data-i18n="mock.app.needsAction">NEEDS ACTION</div><div class="val warn">6</div></div>
             </div>
             <div class="cat-list">
-              <div class="cat"><span class="code">H2O</span><div><div class="nm">Water</div><div class="bars"><i style="background:var(--ok)"></i><i style="background:var(--ok)"></i><i style="background:var(--warn)"></i></div></div><span class="pill crit">1 CRIT</span></div>
-              <div class="cat"><span class="code">FUD</span><div><div class="nm">Food</div><div class="bars"><i style="background:var(--ok);width:34px"></i><i style="background:var(--warn)"></i></div></div><span class="pill warn">3 WARN</span></div>
-              <div class="cat"><span class="code">PWR</span><div><div class="nm">Light &amp; Power</div><div class="bars"><i style="background:var(--ok);width:28px"></i><i style="background:var(--warn)"></i></div></div><span class="pill warn">2 WARN</span></div>
-              <div class="cat"><span class="code">MED</span><div><div class="nm">Medical</div><div class="bars"><i style="background:var(--ok);width:30px"></i></div></div><span class="pill ok">OK</span></div>
+              <div class="cat"><span class="code">H2O</span><div><div class="nm" data-i18n="mock.app.water">Water</div><div class="bars"><i style="background:var(--ok)"></i><i style="background:var(--ok)"></i><i style="background:var(--warn)"></i></div></div><span class="pill crit" data-i18n="mock.app.crit1">1 CRIT</span></div>
+              <div class="cat"><span class="code">FUD</span><div><div class="nm" data-i18n="mock.app.food">Food</div><div class="bars"><i style="background:var(--ok);width:34px"></i><i style="background:var(--warn)"></i></div></div><span class="pill warn" data-i18n="mock.app.warn3">3 WARN</span></div>
+              <div class="cat"><span class="code">PWR</span><div><div class="nm" data-i18n="mock.app.power">Light &amp; Power</div><div class="bars"><i style="background:var(--ok);width:28px"></i><i style="background:var(--warn)"></i></div></div><span class="pill warn" data-i18n="mock.app.warn2">2 WARN</span></div>
+              <div class="cat"><span class="code">MED</span><div><div class="nm" data-i18n="mock.app.medical">Medical</div><div class="bars"><i style="background:var(--ok);width:30px"></i></div></div><span class="pill ok" data-i18n="mock.app.ok">OK</span></div>
             </div>
           </div>
         </div>
@@ -322,10 +322,10 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       </div>
       <div class="feat-media">
         <div class="media">
-          <div class="mediarow"><span>Bottled water 1.5 L</span><span class="r">0 / 56 btl · <span style="color:var(--crit)">OUT</span></span></div>
-          <div class="mediarow"><span>Canned soup</span><span class="r">12 / 14 can · exp 2026-06</span></div>
-          <div class="mediarow"><span>AA batteries</span><span class="r">8 / 20 pcs · <span style="color:var(--warn)">LOW</span></span></div>
-          <div class="mediarow" style="border:none"><span>Paracetamol 500 mg</span><span class="r">24 / 40 tab</span></div>
+          <div class="mediarow"><span data-i18n="mock.f1.item1">Bottled water 1.5 L</span><span class="r"><span data-i18n="mock.f1.item1Qty">0 / 56 btl</span> · <span style="color:var(--crit)" data-i18n="mock.f1.out">OUT</span></span></div>
+          <div class="mediarow"><span data-i18n="mock.f1.item2">Canned soup</span><span class="r" data-i18n="mock.f1.item2Qty">12 / 14 can · exp 2026-06</span></div>
+          <div class="mediarow"><span data-i18n="mock.f1.item3">AA batteries</span><span class="r"><span data-i18n="mock.f1.item3Qty">8 / 20 pcs</span> · <span style="color:var(--warn)" data-i18n="mock.f1.low">LOW</span></span></div>
+          <div class="mediarow" style="border:none"><span data-i18n="mock.f1.item4">Paracetamol 500 mg</span><span class="r" data-i18n="mock.f1.item4Qty">24 / 40 tab</span></div>
         </div>
       </div>
     </div>
@@ -343,8 +343,8 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       </div>
       <div class="feat-media">
         <div class="media">
-          <div class="alertbar"><span class="ai">⚠</span><div class="at"><b>1 ITEM OUT OF STOCK</b><span>Bottled water is at zero — restock 56 bottles.</span></div></div>
-          <div class="alertbar warn"><span class="ai">⏳</span><div class="at"><b>3 ITEMS EXPIRING ≤30D</b><span>Canned soup, sports drinks, coffee.</span></div></div>
+          <div class="alertbar"><span class="ai">⚠</span><div class="at"><b data-i18n="mock.f2.alert1Title">1 ITEM OUT OF STOCK</b><span data-i18n="mock.f2.alert1Desc">Bottled water is at zero — restock 56 bottles.</span></div></div>
+          <div class="alertbar warn"><span class="ai">⏳</span><div class="at"><b data-i18n="mock.f2.alert2Title">3 ITEMS EXPIRING ≤30D</b><span data-i18n="mock.f2.alert2Desc">Canned soup, sports drinks, coffee.</span></div></div>
         </div>
       </div>
     </div>
@@ -363,8 +363,8 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       <div class="feat-media">
         <div class="media">
           <div style="display:flex;gap:12px">
-            <div class="stat" style="flex:1"><div class="lab" style="font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--text3)">READINESS</div><div class="val acc" style="font-size:30px;font-weight:700;color:var(--accent)">74%</div><div class="gauge"><i style="width:74%"></i></div></div>
-            <div class="stat" style="flex:1"><div class="lab" style="font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--text3)">DAYS COVERED</div><div class="val ok" style="font-size:30px;font-weight:700;color:var(--ok)">11</div></div>
+            <div class="stat" style="flex:1"><div class="lab" style="font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--text3)" data-i18n="mock.app.readiness">READINESS</div><div class="val acc" style="font-size:30px;font-weight:700;color:var(--accent)">74%</div><div class="gauge"><i style="width:74%"></i></div></div>
+            <div class="stat" style="flex:1"><div class="lab" style="font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--text3)" data-i18n="mock.app.daysCovered">DAYS COVERED</div><div class="val ok" style="font-size:30px;font-weight:700;color:var(--ok)">11</div></div>
           </div>
         </div>
       </div>
@@ -459,6 +459,33 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       'nav.faq': 'FAQ',
       'nav.openApp': 'Open app',
       'nav.getStarted': 'Get started',
+      'mock.app.overview': 'OVERVIEW',
+      'mock.app.user': 'household.local',
+      'mock.app.readiness': 'READINESS',
+      'mock.app.daysCovered': 'DAYS COVERED',
+      'mock.app.needsAction': 'NEEDS ACTION',
+      'mock.app.water': 'Water',
+      'mock.app.crit1': '1 CRIT',
+      'mock.app.food': 'Food',
+      'mock.app.warn3': '3 WARN',
+      'mock.app.power': 'Light & Power',
+      'mock.app.warn2': '2 WARN',
+      'mock.app.medical': 'Medical',
+      'mock.app.ok': 'OK',
+      'mock.f1.item1': 'Bottled water 1.5 L',
+      'mock.f1.item1Qty': '0 / 56 btl',
+      'mock.f1.out': 'OUT',
+      'mock.f1.item2': 'Canned soup',
+      'mock.f1.item2Qty': '12 / 14 can · exp 2026-06',
+      'mock.f1.item3': 'AA batteries',
+      'mock.f1.item3Qty': '8 / 20 pcs',
+      'mock.f1.low': 'LOW',
+      'mock.f1.item4': 'Paracetamol 500 mg',
+      'mock.f1.item4Qty': '24 / 40 tab',
+      'mock.f2.alert1Title': '1 ITEM OUT OF STOCK',
+      'mock.f2.alert1Desc': 'Bottled water is at zero — restock 56 bottles.',
+      'mock.f2.alert2Title': '3 ITEMS EXPIRING ≤30D',
+      'mock.f2.alert2Desc': 'Canned soup, sports drinks, coffee.',
       'hero.kicker': 'Household preparedness, tracked',
       'hero.title': 'Know your household is <em>actually ready</em>.',
       'hero.sub': "Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance.",
@@ -545,6 +572,33 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       'nav.faq': 'UKK',
       'nav.openApp': 'Avaa sovellus',
       'nav.getStarted': 'Aloita',
+      'mock.app.overview': 'YLEISKATSAUS',
+      'mock.app.user': 'kotitalous.local',
+      'mock.app.readiness': 'VALMIUS',
+      'mock.app.daysCovered': 'PÄIVIÄ KATETTU',
+      'mock.app.needsAction': 'TOIMENPITEITÄ',
+      'mock.app.water': 'Vesi',
+      'mock.app.crit1': '1 KRIIT',
+      'mock.app.food': 'Ruoka',
+      'mock.app.warn3': '3 VARO',
+      'mock.app.power': 'Valo ja sähkö',
+      'mock.app.warn2': '2 VARO',
+      'mock.app.medical': 'Lääkkeet',
+      'mock.app.ok': 'OK',
+      'mock.f1.item1': 'Pullovesi 1,5 l',
+      'mock.f1.item1Qty': '0 / 56 pll',
+      'mock.f1.out': 'LOPPU',
+      'mock.f1.item2': 'Purkkikeitto',
+      'mock.f1.item2Qty': '12 / 14 tlk · vanh 2026-06',
+      'mock.f1.item3': 'AA-paristot',
+      'mock.f1.item3Qty': '8 / 20 kpl',
+      'mock.f1.low': 'VÄHISSÄ',
+      'mock.f1.item4': 'Parasetamoli 500 mg',
+      'mock.f1.item4Qty': '24 / 40 tabl',
+      'mock.f2.alert1Title': '1 TUOTE LOPPU',
+      'mock.f2.alert1Desc': 'Pullovesi on lopussa — täydennä 56 pulloa.',
+      'mock.f2.alert2Title': '3 TUOTETTA VANHENEE ≤30VRK',
+      'mock.f2.alert2Desc': 'Purkkikeitto, urheilujuomat, kahvi.',
       'hero.kicker': 'Kotitalouden valmius, seurattuna',
       'hero.title': 'Tiedä, että kotitaloutesi on <em>oikeasti valmis</em>.',
       'hero.sub': 'Seuraa kaikkia hätävarusteitasi, saat varoituksen ennen kuin jokin loppuu tai vanhenee, ja näet todellisen valmiutesi yhdellä silmäyksellä.',
@@ -635,28 +689,25 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
         if (!raw) return undefined;
         var parsed = JSON.parse(raw);
         return parsed && parsed.settings && parsed.settings.language;
-      } catch (e) {
+      } catch (error) {
+        console.warn('Could not read stored language preference.', error);
         return undefined;
       }
     }
 
     var params = new URLSearchParams(location.search);
     var urlLang = params.get('lang');
-    var lang =
-      urlLang === 'en' || urlLang === 'fi'
-        ? urlLang
-        : getStoredLanguage() === 'fi'
-          ? 'fi'
-          : 'en';
+    var storedLang = getStoredLanguage() === 'fi' ? 'fi' : 'en';
+    var lang = urlLang === 'en' || urlLang === 'fi' ? urlLang : storedLang;
 
     var dict = I18N[lang];
 
     document.querySelectorAll('[data-i18n]').forEach(function (el) {
-      var key = el.getAttribute('data-i18n');
+      var key = el.dataset.i18n;
       if (dict[key] !== undefined) el.textContent = dict[key];
     });
     document.querySelectorAll('[data-i18n-html]').forEach(function (el) {
-      var key = el.getAttribute('data-i18n-html');
+      var key = el.dataset.i18nHtml;
       if (dict[key] !== undefined) el.innerHTML = dict[key];
     });
 

--- a/public/landing.html
+++ b/public/landing.html
@@ -227,8 +227,8 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
     </nav>
     <div class="nav-cta">
       <a href="#" class="lang-toggle" data-lang-toggle>FI</a>
-      <a class="btn btn-primary" href="/" data-i18n="nav.openApp" data-cta="open-app" hidden>Open app</a>
-      <a class="btn btn-primary" href="/" data-i18n="nav.getStarted" data-cta="get-started">Get started</a>
+      <a class="btn btn-primary" href="/?app=1" data-i18n="nav.openApp" data-cta="open-app" hidden>Open app</a>
+      <a class="btn btn-primary" href="/?app=1" data-i18n="nav.getStarted" data-cta="get-started">Get started</a>
     </div>
   </div>
 </header>
@@ -241,8 +241,8 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       <h1 data-i18n-html="hero.title">Know your household is <em>actually ready</em>.</h1>
       <p class="sub" data-i18n="hero.sub">Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance.</p>
       <div class="hero-cta">
-        <a class="btn btn-primary" href="/" data-i18n="hero.ctaPrimary" data-cta="get-started">Start tracking →</a>
-        <a class="btn btn-primary" href="/" data-i18n="hero.ctaGhost" data-cta="open-app" hidden>Open the app</a>
+        <a class="btn btn-primary" href="/?app=1" data-i18n="hero.ctaPrimary" data-cta="get-started">Start tracking →</a>
+        <a class="btn btn-primary" href="/?app=1" data-i18n="hero.ctaGhost" data-cta="open-app" hidden>Open the app</a>
       </div>
       <div class="hero-note">
         <span><i class="dot"></i><span data-i18n="hero.note1">No signup required</span></span>
@@ -426,8 +426,8 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
     <h2 data-i18n="ctaBand.title">Start tracking today.</h2>
     <p data-i18n="ctaBand.sub">No account, no cost. Just open it and go.</p>
     <div class="hero-cta">
-      <a class="btn btn-primary" href="/" data-i18n="ctaBand.primary" data-cta="get-started">Get started →</a>
-      <a class="btn btn-primary" href="/" data-i18n="ctaBand.ghost" data-cta="open-app" hidden>Open the app</a>
+      <a class="btn btn-primary" href="/?app=1" data-i18n="ctaBand.primary" data-cta="get-started">Get started →</a>
+      <a class="btn btn-primary" href="/?app=1" data-i18n="ctaBand.ghost" data-cta="open-app" hidden>Open the app</a>
     </div>
   </div>
 </section>
@@ -439,8 +439,8 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       <p style="color:var(--text2);font-size:14px;max-width:34ch" data-i18n="footer.tagline">Household preparedness you actually keep up with. Private, offline, free.</p>
     </div>
     <div class="foot-cols">
-      <div class="foot-col"><h5 data-i18n="footer.col1.h">Product</h5><a href="#features" data-i18n="nav.features">Features</a><a href="#how" data-i18n="nav.how">How it works</a><a href="#themes" data-i18n="nav.themes">Themes</a><a href="/" data-i18n="nav.openApp">Open app</a></div>
-      <div class="foot-col"><h5 data-i18n="footer.col2.h">Get started</h5><a href="/" data-i18n="footer.col2.l1">Onboarding</a><a href="#faq" data-i18n="nav.faq">FAQ</a><a href="https://github.com/ttu/emergency-supply-tracker" data-i18n="footer.col2.l3">Source on GitHub</a></div>
+      <div class="foot-col"><h5 data-i18n="footer.col1.h">Product</h5><a href="#features" data-i18n="nav.features">Features</a><a href="#how" data-i18n="nav.how">How it works</a><a href="#themes" data-i18n="nav.themes">Themes</a><a href="/?app=1" data-i18n="nav.openApp">Open app</a></div>
+      <div class="foot-col"><h5 data-i18n="footer.col2.h">Get started</h5><a href="/?app=1" data-i18n="footer.col2.l1">Onboarding</a><a href="#faq" data-i18n="nav.faq">FAQ</a><a href="https://github.com/ttu/emergency-supply-tracker" data-i18n="footer.col2.l3">Source on GitHub</a></div>
       <div class="foot-col"><h5 data-i18n="footer.col3.h">Contact</h5><a href="mailto:help@emergencysupplytracker.com">help@emergencysupplytracker.com</a><a href="https://github.com/ttu/emergency-supply-tracker/issues" data-i18n="footer.col3.l2">Report an issue</a></div>
     </div>
   </div>

--- a/public/landing.html
+++ b/public/landing.html
@@ -44,7 +44,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&display=swap"/>
 <style>
 :root{
   --bg:#0a1017; --bg2:#0d141a; --panel:#172129; --panel2:#1d2933;
@@ -181,14 +181,16 @@ section{padding:80px 0}
 /* THEMES */
 .themes{background:var(--bg2);border-top:1px solid var(--ruleSoft)}
 .theme-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-.swatch{border:1px solid var(--ruleSoft);border-radius:8px;overflow:hidden}
-.swatch-top{height:132px;padding:18px;display:flex;flex-direction:column;justify-content:space-between}
-.swatch-top .nm{font-size:15px;font-weight:600}
-.swatch-top .chips{display:flex;gap:6px}
-.swatch-top .chips i{width:22px;height:22px;border-radius:4px;display:block;border:1px solid rgba(0,0,0,.15)}
-.swatch-meta{padding:14px 18px;border-top:1px solid var(--ruleSoft);background:var(--panel)}
-.swatch-meta h4{font-size:14px;margin:0 0 4px}
-.swatch-meta p{font-size:12.5px;color:var(--text2)}
+.swatch{border:1.5px solid var(--ruleSoft);overflow:hidden}
+.swatch-top{padding:16px;display:flex;flex-direction:column;gap:10px}
+.swatch-top .nm{font-size:12px;font-weight:700}
+.swatch-top .chips{display:flex;gap:4px}
+.swatch-top .chips i{width:20px;height:20px;display:block}
+.swatch-bar{display:flex;height:4px;overflow:hidden}
+.swatch-meta{padding:11px 16px;display:flex;align-items:center;justify-content:space-between;gap:12px}
+.swatch-meta h4{font-size:13px;font-weight:600;margin:0 0 2px}
+.swatch-meta p{font-size:9.5px;letter-spacing:.06em;margin:0}
+.swatch-radio{width:16px;height:16px;border-radius:999px;display:grid;place-items:center;font-size:10px;font-weight:700;flex:none;color:#fff}
 @media(max-width:820px){.theme-grid{grid-template-columns:1fr}}
 
 /* FAQ */
@@ -382,26 +384,62 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       <p data-i18n="themes.sub">Pick the feel that fits you — a dark operational console, an official civil-defense document, or a calm Nordic pantry.</p>
     </div>
     <div class="theme-grid">
-      <div class="swatch">
+      <div class="swatch" style="border-radius:4px;border-color:#7dd3fc">
         <div class="swatch-top" style="background:#0d141a">
-          <div class="nm" style="color:#e6ecf0;font-family:var(--mono)">Cockpit</div>
-          <div class="chips"><i style="background:#7dd3fc"></i><i style="background:#4ade80"></i><i style="background:#facc15"></i><i style="background:#172129"></i></div>
+          <div class="nm" style="color:#e6ecf0;font-family:var(--mono);letter-spacing:.1em;text-transform:uppercase">Cockpit</div>
+          <div class="chips">
+            <i style="background:#e6ecf0;border-radius:4px"></i>
+            <i style="background:#7dd3fc;border-radius:4px"></i>
+            <i style="background:#4ade80;border-radius:4px"></i>
+            <i style="background:#facc15;border-radius:4px"></i>
+            <i style="background:#f87171;border-radius:4px"></i>
+          </div>
+          <div class="swatch-bar" style="border-radius:4px">
+            <i style="flex:6;background:#4ade80"></i><i style="flex:3;background:#facc15"></i><i style="flex:1;background:#f87171"></i>
+          </div>
         </div>
-        <div class="swatch-meta"><h4>Cockpit</h4><p data-i18n="themes.cockpit">Dark operational console. Mono type, terse readouts, built for people who like a dashboard.</p></div>
+        <div class="swatch-meta" style="background:#172129;border-top:1px solid #26333d">
+          <div><h4 style="color:#e6ecf0;font-family:var(--mono)">Cockpit</h4><p style="color:#5a6975;font-family:var(--mono)" data-i18n="themes.cockpit">Dark operational console. Mono type, terse readouts, built for people who like a dashboard.</p></div>
+          <span class="swatch-radio" style="background:#7dd3fc">✓</span>
+        </div>
       </div>
-      <div class="swatch">
+      <div class="swatch" style="border-radius:0;border-color:#0b1d2a">
         <div class="swatch-top" style="background:#f4f1ea">
-          <div class="nm" style="color:#0b1d2a">Civil Defense</div>
-          <div class="chips"><i style="background:#d94e1f"></i><i style="background:#0b1d2a"></i><i style="background:#2f6b3a"></i><i style="background:#ffffff"></i></div>
+          <div class="nm" style="color:#0b1d2a;font-family:'Inter Tight',sans-serif;letter-spacing:.1em;text-transform:uppercase">Civil Defense</div>
+          <div class="chips">
+            <i style="background:#0b1d2a"></i>
+            <i style="background:#d94e1f"></i>
+            <i style="background:#2f6b3a"></i>
+            <i style="background:#b9851b"></i>
+            <i style="background:#a3340d"></i>
+          </div>
+          <div class="swatch-bar">
+            <i style="flex:6;background:#2f6b3a"></i><i style="flex:3;background:#b9851b"></i><i style="flex:1;background:#a3340d"></i>
+          </div>
         </div>
-        <div class="swatch-meta"><h4>Civil Defense</h4><p data-i18n="themes.civil">Official document look. Numbered forms, sharp corners, an authoritative voice.</p></div>
+        <div class="swatch-meta" style="background:#ffffff;border-top:1px solid #0b1d2a">
+          <div><h4 style="color:#0b1d2a;font-family:'Inter Tight',sans-serif">Civil Defense</h4><p style="color:#5b6b62;font-family:var(--mono)" data-i18n="themes.civil">Official document look. Numbered forms, sharp corners, an authoritative voice.</p></div>
+          <span class="swatch-radio" style="border:1.5px solid #0b1d2a"></span>
+        </div>
       </div>
-      <div class="swatch">
+      <div class="swatch" style="border-radius:12px;border-color:#d8dbcf">
         <div class="swatch-top" style="background:#eef0ea">
-          <div class="nm" style="color:#1a2620;font-family:Georgia,serif">Pantry</div>
-          <div class="chips"><i style="background:#c9744d"></i><i style="background:#506b53"></i><i style="background:#b6863a"></i><i style="background:#fbfaf5"></i></div>
+          <div class="nm" style="color:#1a2620;font-family:'Fraunces',Georgia,serif">Pantry</div>
+          <div class="chips">
+            <i style="background:#1a2620;border-radius:12px"></i>
+            <i style="background:#b35d3a;border-radius:12px"></i>
+            <i style="background:#506b53;border-radius:12px"></i>
+            <i style="background:#8a6428;border-radius:12px"></i>
+            <i style="background:#a14637;border-radius:12px"></i>
+          </div>
+          <div class="swatch-bar" style="border-radius:12px">
+            <i style="flex:6;background:#506b53"></i><i style="flex:3;background:#8a6428"></i><i style="flex:1;background:#a14637"></i>
+          </div>
         </div>
-        <div class="swatch-meta"><h4>Pantry</h4><p data-i18n="themes.pantry">Calm and Nordic. Soft serif, plain language, preparedness without the pressure.</p></div>
+        <div class="swatch-meta" style="background:#fbfaf5;border-top:1px solid #d8dbcf">
+          <div><h4 style="color:#1a2620;font-family:'Fraunces',Georgia,serif">Pantry</h4><p style="color:#6c7a72;font-family:var(--mono)" data-i18n="themes.pantry">Calm and Nordic. Soft serif, plain language, preparedness without the pressure.</p></div>
+          <span class="swatch-radio" style="border:1.5px solid #d8dbcf"></span>
+        </div>
       </div>
     </div>
   </div>

--- a/public/landing.html
+++ b/public/landing.html
@@ -1,0 +1,726 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<script>
+  // Returning visitors skip the pitch. Any prior app load writes this key
+  // (see STORAGE_KEY in src/shared/utils/storage/localStorage.ts), so its
+  // presence means this browser already has a household set up.
+  // ?preview=1 bypasses this, for links back to the pitch from inside the
+  // app itself (e.g. the Guide screen) — those visitors always have the key
+  // set, so without the override the link would just bounce them right back.
+  (function () {
+    try {
+      var isPreview = new URLSearchParams(location.search).get('preview') === '1';
+      if (!isPreview && localStorage.getItem('emergencySupplyTracker')) {
+        location.replace('/');
+      }
+    } catch (e) {
+      /* localStorage unavailable (privacy mode, etc.) — just show the page */
+    }
+  })();
+</script>
+<title id="meta-title">Emergency Supply Tracker — Know you're ready</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta id="meta-description" name="description" content="Track your emergency supplies and know your household's real readiness. Free, no signup, 100% browser-based, works offline."/>
+<link id="meta-canonical" rel="canonical" href="https://www.emergencysupplytracker.com/landing.html"/>
+<link rel="alternate" hreflang="en" href="https://www.emergencysupplytracker.com/landing.html?lang=en"/>
+<link rel="alternate" hreflang="fi" href="https://www.emergencysupplytracker.com/landing.html?lang=fi"/>
+<link rel="alternate" hreflang="x-default" href="https://www.emergencysupplytracker.com/landing.html"/>
+<meta property="og:type" content="website"/>
+<meta id="meta-og-url" property="og:url" content="https://www.emergencysupplytracker.com/landing.html"/>
+<meta id="meta-og-title" property="og:title" content="Emergency Supply Tracker — Know you're ready"/>
+<meta id="meta-og-description" property="og:description" content="Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance. Free, no signup, works offline."/>
+<meta property="og:image" content="https://www.emergencysupplytracker.com/og-image.png"/>
+<meta property="og:image:width" content="1200"/>
+<meta property="og:image:height" content="630"/>
+<meta id="meta-og-locale" property="og:locale" content="en_US"/>
+<meta property="og:site_name" content="Emergency Supply Tracker"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta id="meta-twitter-title" name="twitter:title" content="Emergency Supply Tracker — Know you're ready"/>
+<meta id="meta-twitter-description" name="twitter:description" content="Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance."/>
+<meta name="twitter:image" content="https://www.emergencysupplytracker.com/og-image.png"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"/>
+<style>
+:root{
+  --bg:#0a1017; --bg2:#0d141a; --panel:#172129; --panel2:#1d2933;
+  --rule:#26333d; --ruleSoft:#1f2a33;
+  --text:#e6ecf0; --text2:#8b9aa6; --text3:#5a6975;
+  --ok:#4ade80; --warn:#facc15; --crit:#f87171; --accent:#7dd3fc; --accentInk:#0a1017;
+  --mono:'JetBrains Mono',ui-monospace,monospace; --body:'Inter',sans-serif;
+  --maxw:1120px;
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{margin:0;background:var(--bg);color:var(--text);font-family:var(--body);line-height:1.55;-webkit-font-smoothing:antialiased}
+h1,h2,h3{margin:0;font-weight:600;line-height:1.1}
+p{margin:0}
+a{color:var(--accent);text-decoration:none}
+a:hover{color:#a5e2ff}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 28px}
+.mono{font-family:var(--mono)}
+.kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--accent)}
+.btn{display:inline-flex;align-items:center;gap:9px;font-family:var(--mono);font-size:14px;font-weight:600;letter-spacing:.04em;padding:13px 22px;border-radius:4px;border:1px solid transparent;cursor:pointer;transition:.15s;text-transform:uppercase}
+.btn[hidden]{display:none}
+.btn-primary{background:var(--accent);color:var(--accentInk);border-color:var(--accent)}
+.btn-primary:hover{background:#a5e2ff;color:var(--accentInk)}
+
+/* NAV */
+header.nav{position:sticky;top:0;z-index:50;background:rgba(10,16,23,.82);backdrop-filter:blur(12px);border-bottom:1px solid var(--ruleSoft)}
+.nav-in{display:flex;align-items:center;gap:28px;height:64px;max-width:var(--maxw);margin:0 auto;padding:0 28px}
+.brand{display:flex;align-items:center;gap:11px;font-family:var(--mono);font-weight:700;letter-spacing:.02em}
+.brand .mk{display:grid;place-items:center;width:30px;height:30px;border:1px solid var(--accent);border-radius:4px;color:var(--accent);font-size:13px;font-weight:700}
+.nav-links{display:flex;gap:26px;margin-left:auto;font-size:14px}
+.nav-links a{color:var(--text2)}
+.nav-links a:hover{color:var(--text)}
+.nav-cta{display:flex;gap:12px;align-items:center}
+.lang-toggle{font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.04em;color:var(--text2);border:1px solid var(--rule);border-radius:4px;padding:6px 9px}
+.lang-toggle:hover{color:var(--accent);border-color:var(--accent)}
+@media(max-width:820px){.nav-links{display:none}}
+@media(max-width:480px){
+  .nav-in{gap:10px}
+  .brand{font-size:13px}
+  .nav-cta{gap:8px}
+  .nav-cta .btn{padding:9px 14px;font-size:12px}
+}
+
+/* HERO */
+.hero{position:relative;padding:76px 0 40px;overflow:hidden}
+.hero:before{content:"";position:absolute;inset:0;background:radial-gradient(900px 420px at 20% -8%,rgba(125,211,252,.10),transparent 60%);pointer-events:none}
+.hero-grid{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:56px;align-items:center}
+.hero h1{font-size:52px;letter-spacing:-.01em;margin:18px 0 20px;text-wrap:balance}
+.hero h1 em{font-style:normal;color:var(--accent)}
+.hero .sub{font-size:19px;color:var(--text2);max-width:30ch}
+.hero-cta{display:flex;gap:14px;margin:32px 0 20px;flex-wrap:wrap}
+.hero-note{display:flex;gap:18px;font-family:var(--mono);font-size:12px;color:var(--text3);flex-wrap:wrap}
+.hero-note span{display:flex;align-items:center;gap:6px}
+.dot{width:6px;height:6px;border-radius:50%;background:var(--ok)}
+@media(max-width:900px){.hero-grid{grid-template-columns:1fr;gap:34px}.hero h1{font-size:40px}}
+
+/* BROWSER MOCK */
+.browser{border:1px solid var(--rule);border-radius:8px;overflow:hidden;background:var(--bg2);box-shadow:0 30px 80px -30px rgba(0,0,0,.8),0 0 0 1px rgba(125,211,252,.04)}
+.browser-bar{display:flex;align-items:center;gap:10px;padding:10px 14px;background:#0f1720;border-bottom:1px solid var(--ruleSoft)}
+.tl{display:flex;gap:6px}
+.tl i{width:10px;height:10px;border-radius:50%;background:#2b3944;display:block}
+.addr{flex:1;font-family:var(--mono);font-size:11px;color:var(--text3);background:#0a1017;border:1px solid var(--ruleSoft);border-radius:4px;padding:5px 11px;display:flex;align-items:center;gap:7px}
+.addr b{color:var(--text2);font-weight:500}
+.lockico{color:var(--ok);font-size:10px}
+
+/* APP MOCK */
+.app{display:grid;grid-template-columns:52px 1fr;height:396px;font-family:var(--mono)}
+.app-rail{background:#0f1720;border-right:1px solid var(--ruleSoft);display:flex;flex-direction:column;align-items:center;padding:14px 0;gap:16px}
+.rail-mk{width:26px;height:26px;border:1px solid var(--accent);border-radius:4px;color:var(--accent);display:grid;place-items:center;font-size:11px;font-weight:700}
+.rail-ico{width:26px;height:26px;border-radius:4px;display:grid;place-items:center;color:var(--text3);font-size:14px}
+.rail-ico.on{background:rgba(125,211,252,.12);color:var(--accent)}
+.app-main{padding:16px 18px;overflow:hidden}
+.app-top{display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--ruleSoft);padding-bottom:11px;margin-bottom:14px}
+.app-top .t{font-size:12px;letter-spacing:.14em;color:var(--text2)}
+.app-top .u{font-size:10px;color:var(--text3)}
+.stat-row{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:14px}
+.stat{background:var(--panel);border:1px solid var(--ruleSoft);border-radius:4px;padding:10px 12px}
+.stat .lab{font-size:9px;letter-spacing:.12em;color:var(--text3)}
+.stat .val{font-size:24px;font-weight:700;margin-top:3px}
+.stat .val.ok{color:var(--ok)}.stat .val.warn{color:var(--warn)}.stat .val.acc{color:var(--accent)}
+.gauge{height:6px;border-radius:3px;background:#0a1017;margin-top:9px;overflow:hidden}
+.gauge i{display:block;height:100%;background:linear-gradient(90deg,var(--ok),var(--accent))}
+.cat-list{display:flex;flex-direction:column;gap:0}
+.cat{display:grid;grid-template-columns:38px 1fr auto;gap:11px;align-items:center;padding:9px 4px;border-bottom:1px solid var(--ruleSoft)}
+.cat .code{font-size:10px;color:var(--text3);letter-spacing:.08em}
+.cat .nm{font-family:var(--body);font-size:12px;color:var(--text)}
+.cat .bars{display:flex;gap:3px;margin-top:4px}
+.cat .bars i{height:4px;width:20px;border-radius:2px;display:block}
+.pill{font-size:9px;padding:3px 8px;border-radius:3px;letter-spacing:.08em}
+.pill.ok{background:rgba(74,222,128,.14);color:var(--ok)}
+.pill.warn{background:rgba(250,204,21,.14);color:var(--warn)}
+.pill.crit{background:rgba(248,113,113,.14);color:var(--crit)}
+
+/* SECTIONS */
+section{padding:80px 0}
+.sec-head{max-width:640px;margin:0 auto 52px;text-align:center}
+.sec-head h2{font-size:34px;letter-spacing:-.01em;margin:14px 0 12px}
+.sec-head p{color:var(--text2);font-size:17px}
+
+/* SELLING POINTS */
+.sell{background:var(--bg2);border-top:1px solid var(--ruleSoft);border-bottom:1px solid var(--ruleSoft)}
+.sell-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+.sell-card{background:var(--panel);border:1px solid var(--ruleSoft);border-left:2px solid var(--accent);border-radius:4px;padding:22px}
+.sell-card.soon{border-left-color:var(--warn)}
+.sell-card .ic{font-size:20px;margin-bottom:12px}
+.sell-card h3{font-size:16px;margin-bottom:7px;font-family:var(--mono);letter-spacing:.01em}
+.sell-card p{color:var(--text2);font-size:14px}
+.tag{display:inline-block;font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--warn);border:1px solid rgba(250,204,21,.3);border-radius:3px;padding:2px 6px;margin-left:8px;vertical-align:middle}
+@media(max-width:820px){.sell-grid{grid-template-columns:1fr}}
+
+/* FEATURE ROWS */
+.feat{display:grid;grid-template-columns:1fr 1fr;gap:56px;align-items:center;margin-bottom:34px}
+.feat:nth-child(even) .feat-media{order:-1}
+.feat h3{font-size:26px;margin:14px 0 12px}
+.feat p{color:var(--text2);font-size:16px;max-width:44ch}
+.feat ul{list-style:none;padding:0;margin:20px 0 0;display:flex;flex-direction:column;gap:11px}
+.feat li{display:flex;gap:11px;align-items:flex-start;font-size:14px;color:var(--text)}
+.feat li .ck{color:var(--accent);font-family:var(--mono);flex:none}
+.media{border:1px solid var(--rule);border-radius:8px;background:var(--panel);padding:18px;font-family:var(--mono)}
+@media(max-width:900px){.feat{grid-template-columns:1fr;gap:26px;margin-bottom:20px}.feat:nth-child(even) .feat-media{order:0}}
+
+/* alert banner mock */
+.alertbar{display:flex;gap:11px;align-items:flex-start;background:rgba(248,113,113,.08);border:1px solid rgba(248,113,113,.28);border-left:3px solid var(--crit);border-radius:4px;padding:12px 14px;margin-bottom:10px}
+.alertbar.warn{background:rgba(250,204,21,.08);border-color:rgba(250,204,21,.28);border-left-color:var(--warn)}
+.alertbar .ai{font-size:14px}
+.alertbar .at{font-size:12px}
+.alertbar .at b{display:block;font-size:11px;letter-spacing:.06em}
+.alertbar .at span{color:var(--text2);font-family:var(--body);font-size:12px}
+.mediarow{display:flex;justify-content:space-between;align-items:center;padding:9px 2px;border-bottom:1px solid var(--ruleSoft);font-size:12px}
+.mediarow .r{color:var(--text3);font-size:11px}
+
+/* THEMES */
+.themes{background:var(--bg2);border-top:1px solid var(--ruleSoft)}
+.theme-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
+.swatch{border:1px solid var(--ruleSoft);border-radius:8px;overflow:hidden}
+.swatch-top{height:132px;padding:18px;display:flex;flex-direction:column;justify-content:space-between}
+.swatch-top .nm{font-size:15px;font-weight:600}
+.swatch-top .chips{display:flex;gap:6px}
+.swatch-top .chips i{width:22px;height:22px;border-radius:4px;display:block;border:1px solid rgba(0,0,0,.15)}
+.swatch-meta{padding:14px 18px;border-top:1px solid var(--ruleSoft);background:var(--panel)}
+.swatch-meta h4{font-size:14px;margin:0 0 4px}
+.swatch-meta p{font-size:12.5px;color:var(--text2)}
+@media(max-width:820px){.theme-grid{grid-template-columns:1fr}}
+
+/* FAQ */
+.faq{max-width:760px;margin:0 auto;display:flex;flex-direction:column;gap:0}
+details{border-bottom:1px solid var(--ruleSoft);padding:20px 4px}
+details summary{cursor:pointer;list-style:none;font-size:17px;font-weight:600;display:flex;justify-content:space-between;align-items:center;gap:16px}
+details summary::-webkit-details-marker{display:none}
+details summary .pm{font-family:var(--mono);color:var(--accent);font-size:20px;flex:none;transition:.2s}
+details[open] summary .pm{transform:rotate(45deg)}
+details p{color:var(--text2);font-size:15px;margin-top:12px;max-width:64ch}
+
+/* CTA */
+.cta-band{text-align:center;background:linear-gradient(180deg,var(--bg2),var(--bg));border-top:1px solid var(--ruleSoft)}
+.cta-band h2{font-size:38px;margin-bottom:16px}
+.cta-band p{color:var(--text2);font-size:18px;margin-bottom:30px}
+.cta-band .hero-cta{justify-content:center}
+
+/* FOOTER */
+footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(--bg2)}
+.foot-in{display:flex;justify-content:space-between;gap:24px;flex-wrap:wrap;align-items:flex-start}
+.foot-in .brand{margin-bottom:12px}
+.foot-cols{display:flex;gap:56px;flex-wrap:wrap}
+.foot-col h5{font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--text3);margin:0 0 12px}
+.foot-col a{display:block;color:var(--text2);font-size:14px;margin-bottom:9px}
+.foot-col a:hover{color:var(--text)}
+.foot-bot{max-width:var(--maxw);margin:32px auto 0;padding:22px 28px 0;border-top:1px solid var(--ruleSoft);display:flex;justify-content:space-between;gap:16px;flex-wrap:wrap;font-family:var(--mono);font-size:12px;color:var(--text3)}
+</style>
+</head>
+<body>
+
+<header class="nav">
+  <div class="nav-in">
+    <a href="#top" class="brand"><span class="mk">E</span>Emergency Supply Tracker</a>
+    <nav class="nav-links">
+      <a href="#features" data-i18n="nav.features">Features</a>
+      <a href="#how" data-i18n="nav.how">How it works</a>
+      <a href="#themes" data-i18n="nav.themes">Themes</a>
+      <a href="#faq" data-i18n="nav.faq">FAQ</a>
+    </nav>
+    <div class="nav-cta">
+      <a href="#" class="lang-toggle" data-lang-toggle>FI</a>
+      <a class="btn btn-primary" href="/" data-i18n="nav.openApp" data-cta="open-app" hidden>Open app</a>
+      <a class="btn btn-primary" href="/" data-i18n="nav.getStarted" data-cta="get-started">Get started</a>
+    </div>
+  </div>
+</header>
+
+<a id="top"></a>
+<section class="hero">
+  <div class="wrap hero-grid">
+    <div>
+      <span class="kicker" data-i18n="hero.kicker">Household preparedness, tracked</span>
+      <h1 data-i18n-html="hero.title">Know your household is <em>actually ready</em>.</h1>
+      <p class="sub" data-i18n="hero.sub">Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance.</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="/" data-i18n="hero.ctaPrimary" data-cta="get-started">Start tracking →</a>
+        <a class="btn btn-primary" href="/" data-i18n="hero.ctaGhost" data-cta="open-app" hidden>Open the app</a>
+      </div>
+      <div class="hero-note">
+        <span><i class="dot"></i><span data-i18n="hero.note1">No signup required</span></span>
+        <span><i class="dot"></i><span data-i18n="hero.note2">Free forever</span></span>
+        <span><i class="dot"></i><span data-i18n="hero.note3">Works offline</span></span>
+      </div>
+    </div>
+    <div class="hero-media">
+      <div class="browser">
+        <div class="browser-bar">
+          <div class="tl"><i></i><i></i><i></i></div>
+          <div class="addr"><span class="lockico">🔒</span><b>emergencysupplytracker.com</b>/overview</div>
+        </div>
+        <div class="app">
+          <div class="app-rail">
+            <div class="rail-mk">E</div>
+            <div class="rail-ico on">▤</div>
+            <div class="rail-ico">☰</div>
+            <div class="rail-ico">?</div>
+            <div class="rail-ico" style="margin-top:auto">⚙</div>
+          </div>
+          <div class="app-main">
+            <div class="app-top"><div class="t">OVERVIEW</div><div class="u">household.local</div></div>
+            <div class="stat-row">
+              <div class="stat"><div class="lab">READINESS</div><div class="val acc">74%</div><div class="gauge"><i style="width:74%"></i></div></div>
+              <div class="stat"><div class="lab">DAYS COVERED</div><div class="val ok">11</div></div>
+              <div class="stat"><div class="lab">NEEDS ACTION</div><div class="val warn">6</div></div>
+            </div>
+            <div class="cat-list">
+              <div class="cat"><span class="code">H2O</span><div><div class="nm">Water</div><div class="bars"><i style="background:var(--ok)"></i><i style="background:var(--ok)"></i><i style="background:var(--warn)"></i></div></div><span class="pill crit">1 CRIT</span></div>
+              <div class="cat"><span class="code">FUD</span><div><div class="nm">Food</div><div class="bars"><i style="background:var(--ok);width:34px"></i><i style="background:var(--warn)"></i></div></div><span class="pill warn">3 WARN</span></div>
+              <div class="cat"><span class="code">PWR</span><div><div class="nm">Light &amp; Power</div><div class="bars"><i style="background:var(--ok);width:28px"></i><i style="background:var(--warn)"></i></div></div><span class="pill warn">2 WARN</span></div>
+              <div class="cat"><span class="code">MED</span><div><div class="nm">Medical</div><div class="bars"><i style="background:var(--ok);width:30px"></i></div></div><span class="pill ok">OK</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="sell" id="features" style="padding:64px 0">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="kicker" data-i18n="sell.kicker">Why it's different</span>
+      <h2 data-i18n="sell.title">Yours, private, and free — no strings.</h2>
+      <p data-i18n="sell.sub">A serious preparedness tool that respects your data and your wallet.</p>
+    </div>
+    <div class="sell-grid">
+      <div class="sell-card"><div class="ic">✓</div><h3 data-i18n="sell.card1.h">No signup required</h3><p data-i18n="sell.card1.p">Start using it immediately. No account, no email, no waiting.</p></div>
+      <div class="sell-card"><div class="ic">🔒</div><h3 data-i18n="sell.card2.h">100% browser-based</h3><p data-i18n="sell.card2.p">Your data stays on your device, completely private. Nothing is uploaded.</p></div>
+      <div class="sell-card"><div class="ic">🎁</div><h3 data-i18n="sell.card3.h">Completely free</h3><p data-i18n="sell.card3.p">Every feature included. No premium tiers, no paywalls, ever.</p></div>
+      <div class="sell-card"><div class="ic">🔌</div><h3 data-i18n="sell.card4.h">Works offline</h3><p data-i18n="sell.card4.p">Access your supplies anytime, even with no internet connection.</p></div>
+      <div class="sell-card"><div class="ic">💻</div><h3 data-i18n="sell.card5.h">Open source</h3><p data-i18n="sell.card5.p">Transparent code you can inspect, audit, and contribute to.</p></div>
+      <div class="sell-card soon"><div class="ic">☁️</div><h3 data-i18n-html="sell.card6.h">Cloud sync<span class="tag">Coming soon</span></h3><p data-i18n="sell.card6.p">Optional sync to your own cloud provider — on your terms.</p></div>
+    </div>
+  </div>
+</section>
+
+<section id="how">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="kicker" data-i18n="how.kicker">How it works</span>
+      <h2 data-i18n="how.title">Three things it does, done well.</h2>
+    </div>
+
+    <div class="feat">
+      <div>
+        <span class="kicker" data-i18n="how.f1.kicker">01 · Track</span>
+        <h3 data-i18n="how.f1.h">Track every supply in one place</h3>
+        <p data-i18n="how.f1.p">Organize water, food, power, medical and more into clear categories. See quantity against your recommended target and know exactly what's covered.</p>
+        <ul>
+          <li><span class="ck">›</span><span data-i18n="how.f1.li1">Ten built-in categories, from water to pet supplies</span></li>
+          <li><span class="ck">›</span><span data-i18n="how.f1.li2">Quantity, location and expiry per item</span></li>
+          <li><span class="ck">›</span><span data-i18n="how.f1.li3">Presets to fill a household in minutes</span></li>
+        </ul>
+      </div>
+      <div class="feat-media">
+        <div class="media">
+          <div class="mediarow"><span>Bottled water 1.5 L</span><span class="r">0 / 56 btl · <span style="color:var(--crit)">OUT</span></span></div>
+          <div class="mediarow"><span>Canned soup</span><span class="r">12 / 14 can · exp 2026-06</span></div>
+          <div class="mediarow"><span>AA batteries</span><span class="r">8 / 20 pcs · <span style="color:var(--warn)">LOW</span></span></div>
+          <div class="mediarow" style="border:none"><span>Paracetamol 500 mg</span><span class="r">24 / 40 tab</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="feat">
+      <div>
+        <span class="kicker" data-i18n="how.f2.kicker">02 · Get alerts</span>
+        <h3 data-i18n="how.f2.h">Never get caught short</h3>
+        <p data-i18n="how.f2.p">The dashboard warns you the moment items run low or approach their expiry date — right where you'll see it, no notifications to set up.</p>
+        <ul>
+          <li><span class="ck">›</span><span data-i18n="how.f2.li1">Low-stock and expiry warnings, front and center</span></li>
+          <li><span class="ck">›</span><span data-i18n="how.f2.li2">Dismiss what you've handled</span></li>
+          <li><span class="ck">›</span><span data-i18n="how.f2.li3">Readiness score updates as you restock</span></li>
+        </ul>
+      </div>
+      <div class="feat-media">
+        <div class="media">
+          <div class="alertbar"><span class="ai">⚠</span><div class="at"><b>1 ITEM OUT OF STOCK</b><span>Bottled water is at zero — restock 56 bottles.</span></div></div>
+          <div class="alertbar warn"><span class="ai">⏳</span><div class="at"><b>3 ITEMS EXPIRING ≤30D</b><span>Canned soup, sports drinks, coffee.</span></div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="feat">
+      <div>
+        <span class="kicker" data-i18n="how.f3.kicker">03 · Stay prepared</span>
+        <h3 data-i18n="how.f3.h">See your readiness at a glance</h3>
+        <p data-i18n="how.f3.p">One number tells you how ready your household really is, and how many days you're covered for. Export a shopping list for whatever's missing.</p>
+        <ul>
+          <li><span class="ck">›</span><span data-i18n="how.f3.li1">Overall readiness score and days-covered estimate</span></li>
+          <li><span class="ck">›</span><span data-i18n="how.f3.li2">Shopping list export for the gaps</span></li>
+          <li><span class="ck">›</span><span data-i18n="how.f3.li3">Built for the whole household</span></li>
+        </ul>
+      </div>
+      <div class="feat-media">
+        <div class="media">
+          <div style="display:flex;gap:12px">
+            <div class="stat" style="flex:1"><div class="lab" style="font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--text3)">READINESS</div><div class="val acc" style="font-size:30px;font-weight:700;color:var(--accent)">74%</div><div class="gauge"><i style="width:74%"></i></div></div>
+            <div class="stat" style="flex:1"><div class="lab" style="font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--text3)">DAYS COVERED</div><div class="val ok" style="font-size:30px;font-weight:700;color:var(--ok)">11</div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="themes" id="themes">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="kicker" data-i18n="themes.kicker">Make it yours</span>
+      <h2 data-i18n="themes.title">Three looks. Same tracker.</h2>
+      <p data-i18n="themes.sub">Pick the feel that fits you — a dark operational console, an official civil-defense document, or a calm Nordic pantry.</p>
+    </div>
+    <div class="theme-grid">
+      <div class="swatch">
+        <div class="swatch-top" style="background:#0d141a">
+          <div class="nm" style="color:#e6ecf0;font-family:var(--mono)">Cockpit</div>
+          <div class="chips"><i style="background:#7dd3fc"></i><i style="background:#4ade80"></i><i style="background:#facc15"></i><i style="background:#172129"></i></div>
+        </div>
+        <div class="swatch-meta"><h4>Cockpit</h4><p data-i18n="themes.cockpit">Dark operational console. Mono type, terse readouts, built for people who like a dashboard.</p></div>
+      </div>
+      <div class="swatch">
+        <div class="swatch-top" style="background:#f4f1ea">
+          <div class="nm" style="color:#0b1d2a">Civil Defense</div>
+          <div class="chips"><i style="background:#d94e1f"></i><i style="background:#0b1d2a"></i><i style="background:#2f6b3a"></i><i style="background:#ffffff"></i></div>
+        </div>
+        <div class="swatch-meta"><h4>Civil Defense</h4><p data-i18n="themes.civil">Official document look. Numbered forms, sharp corners, an authoritative voice.</p></div>
+      </div>
+      <div class="swatch">
+        <div class="swatch-top" style="background:#eef0ea">
+          <div class="nm" style="color:#1a2620;font-family:Georgia,serif">Pantry</div>
+          <div class="chips"><i style="background:#c9744d"></i><i style="background:#506b53"></i><i style="background:#b6863a"></i><i style="background:#fbfaf5"></i></div>
+        </div>
+        <div class="swatch-meta"><h4>Pantry</h4><p data-i18n="themes.pantry">Calm and Nordic. Soft serif, plain language, preparedness without the pressure.</p></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="faq">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="kicker" data-i18n="faq.kicker">FAQ</span>
+      <h2 data-i18n="faq.title">Questions, answered.</h2>
+    </div>
+    <div class="faq">
+      <details open><summary><span data-i18n="faq.q1">Do I need an account?</span><span class="pm">+</span></summary><p data-i18n="faq.a1">No. Open the app and start tracking immediately — there's no signup, no email, and nothing to verify.</p></details>
+      <details><summary><span data-i18n="faq.q2">Where is my data stored?</span><span class="pm">+</span></summary><p data-i18n="faq.a2">Entirely on your own device, in your browser. Nothing is uploaded to a server, so your household inventory stays completely private.</p></details>
+      <details><summary><span data-i18n="faq.q3">Does it really work offline?</span><span class="pm">+</span></summary><p data-i18n="faq.a3">Yes. Once loaded, the app runs without an internet connection, so you can check and update your supplies during an outage.</p></details>
+      <details><summary><span data-i18n="faq.q4">Is it actually free?</span><span class="pm">+</span></summary><p data-i18n="faq.a4">Completely. Every feature is included with no premium tiers or paywalls, and the code is open source.</p></details>
+    </div>
+  </div>
+</section>
+
+<section class="cta-band">
+  <div class="wrap">
+    <span class="kicker" data-i18n="ctaBand.kicker">Ready in minutes</span>
+    <h2 data-i18n="ctaBand.title">Start tracking today.</h2>
+    <p data-i18n="ctaBand.sub">No account, no cost. Just open it and go.</p>
+    <div class="hero-cta">
+      <a class="btn btn-primary" href="/" data-i18n="ctaBand.primary" data-cta="get-started">Get started →</a>
+      <a class="btn btn-primary" href="/" data-i18n="ctaBand.ghost" data-cta="open-app" hidden>Open the app</a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap foot-in">
+    <div>
+      <div class="brand"><span class="mk">E</span>Emergency Supply Tracker</div>
+      <p style="color:var(--text2);font-size:14px;max-width:34ch" data-i18n="footer.tagline">Household preparedness you actually keep up with. Private, offline, free.</p>
+    </div>
+    <div class="foot-cols">
+      <div class="foot-col"><h5 data-i18n="footer.col1.h">Product</h5><a href="#features" data-i18n="nav.features">Features</a><a href="#how" data-i18n="nav.how">How it works</a><a href="#themes" data-i18n="nav.themes">Themes</a><a href="/" data-i18n="nav.openApp">Open app</a></div>
+      <div class="foot-col"><h5 data-i18n="footer.col2.h">Get started</h5><a href="/" data-i18n="footer.col2.l1">Onboarding</a><a href="#faq" data-i18n="nav.faq">FAQ</a><a href="https://github.com/ttu/emergency-supply-tracker" data-i18n="footer.col2.l3">Source on GitHub</a></div>
+      <div class="foot-col"><h5 data-i18n="footer.col3.h">Contact</h5><a href="mailto:help@emergencysupplytracker.com">help@emergencysupplytracker.com</a><a href="https://github.com/ttu/emergency-supply-tracker/issues" data-i18n="footer.col3.l2">Report an issue</a></div>
+    </div>
+  </div>
+  <div class="foot-bot">
+    <span data-i18n="footer.copyright">© 2026 Emergency Supply Tracker</span>
+    <span data-i18n="footer.dataNote">Your data never leaves your device.</span>
+  </div>
+</footer>
+
+<script>
+  var I18N = {
+    en: {
+      'nav.features': 'Features',
+      'nav.how': 'How it works',
+      'nav.themes': 'Themes',
+      'nav.faq': 'FAQ',
+      'nav.openApp': 'Open app',
+      'nav.getStarted': 'Get started',
+      'hero.kicker': 'Household preparedness, tracked',
+      'hero.title': 'Know your household is <em>actually ready</em>.',
+      'hero.sub': "Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance.",
+      'hero.ctaPrimary': 'Start tracking →',
+      'hero.ctaGhost': 'Open the app',
+      'hero.note1': 'No signup required',
+      'hero.note2': 'Free forever',
+      'hero.note3': 'Works offline',
+      'sell.kicker': "Why it's different",
+      'sell.title': 'Yours, private, and free — no strings.',
+      'sell.sub': 'A serious preparedness tool that respects your data and your wallet.',
+      'sell.card1.h': 'No signup required',
+      'sell.card1.p': 'Start using it immediately. No account, no email, no waiting.',
+      'sell.card2.h': '100% browser-based',
+      'sell.card2.p': 'Your data stays on your device, completely private. Nothing is uploaded.',
+      'sell.card3.h': 'Completely free',
+      'sell.card3.p': 'Every feature included. No premium tiers, no paywalls, ever.',
+      'sell.card4.h': 'Works offline',
+      'sell.card4.p': 'Access your supplies anytime, even with no internet connection.',
+      'sell.card5.h': 'Open source',
+      'sell.card5.p': 'Transparent code you can inspect, audit, and contribute to.',
+      'sell.card6.h': 'Cloud sync<span class="tag">Coming soon</span>',
+      'sell.card6.p': 'Optional sync to your own cloud provider — on your terms.',
+      'how.kicker': 'How it works',
+      'how.title': 'Three things it does, done well.',
+      'how.f1.kicker': '01 · Track',
+      'how.f1.h': 'Track every supply in one place',
+      'how.f1.p': "Organize water, food, power, medical and more into clear categories. See quantity against your recommended target and know exactly what's covered.",
+      'how.f1.li1': 'Ten built-in categories, from water to pet supplies',
+      'how.f1.li2': 'Quantity, location and expiry per item',
+      'how.f1.li3': 'Presets to fill a household in minutes',
+      'how.f2.kicker': '02 · Get alerts',
+      'how.f2.h': 'Never get caught short',
+      'how.f2.p': "The dashboard warns you the moment items run low or approach their expiry date — right where you'll see it, no notifications to set up.",
+      'how.f2.li1': 'Low-stock and expiry warnings, front and center',
+      'how.f2.li2': "Dismiss what you've handled",
+      'how.f2.li3': 'Readiness score updates as you restock',
+      'how.f3.kicker': '03 · Stay prepared',
+      'how.f3.h': 'See your readiness at a glance',
+      'how.f3.p': "One number tells you how ready your household really is, and how many days you're covered for. Export a shopping list for whatever's missing.",
+      'how.f3.li1': 'Overall readiness score and days-covered estimate',
+      'how.f3.li2': 'Shopping list export for the gaps',
+      'how.f3.li3': 'Built for the whole household',
+      'themes.kicker': 'Make it yours',
+      'themes.title': 'Three looks. Same tracker.',
+      'themes.sub': 'Pick the feel that fits you — a dark operational console, an official civil-defense document, or a calm Nordic pantry.',
+      'themes.cockpit': 'Dark operational console. Mono type, terse readouts, built for people who like a dashboard.',
+      'themes.civil': 'Official document look. Numbered forms, sharp corners, an authoritative voice.',
+      'themes.pantry': 'Calm and Nordic. Soft serif, plain language, preparedness without the pressure.',
+      'faq.kicker': 'FAQ',
+      'faq.title': 'Questions, answered.',
+      'faq.q1': 'Do I need an account?',
+      'faq.a1': "No. Open the app and start tracking immediately — there's no signup, no email, and nothing to verify.",
+      'faq.q2': 'Where is my data stored?',
+      'faq.a2': 'Entirely on your own device, in your browser. Nothing is uploaded to a server, so your household inventory stays completely private.',
+      'faq.q3': 'Does it really work offline?',
+      'faq.a3': 'Yes. Once loaded, the app runs without an internet connection, so you can check and update your supplies during an outage.',
+      'faq.q4': 'Is it actually free?',
+      'faq.a4': 'Completely. Every feature is included with no premium tiers or paywalls, and the code is open source.',
+      'ctaBand.kicker': 'Ready in minutes',
+      'ctaBand.title': 'Start tracking today.',
+      'ctaBand.sub': 'No account, no cost. Just open it and go.',
+      'ctaBand.primary': 'Get started →',
+      'ctaBand.ghost': 'Open the app',
+      'footer.tagline': 'Household preparedness you actually keep up with. Private, offline, free.',
+      'footer.col1.h': 'Product',
+      'footer.col2.h': 'Get started',
+      'footer.col2.l1': 'Onboarding',
+      'footer.col2.l3': 'Source on GitHub',
+      'footer.col3.h': 'Contact',
+      'footer.col3.l2': 'Report an issue',
+      'footer.copyright': '© 2026 Emergency Supply Tracker',
+      'footer.dataNote': 'Your data never leaves your device.',
+      'meta.title': "Emergency Supply Tracker — Know you're ready",
+      'meta.description': "Track your emergency supplies and know your household's real readiness. Free, no signup, 100% browser-based, works offline.",
+      'meta.ogDescription': 'Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance. Free, no signup, works offline.',
+      'meta.twitterDescription': 'Track every emergency supply you own, get warned before things run low or expire, and see your real readiness at a glance.',
+      'meta.ogLocale': 'en_US',
+    },
+    fi: {
+      'nav.features': 'Ominaisuudet',
+      'nav.how': 'Näin se toimii',
+      'nav.themes': 'Teemat',
+      'nav.faq': 'UKK',
+      'nav.openApp': 'Avaa sovellus',
+      'nav.getStarted': 'Aloita',
+      'hero.kicker': 'Kotitalouden valmius, seurattuna',
+      'hero.title': 'Tiedä, että kotitaloutesi on <em>oikeasti valmis</em>.',
+      'hero.sub': 'Seuraa kaikkia hätävarusteitasi, saat varoituksen ennen kuin jokin loppuu tai vanhenee, ja näet todellisen valmiutesi yhdellä silmäyksellä.',
+      'hero.ctaPrimary': 'Aloita seuranta →',
+      'hero.ctaGhost': 'Avaa sovellus',
+      'hero.note1': 'Ei rekisteröitymistä',
+      'hero.note2': 'Aina ilmainen',
+      'hero.note3': 'Toimii offline-tilassa',
+      'sell.kicker': 'Miksi tämä on erilainen',
+      'sell.title': 'Sinun, yksityinen ja ilmainen — ei ehtoja.',
+      'sell.sub': 'Vakavasti otettava varautumistyökalu, joka kunnioittaa tietojasi ja lompakkoasi.',
+      'sell.card1.h': 'Ei rekisteröitymistä',
+      'sell.card1.p': 'Aloita käyttö heti. Ei tiliä, ei sähköpostia, ei odottelua.',
+      'sell.card2.h': '100 % selainpohjainen',
+      'sell.card2.p': 'Tietosi pysyvät laitteellasi, täysin yksityisinä. Mitään ei lähetetä minnekään.',
+      'sell.card3.h': 'Täysin ilmainen',
+      'sell.card3.p': 'Kaikki ominaisuudet mukana. Ei maksullisia tasoja, ei koskaan.',
+      'sell.card4.h': 'Toimii offline-tilassa',
+      'sell.card4.p': 'Pääset varastoosi käsiksi milloin vain, myös ilman internetyhteyttä.',
+      'sell.card5.h': 'Avoin lähdekoodi',
+      'sell.card5.p': 'Läpinäkyvä koodi, jota voit tarkastella, auditoida ja johon voit osallistua.',
+      'sell.card6.h': 'Pilvisynkronointi<span class="tag">Tulossa pian</span>',
+      'sell.card6.p': 'Valinnainen synkronointi omaan pilvipalveluusi — omilla ehdoillasi.',
+      'how.kicker': 'Näin se toimii',
+      'how.title': 'Kolme asiaa, jotka se tekee hyvin.',
+      'how.f1.kicker': '01 · Seuraa',
+      'how.f1.h': 'Seuraa kaikkia varusteita yhdessä paikassa',
+      'how.f1.p': 'Järjestä vesi, ruoka, sähkö, lääkintätarvikkeet ja muut selkeisiin kategorioihin. Näe määrä suhteessa suositukseen ja tiedä tarkalleen, mikä on katettu.',
+      'how.f1.li1': 'Kymmenen valmista kategoriaa, vedestä lemmikkitarvikkeisiin',
+      'how.f1.li2': 'Määrä, sijainti ja vanhenemispäivä jokaiselle tuotteelle',
+      'how.f1.li3': 'Valmiit pohjat, joilla kotitalous täyttyy minuuteissa',
+      'how.f2.kicker': '02 · Saat hälytykset',
+      'how.f2.h': 'Et jää enää yllätetyksi',
+      'how.f2.p': 'Kojelauta varoittaa heti, kun jokin tuote on vähissä tai lähestyy vanhenemispäivää — juuri siellä missä sen näet, ilman erillisiä ilmoitusasetuksia.',
+      'how.f2.li1': 'Vähäisen varaston ja vanhenemisen varoitukset näkyvästi esillä',
+      'how.f2.li2': 'Merkitse hoidetuksi, kun olet hoitanut asian',
+      'how.f2.li3': 'Valmiuspisteet päivittyvät, kun täydennät varastoa',
+      'how.f3.kicker': '03 · Pysy valmiina',
+      'how.f3.h': 'Näe valmiutesi yhdellä silmäyksellä',
+      'how.f3.p': 'Yksi luku kertoo, kuinka valmis kotitaloutesi todella on ja kuinka monta päivää varastosi riittää. Vie ostoslista puuttuvista tarvikkeista.',
+      'how.f3.li1': 'Kokonaisvalmiuspisteet ja arvio katetuista päivistä',
+      'how.f3.li2': 'Ostoslistan vienti puuttuville tuotteille',
+      'how.f3.li3': 'Suunniteltu koko kotitaloudelle',
+      'themes.kicker': 'Tee siitä omasi',
+      'themes.title': 'Kolme ilmettä. Sama seurantatyökalu.',
+      'themes.sub': 'Valitse itsellesi sopiva tunnelma — tumma ohjaamokonsoli, virallinen väestönsuojelun asiakirja tai rauhallinen pohjoismainen pentteri.',
+      'themes.cockpit': 'Tumma ohjaamokonsoli. Tasavälistä kirjasinta, tiiviit lukemat, tehty niille jotka pitävät kojelaudoista.',
+      'themes.civil': 'Virallisen asiakirjan ilme. Numeroidut lomakkeet, terävät kulmat, arvovaltainen sävy.',
+      'themes.pantry': 'Rauhallinen ja pohjoismainen. Pehmeä antiikva, selkeä kieli, varautumista ilman painetta.',
+      'faq.kicker': 'UKK',
+      'faq.title': 'Kysymyksiä ja vastauksia.',
+      'faq.q1': 'Tarvitsenko tilin?',
+      'faq.a1': 'Et. Avaa sovellus ja aloita seuranta heti — ei rekisteröitymistä, ei sähköpostia, ei mitään vahvistettavaa.',
+      'faq.q2': 'Missä tietoni säilytetään?',
+      'faq.a2': 'Kokonaan omalla laitteellasi, selaimessasi. Mitään ei lähetetä palvelimelle, joten kotitaloutesi varastotiedot pysyvät täysin yksityisinä.',
+      'faq.q3': 'Toimiiko se todella offline-tilassa?',
+      'faq.a3': 'Kyllä. Kerran ladattuna sovellus toimii ilman internetyhteyttä, joten voit tarkistaa ja päivittää varastoasi myös sähkökatkon aikana.',
+      'faq.q4': 'Onko se todella ilmainen?',
+      'faq.a4': 'Täysin. Kaikki ominaisuudet sisältyvät, ei maksullisia tasoja, ja koodi on avointa lähdekoodia.',
+      'ctaBand.kicker': 'Valmiina minuuteissa',
+      'ctaBand.title': 'Aloita seuranta tänään.',
+      'ctaBand.sub': 'Ei tiliä, ei kustannuksia. Avaa vain ja aloita.',
+      'ctaBand.primary': 'Aloita →',
+      'ctaBand.ghost': 'Avaa sovellus',
+      'footer.tagline': 'Kotitalouden varautuminen, josta oikeasti pidät kiinni. Yksityinen, offline, ilmainen.',
+      'footer.col1.h': 'Tuote',
+      'footer.col2.h': 'Aloitus',
+      'footer.col2.l1': 'Käyttöönotto',
+      'footer.col2.l3': 'Lähdekoodi GitHubissa',
+      'footer.col3.h': 'Yhteystiedot',
+      'footer.col3.l2': 'Ilmoita ongelmasta',
+      'footer.copyright': '© 2026 Emergency Supply Tracker',
+      'footer.dataNote': 'Tietosi eivät koskaan poistu laitteeltasi.',
+      'meta.title': 'Hätävarastojen seuranta — Tiedä, että olet valmis',
+      'meta.description': 'Seuraa hätävarastojasi ja tiedä kotitaloutesi todellinen valmius. Ilmainen, ei rekisteröitymistä, 100 % selainpohjainen, toimii offline-tilassa.',
+      'meta.ogDescription': 'Seuraa kaikkia hätävarusteitasi, saat varoituksen ennen kuin jokin loppuu tai vanhenee, ja näet todellisen valmiutesi yhdellä silmäyksellä. Ilmainen, ei rekisteröitymistä, toimii offline-tilassa.',
+      'meta.twitterDescription': 'Seuraa kaikkia hätävarusteitasi, saat varoituksen ennen kuin jokin loppuu tai vanhenee, ja näet todellisen valmiutesi yhdellä silmäyksellä.',
+      'meta.ogLocale': 'fi_FI',
+    },
+  };
+
+  (function () {
+    // Priority matches src/shared/utils/urlLanguage.ts: ?lang= param, then
+    // the language saved in the app's own settings, then 'en'.
+    function getStoredLanguage() {
+      try {
+        var raw = localStorage.getItem('emergencySupplyTracker');
+        if (!raw) return undefined;
+        var parsed = JSON.parse(raw);
+        return parsed && parsed.settings && parsed.settings.language;
+      } catch (e) {
+        return undefined;
+      }
+    }
+
+    var params = new URLSearchParams(location.search);
+    var urlLang = params.get('lang');
+    var lang =
+      urlLang === 'en' || urlLang === 'fi'
+        ? urlLang
+        : getStoredLanguage() === 'fi'
+          ? 'fi'
+          : 'en';
+
+    var dict = I18N[lang];
+
+    document.querySelectorAll('[data-i18n]').forEach(function (el) {
+      var key = el.getAttribute('data-i18n');
+      if (dict[key] !== undefined) el.textContent = dict[key];
+    });
+    document.querySelectorAll('[data-i18n-html]').forEach(function (el) {
+      var key = el.getAttribute('data-i18n-html');
+      if (dict[key] !== undefined) el.innerHTML = dict[key];
+    });
+
+    // A visitor with data already in localStorage has used the app before
+    // (this is the same key the redirect guard at the top of the file
+    // checks), so "Get started" reads wrong for them — show "Open app"
+    // instead. Buttons default to the get-started state in markup so this
+    // only has to flip one way or the other, never show both.
+    var isReturningVisitor = (function () {
+      try {
+        return !!localStorage.getItem('emergencySupplyTracker');
+      } catch (e) {
+        return false;
+      }
+    })();
+    document.querySelectorAll('[data-cta="get-started"]').forEach(
+      function (el) {
+        el.hidden = isReturningVisitor;
+      },
+    );
+    document.querySelectorAll('[data-cta="open-app"]').forEach(function (el) {
+      el.hidden = !isReturningVisitor;
+    });
+
+    document.documentElement.lang = lang;
+    document.getElementById('meta-title').textContent = dict['meta.title'];
+    document.title = dict['meta.title'];
+    document
+      .getElementById('meta-description')
+      .setAttribute('content', dict['meta.description']);
+    document
+      .getElementById('meta-og-title')
+      .setAttribute('content', dict['meta.title']);
+    document
+      .getElementById('meta-og-description')
+      .setAttribute('content', dict['meta.ogDescription']);
+    document
+      .getElementById('meta-og-locale')
+      .setAttribute('content', dict['meta.ogLocale']);
+    document
+      .getElementById('meta-twitter-title')
+      .setAttribute('content', dict['meta.title']);
+    document
+      .getElementById('meta-twitter-description')
+      .setAttribute('content', dict['meta.twitterDescription']);
+
+    var canonicalUrl =
+      'https://www.emergencysupplytracker.com/landing.html' +
+      (urlLang === 'en' || urlLang === 'fi' ? '?lang=' + urlLang : '');
+    document.getElementById('meta-canonical').setAttribute('href', canonicalUrl);
+    document.getElementById('meta-og-url').setAttribute('content', canonicalUrl);
+
+    var otherLang = lang === 'fi' ? 'en' : 'fi';
+    document.querySelectorAll('[data-lang-toggle]').forEach(function (toggle) {
+      toggle.textContent = otherLang.toUpperCase();
+      toggle.addEventListener('click', function (event) {
+        event.preventDefault();
+        var url = new URL(location.href);
+        url.searchParams.set('lang', otherLang);
+        location.href = url.toString();
+      });
+    });
+  })();
+</script>
+
+</body>
+</html>

--- a/public/landing.html
+++ b/public/landing.html
@@ -149,7 +149,9 @@ section{padding:80px 0}
 .sell-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
 .sell-card{background:var(--panel);border:1px solid var(--ruleSoft);border-left:2px solid var(--accent);border-radius:4px;padding:22px}
 .sell-card.soon{border-left-color:var(--warn)}
-.sell-card .ic{font-size:20px;margin-bottom:12px}
+.sell-card .ic{width:20px;height:20px;margin-bottom:12px;color:var(--accent)}
+.sell-card .ic svg{display:block;width:100%;height:100%}
+.sell-card.soon .ic{color:var(--warn)}
 .sell-card h3{font-size:16px;margin-bottom:7px;font-family:var(--mono);letter-spacing:.01em}
 .sell-card p{color:var(--text2);font-size:14px}
 .tag{display:inline-block;font-family:var(--mono);font-size:9px;letter-spacing:.12em;color:var(--warn);border:1px solid rgba(250,204,21,.3);border-radius:3px;padding:2px 6px;margin-left:8px;vertical-align:middle}
@@ -292,12 +294,12 @@ footer{border-top:1px solid var(--ruleSoft);padding:44px 0 40px;background:var(-
       <p data-i18n="sell.sub">A serious preparedness tool that respects your data and your wallet.</p>
     </div>
     <div class="sell-grid">
-      <div class="sell-card"><div class="ic">✓</div><h3 data-i18n="sell.card1.h">No signup required</h3><p data-i18n="sell.card1.p">Start using it immediately. No account, no email, no waiting.</p></div>
-      <div class="sell-card"><div class="ic">🔒</div><h3 data-i18n="sell.card2.h">100% browser-based</h3><p data-i18n="sell.card2.p">Your data stays on your device, completely private. Nothing is uploaded.</p></div>
-      <div class="sell-card"><div class="ic">🎁</div><h3 data-i18n="sell.card3.h">Completely free</h3><p data-i18n="sell.card3.p">Every feature included. No premium tiers, no paywalls, ever.</p></div>
-      <div class="sell-card"><div class="ic">🔌</div><h3 data-i18n="sell.card4.h">Works offline</h3><p data-i18n="sell.card4.p">Access your supplies anytime, even with no internet connection.</p></div>
-      <div class="sell-card"><div class="ic">💻</div><h3 data-i18n="sell.card5.h">Open source</h3><p data-i18n="sell.card5.p">Transparent code you can inspect, audit, and contribute to.</p></div>
-      <div class="sell-card soon"><div class="ic">☁️</div><h3 data-i18n-html="sell.card6.h">Cloud sync<span class="tag">Coming soon</span></h3><p data-i18n="sell.card6.p">Optional sync to your own cloud provider — on your terms.</p></div>
+      <div class="sell-card"><div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div><h3 data-i18n="sell.card1.h">No signup required</h3><p data-i18n="sell.card1.p">Start using it immediately. No account, no email, no waiting.</p></div>
+      <div class="sell-card"><div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></div><h3 data-i18n="sell.card2.h">100% browser-based</h3><p data-i18n="sell.card2.p">Your data stays on your device, completely private. Nothing is uploaded.</p></div>
+      <div class="sell-card"><div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 12 20 22 4 22 4 12"/><rect x="2" y="7" width="20" height="5"/><line x1="12" y1="22" x2="12" y2="7"/><path d="M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7z"/><path d="M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z"/></svg></div><h3 data-i18n="sell.card3.h">Completely free</h3><p data-i18n="sell.card3.p">Every feature included. No premium tiers, no paywalls, ever.</p></div>
+      <div class="sell-card"><div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="1" y1="1" x2="23" y2="23"/><path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/><path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/><path d="M10.71 5.05A16 16 0 0 1 22.58 9"/><path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg></div><h3 data-i18n="sell.card4.h">Works offline</h3><p data-i18n="sell.card4.p">Access your supplies anytime, even with no internet connection.</p></div>
+      <div class="sell-card"><div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></div><h3 data-i18n="sell.card5.h">Open source</h3><p data-i18n="sell.card5.p">Transparent code you can inspect, audit, and contribute to.</p></div>
+      <div class="sell-card soon"><div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg></div><h3 data-i18n-html="sell.card6.h">Cloud sync<span class="tag">Coming soon</span></h3><p data-i18n="sell.card6.p">Optional sync to your own cloud provider — on your terms.</p></div>
     </div>
   </div>
 </section>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -675,6 +675,7 @@
     "contactTitle": "Need More Help?",
     "contactText": "Report bugs, suggest features, leave feedback, or contribute—visit our GitHub repository or email us.",
     "githubLink": "Visit GitHub Repository",
+    "landingLink": "View Landing Page",
     "gettingStarted": {
       "question": "How do I get started?",
       "answer": "When you open the app for the first time, you'll be guided through an onboarding process. The process will help you:\n\n1. Select your language (English/Finnish)\n2. Choose a household preset or configure it manually\n3. Set up your household information (adults, children, supply duration)\n4. Add recommended items to your inventory or start with an empty inventory\n\nAfter onboarding, you can start using the app. You can modify household settings later from the Settings tab."
@@ -2683,6 +2684,21 @@
         "cockpit": "SUPPORT",
         "civil": "SUPPORT",
         "pantry": "Need more help?"
+      },
+      "landingTitle": {
+        "cockpit": "LANDING PAGE",
+        "civil": "LANDING PAGE",
+        "pantry": "The landing page"
+      },
+      "landingText": {
+        "cockpit": "PUBLIC OVERVIEW · The marketing page shown to first-time visitors — a quick summary of what this app does.",
+        "civil": "PUBLIC OVERVIEW · The marketing page shown to first-time visitors — a quick summary of what this app does.",
+        "pantry": "This is the page new visitors see before they start — a friendly overview of what's here."
+      },
+      "landingLink": {
+        "cockpit": "VIEW LANDING PAGE",
+        "civil": "VIEW LANDING PAGE",
+        "pantry": "View the landing page"
       },
       "howIsItFree": {
         "cockpit": "HOW IS THIS FREE · Personal project, shared openly. AI-accelerated development — about 100 hours of work as of 08/2026. Runs entirely in the browser; hosting, CI/CD, and tooling are all free on GitHub. Only recurring cost: the ~$10/year domain.",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -675,6 +675,7 @@
     "contactTitle": "Tarvitsetko lisää apua?",
     "contactText": "Ilmoita bugeista, ehdota ominaisuuksia, jätä palautetta tai osallistu koodilla—käy GitHub-sivustollamme tai lähetä sähköpostia.",
     "githubLink": "Käy GitHub-sivustolla",
+    "landingLink": "Näytä aloitussivu",
     "gettingStarted": {
       "question": "Miten aloitan?",
       "answer": "Kun avaat sovelluksen ensimmäisen kerran, ohjataan sinut onboarding-prosessiin. Prosessi opastaa sinua:\n\n1. Valitsemaan kielen (suomi/englanti)\n2. Valitsemaan kotitalouden esiasetuksen tai määrittämään sen manuaalisesti\n3. Määrittämään kotitalouden tiedot (aikuiset, lapset, varastojakso)\n4. Lisäämään suositellut tuotteet varastoon tai aloittamaan tyhjällä varastolla\n\nOnboardingin jälkeen voit aloittaa käyttämään sovellusta. Voit muokata kotitalouden asetuksia myöhemmin Asetukset-välilehdeltä."
@@ -2683,6 +2684,21 @@
         "cockpit": "TUKI",
         "civil": "TUKI",
         "pantry": "Tarvitsetko lisää apua?"
+      },
+      "landingTitle": {
+        "cockpit": "ALOITUSSIVU",
+        "civil": "ALOITUSSIVU",
+        "pantry": "Aloitussivu"
+      },
+      "landingText": {
+        "cockpit": "JULKINEN ESITTELY · Markkinointisivu, joka näytetään ensikertalaisille vierailijoille — tiivis yhteenveto siitä, mitä tämä sovellus tekee.",
+        "civil": "JULKINEN ESITTELY · Markkinointisivu, joka näytetään ensikertalaisille vierailijoille — tiivis yhteenveto siitä, mitä tämä sovellus tekee.",
+        "pantry": "Tämä on sivu, jonka uudet kävijät näkevät ennen aloitusta — ystävällinen yleiskatsaus siitä, mitä täällä on."
+      },
+      "landingLink": {
+        "cockpit": "NÄYTÄ ALOITUSSIVU",
+        "civil": "NÄYTÄ ALOITUSSIVU",
+        "pantry": "Näytä aloitussivu"
       },
       "howIsItFree": {
         "cockpit": "MITEN TÄMÄ ON ILMAINEN · Oma projekti, jaettu avoimesti. Tekoälyn avulla kehitetty nopeasti — noin 100 tuntia työtä 08/2026 mennessä. Toimii täysin selaimessa; hostaus, CI/CD ja työkalut ovat ilmaisia GitHubissa. Ainoa toistuva kustannus on noin 10 dollarin verkkotunnus vuodessa.",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,6 +9,19 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <!--
+    Crawlers arrive with empty localStorage, so the root gate in index.html
+    always redirects them here. This is the page that actually gets indexed
+    for a first-time visitor, so it has to be listed in its own right.
+  -->
+  <url>
+    <loc>https://www.emergencysupplytracker.com/landing.html</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.emergencysupplytracker.com/landing.html?lang=en"/>
+    <xhtml:link rel="alternate" hreflang="fi" href="https://www.emergencysupplytracker.com/landing.html?lang=fi"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.emergencysupplytracker.com/landing.html"/>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
   <url>
     <loc>https://www.emergencysupplytracker.com/?lang=en</loc>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.emergencysupplytracker.com/?lang=en"/>

--- a/public/sw.js
+++ b/public/sw.js
@@ -23,6 +23,7 @@ const OFFLINE_URL = resolvePath(OFFLINE_PAGE);
 // Note: index.html is served by Vite at the root path (''), not as a separate file
 const PRECACHE_PATHS = [
   '',
+  'landing.html',
   'offline.html',
   'manifest.json',
   'favicon.svg',

--- a/public/sw.js
+++ b/public/sw.js
@@ -104,10 +104,15 @@ self.addEventListener('fetch', (event) => {
           return response;
         })
         .catch(() => {
-          // If network fails, try cache, then offline page
-          return caches.match(request).then((cachedResponse) => {
-            return cachedResponse || caches.match(OFFLINE_URL);
-          });
+          // If network fails, try cache, then offline page. Precached
+          // navigable pages (e.g. landing.html) have no query string, so
+          // ignore the request's search params (?lang=, ?app=, ?preview=)
+          // when matching.
+          return caches
+            .match(request, { ignoreSearch: true })
+            .then((cachedResponse) => {
+              return cachedResponse || caches.match(OFFLINE_URL);
+            });
         })
     );
     return;

--- a/src/features/help/components/v2/Guide.test.tsx
+++ b/src/features/help/components/v2/Guide.test.tsx
@@ -73,4 +73,19 @@ describe('Guide (v2)', () => {
       'https://github.com/ttu/emergency-supply-tracker',
     );
   });
+
+  it('offers a landing page section, separate from support, with its own link', () => {
+    renderWithProviders(<Guide />, {
+      initialAppData: { settings: createMockSettings({ theme: 'cockpit' }) },
+    });
+    expect(
+      screen.getByText('v2.guide.landingTitle.cockpit'),
+    ).toBeInTheDocument();
+    const landingLink = screen.getByRole('link', {
+      name: 'v2.guide.landingLink.cockpit',
+    });
+    expect(landingLink).toHaveAttribute('href', '/landing.html?preview=1');
+    expect(landingLink).toHaveAttribute('target', '_blank');
+    expect(landingLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
 });

--- a/src/features/help/components/v2/Guide.tsx
+++ b/src/features/help/components/v2/Guide.tsx
@@ -84,6 +84,24 @@ export function Guide() {
           </a>
         </div>
       </Panel>
+      <Panel padding={24}>
+        <div className={styles.supportTitle}>
+          {t(`v2.guide.landingTitle.${themeKey}`)}
+        </div>
+        <div className={styles.supportText}>
+          {t(`v2.guide.landingText.${themeKey}`)}
+        </div>
+        <div className={styles.supportLinks}>
+          <a
+            href="/landing.html?preview=1"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.supportLink}
+          >
+            {t(`v2.guide.landingLink.${themeKey}`)}
+          </a>
+        </div>
+      </Panel>
     </div>
   );
 }

--- a/src/features/help/pages/Help.test.tsx
+++ b/src/features/help/pages/Help.test.tsx
@@ -66,4 +66,12 @@ describe('Help', () => {
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
+
+  it('should render a link to the landing page', () => {
+    render(<Help />);
+    const link = screen.getByText('help.landingLink');
+    expect(link).toHaveAttribute('href', '/landing.html?preview=1');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
 });

--- a/src/features/help/pages/Help.tsx
+++ b/src/features/help/pages/Help.tsx
@@ -26,6 +26,14 @@ function ContactLinks() {
         <GitHubIcon className={styles.githubIcon} />
         {t('help.githubLink')}
       </a>
+      <a
+        href="/landing.html?preview=1"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.link}
+      >
+        {t('help.landingLink')}
+      </a>
     </div>
   );
 }

--- a/src/features/settings/components/v2/SettingsRows.tsx
+++ b/src/features/settings/components/v2/SettingsRows.tsx
@@ -113,10 +113,15 @@ export function StepperRow({
   decimals = 0,
   last,
 }: Readonly<StepperRowProps>) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const clamp = (v: number) => Math.min(max, Math.max(min, v));
+  // Group digits by the language the app is showing, not the one the device
+  // happens to be set to: a Finnish reader wants "2 050" and an English one
+  // "2,050", and bare toLocaleString() gives whichever the OS prefers.
   const display =
-    decimals > 0 ? value.toFixed(decimals) : value.toLocaleString();
+    decimals > 0
+      ? value.toFixed(decimals)
+      : value.toLocaleString(i18n.language);
   return (
     <div
       className={`${styles.stepperRow} ${last ? styles.stepperRowLast : ''}`}


### PR DESCRIPTION
## Summary

- Adds `public/landing.html`, a standalone marketing page for first-time visitors, served outside the React app bundle
- Visitors who already have app data are redirected straight to `/`, so the page never gets in the way of returning users
- Links to the page from the in-app Help and v2 Guide screens, fully translated in EN/FI

## Changes

**Landing page**

- `public/landing.html` — self-contained static page with hero, feature overview, and CTA band
- Shown only to visitors with no `emergencySupplyTracker` localStorage key; anyone who has loaded the app before (including mid-onboarding) is redirected to `/`
- `?preview=1` query override skips the redirect, so in-app links back to the page still work
- Hero/nav/CTA-band buttons swap between "Get started" and "Open app" depending on whether stored data exists, with a single consistent highlight color
- Inline i18n dictionary with the same language priority as the app (`?lang=` → stored `settings.language` → `en`), plus a manual EN/FI toggle in the nav

**In-app links**

- `src/features/help/pages/Help.tsx` — landing page link in the help list
- `src/features/help/components/v2/Guide.tsx` — dedicated landing page panel in the support section
- EN/FI translations for both, including per-theme variants (cockpit/civil/pantry) for the v2 Guide

**Docs & tests**

- `docs/FUNCTIONAL_SPEC.md` — documents the landing page behavior and redirect rules
- `e2e/landing-page.spec.ts` — covers the redirect, `?preview=1` override, CTA states, and language toggle
- Component tests for the new Help and Guide links

## Test plan

- [ ] All tests pass
- [ ] TypeScript type-check passes
- [ ] Production build succeeds
- [ ] Lint passes
- [ ] E2E: landing page redirect, preview override, CTA states, language toggle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bilingual English/Finnish landing page with responsive design, feature highlights, FAQs, previews, and calls to action.
  * Added language detection, manual switching, and language-aware links from Help and Guide.
  * Added sitemap visibility and offline availability for the landing page.
  * Improved localized formatting for whole-number settings.

* **Bug Fixes**
  * Improved routing for new and returning visitors, including app bypass and preview modes.
  * Preserved language settings when navigating between landing and app pages.

* **Tests**
  * Added end-to-end coverage for routing, redirects, storage detection, previews, and language switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->