### PR TITLE
fix: stop the mobile shell's bottom nav drifting after edits

### DIFF
--- a/src/features/onboarding/components/v2/OnboardLayout.module.css
+++ b/src/features/onboarding/components/v2/OnboardLayout.module.css
@@ -116,6 +116,7 @@
 
 .footerActions {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
 }
 

--- a/src/features/onboarding/components/v2/OnboardQuickSetup.module.css
+++ b/src/features/onboarding/components/v2/OnboardQuickSetup.module.css
@@ -153,5 +153,6 @@
 .footerActions {
   margin-top: 14px;
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
 }

--- a/src/shared/components/design-v2/Shell.module.css
+++ b/src/shared/components/design-v2/Shell.module.css
@@ -147,6 +147,7 @@
 .mobileRoot {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   background: var(--color-bg);
   color: var(--color-text);
   font-family: var(--font-body);
@@ -169,7 +170,12 @@
 
 .mobileMain {
   flex: 1;
+  min-height: 0;
   overflow: auto;
+  /* Without this, content that happens to end near the fold (e.g. the
+     "Custom Item" CTA in the add-item picker) sits flush against — and gets
+     clipped by — this scrollport's own edge, right where the nav begins. */
+  padding-bottom: 20px;
 }
 
 .mobileNav {

--- a/src/styles/design-themes.css
+++ b/src/styles/design-themes.css
@@ -12,11 +12,40 @@
  * MobileShell wrappers are fixed at 100vh and own the inner scrolling
  * (their <main> is overflow:auto). Without this rule the page itself can
  * pick up a scrollbar that competes with the inner one, producing a
- * "double scrollbar" effect. */
-:root:is([data-theme='cockpit'], [data-theme='civil'], [data-theme='pantry']),
-:where(html, body):has(
-  :where([data-theme='cockpit'], [data-theme='civil'], [data-theme='pantry'])
-) {
+ * "double scrollbar" effect.
+ *
+ * `data-theme` is set on <html> itself, not on some descendant of it, so a
+ * `:has()` check for it never matches html or body — that variant looked
+ * like it locked <body> too but never actually did, leaving body free to
+ * grow past the viewport (and drag the shell's bottom nav out of place)
+ * whenever inner content briefly exceeded 100dvh. Targeting body as a
+ * plain descendant of the themed root fixes that. */
+:root:is([data-theme='cockpit'], [data-theme='civil'], [data-theme='pantry']) {
+  overflow: hidden;
+  height: 100vh;
+  height: 100dvh;
+}
+
+/* `overflow: hidden` on body only hides the scrollbar and blocks
+ * user-initiated wheel/touch scrolling — verified in-browser that it does
+ * NOT stop `window.scrollTo`/`documentElement.scrollTop` from moving the
+ * page (this holds even with the newer `overflow: clip`, which disables an
+ * element's own overflow scrolling but not the root scrolling element's).
+ * Browsers run exactly that kind of programmatic scroll on their own to
+ * bring a focused element into view — e.g. a form field tapped while the
+ * on-screen keyboard opens — and the residual scroll then persists after
+ * the keyboard closes, landing the shell's bottom nav somewhere other than
+ * the screen edge with the emptied space showing beneath it as "page
+ * overflow". Taking body out of the flow entirely with `position: fixed`
+ * closes that gap: with nothing left in normal flow under <html>, there is
+ * no scroll range for either the user or the browser to move into. */
+:root:is([data-theme='cockpit'], [data-theme='civil'], [data-theme='pantry'])
+  body {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   overflow: hidden;
   height: 100vh;
   height: 100dvh;

--- a/src/styles/viewportHeight.test.ts
+++ b/src/styles/viewportHeight.test.ts
@@ -41,6 +41,29 @@ describe('design v2 full-viewport containers', () => {
     );
   });
 
+  it('takes body out of flow so it has no scroll range of its own', () => {
+    // `overflow: hidden` on body only blocks user-gesture scrolling — it does
+    // not stop `window.scrollTo`/`documentElement.scrollTop`, which browsers
+    // invoke themselves to bring a focused element into view (e.g. a form
+    // field tapped while the on-screen keyboard opens). That residual scroll
+    // then persists after the keyboard closes, landing the shell's bottom nav
+    // away from the screen edge. `position: fixed` removes body from normal
+    // flow entirely, so there is no scroll range for either path to move
+    // into — verified in-browser that `overflow: hidden` alone still let
+    // `window.scrollTo` move the page, and that this pairing stops it.
+    const css = read('styles/design-themes.css');
+    const rule =
+      /:root:is\(\[data-theme='cockpit'\][^{}]*\)\s*body\s*\{([^}]*)\}/.exec(
+        css,
+      );
+    expect(rule).not.toBeNull();
+    expect(rule![1]).toMatch(/position:\s*fixed/);
+    expect(rule![1]).toMatch(/top:\s*0/);
+    expect(rule![1]).toMatch(/right:\s*0/);
+    expect(rule![1]).toMatch(/bottom:\s*0/);
+    expect(rule![1]).toMatch(/left:\s*0/);
+  });
+
   it.each([
     ['shared/components/design-v2/Shell.tsx', 2],
     ['features/onboarding/components/v2/OnboardLayout.tsx', 1],


### PR DESCRIPTION
## Summary
- On the design-v2 mobile shell (cockpit/civil/pantry, now the default experience), editing an item and tapping into a field could leave the page scrolled after saving: the bottom nav would land away from the screen edge with extra scroll room showing beneath it.
- Root cause: `overflow: hidden` on `<body>` only blocks scrollbars and user-gesture (wheel/touch) scrolling — it does **not** stop `window.scrollTo()` / `documentElement.scrollTop`, which browsers invoke themselves to bring a focused field into view (e.g. tapping an input while the on-screen keyboard opens). That residual scroll then persisted after the keyboard closed. Verified this live in a browser: `overflow: hidden` alone still let `window.scrollTo` move the page and visibly displace the nav; `position: fixed` on body closes the gap by removing it from flow entirely, so there's no scroll range to move into.
- Along the way, also found and fixed a couple of smaller narrow-viewport (320px) overflow bugs in the onboarding flow.

## Changes
- **`src/styles/design-themes.css`**: `position: fixed; inset` on `<body>` under v2 themes so neither user gestures nor browser-driven programmatic scroll (focus-into-view) can move the document. Also fixed a dead `:has()` selector that was meant to lock body's scroll but never actually matched, since `data-theme` lives on `<html>` itself rather than a descendant.
- **`src/shared/components/design-v2/Shell.module.css`**: `.mobileRoot` now clips its own box (`overflow: hidden`) and `.mobileMain` gets `min-height: 0` plus bottom padding, so scrollable content is properly contained by the shell instead of risking growth past the locked viewport height.
- **`src/features/onboarding/components/v2/OnboardQuickSetup.module.css`** and **`OnboardLayout.module.css`**: two footer button rows (skip/demo-data, back/continue) used a plain flex row with `nowrap` buttons and no wrapping, overflowing the viewport by a few px on 320px-wide screens (e.g. iPhone SE). Added `flex-wrap: wrap`.
- **`src/styles/viewportHeight.test.ts`**: updated/added coverage for the new body scroll-lock rule.

(Note: a `Title` overflow-wrap bug I found independently while poking around turned out to already be fixed on `main` via #288, so no change needed there — confirmed identical after rebase.)

## Test plan
- [x] Full unit suite passes (365 files / 4342 tests)
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [x] Lint/format clean
- [x] Manually verified in a real browser session at mobile viewport sizes (390px, 320px): reproduced the original scroll-drift bug via `window.scrollTo`/focus + save, confirmed it's fully blocked after the fix; confirmed the two footer rows no longer overflow at 320px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding footer layouts so controls wrap cleanly on smaller screens.
  * Prevented unwanted page scrolling and residual scroll areas in design v2 views.
  * Improved mobile content sizing and scrolling, including additional bottom spacing.

* **Tests**
  * Added coverage to verify that themed layouts prevent document scrolling correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->